### PR TITLE
Feature: Seo & openGraph 

### DIFF
--- a/archetypes/post.md
+++ b/archetypes/post.md
@@ -15,4 +15,5 @@ layout: post
 published: true
 featured: yellow
 title: "Das ist der Titel"
+twitter_creator_id: "twitter id of the author | used for open graph"
 ---

--- a/archetypes/project.md
+++ b/archetypes/project.md
@@ -27,6 +27,7 @@ cta_text: |-
   Längere Text mit Markdown wie mensch sich einbringen kann
 more_text: |-
   Text mit Markdown wie mensch mehr erfahren kann
+twitter_creator_id: "twitter id of the author | used for open graph"
 ---
 
 Hier kommt der Projektbeschreibungstext rein

--- a/config.toml
+++ b/config.toml
@@ -68,3 +68,33 @@ section = [ "HTML", "Atom", "Json", "Rss" ]
 
 [frontmatter]
 date  = [":filename", ":default"]
+
+[minify]
+  disableCSS = false
+  disableHTML = false
+  disableJS = false
+  disableJSON = false
+  disableSVG = false
+  disableXML = false
+  minifyOutput = true
+  [minify.tdewolff]
+    [minify.tdewolff.css]
+      keepCSS2 = true
+      precision = 0
+    [minify.tdewolff.html]
+      keepComments = false
+      keepConditionalComments = true
+      keepDefaultAttrVals = true
+      keepDocumentTags = true
+      keepEndTags = true
+      keepQuotes = false
+      keepWhitespace = false
+    [minify.tdewolff.js]
+      keepVarNames = false
+      precision = 0
+    [minify.tdewolff.json]
+      precision = 0
+    [minify.tdewolff.svg]
+      precision = 0
+    [minify.tdewolff.xml]
+      keepWhitespace = false

--- a/config.toml
+++ b/config.toml
@@ -6,6 +6,10 @@ enableRobotsTXT = true
 
 [params]
   twitter = "okfde"
+  twitter_site_id = "255123777" 
+  author = "okfde" 
+  keywords = ["Offene Daten", "Civic Tech", "Open Government", "Offene Bildung", "Digitale Mündigkeit" , "Informationsfreiheit", " Open Data"]
+  subtitle = "Open Knowledge Foundation Deutschland e.V."
 
 [permalinks]
   blog = 'blog/:year/:month/:slug/'

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,11 +1,3 @@
-{{ define "title"}}
-<title>404 - Page not found</title>
-{{ end }}
-
-{{ define "head" }}
-<style>img { width:100%; height: auto; }</style>
-{{ end }}
-
 {{ define "main"}}
 <main id="main">
   <div class="container">

--- a/layouts/_default/anniversary.html
+++ b/layouts/_default/anniversary.html
@@ -1,22 +1,3 @@
-{{ define "title"}}
-<title>{{ .Title }} - {{ .Site.Title }}</title>
-{{ end }}
-
-{{ define "head" }}
-{{ range .AlternativeOutputFormats -}}
-<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
-{{ end -}}
-<meta property="og:title" content="{{ .Site.Title }} {{ .Title }}" />
-<meta property="og:type" content="website" />
-<meta property="og:url" content="{{ .Permalink }}" />
-{{ with .Params.img_header }}
-<meta property="og:image" content="{{ . }}" />{{ end }}
-{{with .Params.meta}}
-<meta property="og:description" content="{{.}}">
-<meta name="description" content="{{.}}">
-{{end}}
-{{ end }}
-
 {{ define "main" }}
 <div class="container align-items-end">
   <div class="row align-items-end">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,8 +2,6 @@
 <html lang="{{ .Lang }}">
   <head>
     {{- partial "head.html" . -}}
-    {{- block "title" .}}{{- end }}
-    {{- block "head" .}}{{- end }}
   </head>
   <body class="no-js rebuildall">
     {{- partial "header.html" . -}}

--- a/layouts/_default/blog.html
+++ b/layouts/_default/blog.html
@@ -1,32 +1,3 @@
-{{ define "title"}}
-<title>{{ .Title }} - {{ .Site.Title }}</title>
-{{ end }}
-
-{{ define "head" }}
-  {{ range .AlternativeOutputFormats -}}
-    <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
-  {{ end -}}
-
-  <meta property="og:title" content="{{ .Site.Title }} {{ .Title }}" />
-  <meta property="og:type" content="website" />
-  <meta property="og:url" content="{{ .Permalink }}" />
-
-  {{ with .Params.meta }}
-    <meta property="og:description" content="{{.}}">
-    <meta name="description" content="{{.}}">
-    <meta name="twitter:description" content="{{ truncate 200 .}}">
-  {{ end }}
-
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:site" content="@{{ .Site.Params.twitter }}">
-  <meta name="twitter:title" content="{{ .Title }}">
-
-  {{ with .Params.img_header }}
-    <meta property="og:image" content="{{ . }}" />
-    <meta name="twitter:image" content="{{ . }}">
-  {{ end }}
-{{ end }}
-
 {{ define "main" }}
 <main>
   <header class="l__blog__header container align-items-end">

--- a/layouts/_default/board.html
+++ b/layouts/_default/board.html
@@ -1,20 +1,3 @@
-{{ define "title"}}
-<title>{{ .Title }} - {{ .Site.Title }}</title>
-{{ end }}
-
-{{ define "head" }}
-{{ range .AlternativeOutputFormats -}}
-<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
-{{ end -}}
-<meta property="og:title" content="{{ .Site.Title }} {{ .Title }}" />
-<meta property="og:type" content="website" />
-<meta property="og:url" content="{{ .Permalink }}" />
-{{ with .Params.img_header }}<meta property="og:image" content="{{ . }}" />{{ end }}
-{{with .Params.meta}}
-<meta property="og:description" content="{{.}}">
-<meta name="description" content="{{.}}">
-{{end}}
-{{ end }}
 
 {{ define "main" }}
 <main>

--- a/layouts/_default/donation.html
+++ b/layouts/_default/donation.html
@@ -1,21 +1,3 @@
-{{ define "title"}}
-<title>{{ .Title }} - {{ .Site.Title }}</title>
-{{ end }}
-
-{{ define "head" }}
-{{ range .AlternativeOutputFormats -}}
-<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
-{{ end -}}
-<meta property="og:title" content="{{ .Site.Title }} {{ .Title }}" />
-<meta property="og:type" content="website" />
-<meta property="og:url" content="{{ .Permalink }}" />
-{{ with .Params.img_header }}<meta property="og:image" content="{{ . }}" />{{ end }}
-{{with .Params.meta}}
-<meta property="og:description" content="{{.}}">
-<meta name="description" content="{{.}}">
-{{end}}
-{{ end }}
-
 {{ define "main" }}
 <section class="l__donation container align-items-end">
   <div class="row align-items-end">

--- a/layouts/_default/finance.html
+++ b/layouts/_default/finance.html
@@ -1,21 +1,3 @@
-{{ define "title"}}
-<title>{{ .Title }} - {{ .Site.Title }}</title>
-{{ end }}
-
-{{ define "head" }}
-{{ range .AlternativeOutputFormats -}}
-<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
-{{ end -}}
-<meta property="og:title" content="{{ .Site.Title }} {{ .Title }}" />
-<meta property="og:type" content="website" />
-<meta property="og:url" content="{{ .Permalink }}" />
-{{ with .Params.img_header }}<meta property="og:image" content="{{ . }}" />{{ end }}
-{{with .Params.meta}}
-<meta property="og:description" content="{{.}}">
-<meta name="description" content="{{.}}">
-{{end}}
-{{ end }}
-
 {{ define "main" }}
 <section class="l__finance container align-items-end">
   <div class="row align-items-end">

--- a/layouts/_default/jobs.html
+++ b/layouts/_default/jobs.html
@@ -1,21 +1,3 @@
-{{ define "title"}}
-<title>{{ .Title }} - {{ .Site.Title }}</title>
-{{ end }}
-
-{{ define "head" }}
-{{ range .AlternativeOutputFormats -}}
-<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
-{{ end -}}
-<meta property="og:title" content="{{ .Site.Title }} {{ .Title }}" />
-<meta property="og:type" content="website" />
-<meta property="og:url" content="{{ .Permalink }}" />
-{{ with .Params.img_header }}<meta property="og:image" content="{{ . }}" />{{ end }}
-{{with .Params.meta}}
-<meta property="og:description" content="{{.}}">
-<meta name="description" content="{{.}}">
-{{end}}
-{{ end }}
-
 {{ define "main" }}
 <main>
   <div class="l__content container">

--- a/layouts/_default/profile.html
+++ b/layouts/_default/profile.html
@@ -1,22 +1,3 @@
-{{ define "title"}}
-<title>{{ .Title }} - {{ .Site.Title }}</title>
-{{ end }}
-
-{{ define "head" }}
-{{ range .AlternativeOutputFormats -}}
-<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
-{{ end -}}
-<meta property="og:title" content="{{ .Site.Title }} {{ .Title }}" />
-<meta property="og:type" content="website" />
-<meta property="og:url" content="{{ .Permalink }}" />
-{{ with .Params.img_header }}
-<meta property="og:image" content="{{ . }}" />{{ end }}
-{{with .Params.meta}}
-<meta property="og:description" content="{{.}}">
-<meta name="description" content="{{.}}">
-{{end}}
-{{ end }}
-
 {{ define "main" }}
 <div class="container">
   <div class="row">

--- a/layouts/_default/project.html
+++ b/layouts/_default/project.html
@@ -1,22 +1,3 @@
-{{ define "title"}}
-<title>{{ .Title }} - {{ strings.FirstUpper .Section }} - {{ .Site.Title}}</title>
-{{ end }}
-
-{{ define "head" }}
-{{ range .AlternativeOutputFormats -}}
-<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
-{{ end -}}
-{{with .Params.subtitle }}<meta description="{{.}}">{{ end }}
-<meta property="og:title" content="{{ .Title }}" />
-<meta property="og:type" content="article" />
-<meta property="og:url" content="{{ .Permalink }}" />
-<meta property="og:image" content='/files/{{ trim .Params.img_header "/"}}' />
-{{with .Params.subtitle}}
-<meta property="og:description" content="{{.}}">
-<meta name="description" content="{{.}}">
-{{end}}
-{{ end }}
-
 {{ define "main" }}
 <main>
   <article class="l__project">

--- a/layouts/_default/projekte.html
+++ b/layouts/_default/projekte.html
@@ -1,22 +1,3 @@
-{{ define "title"}}
-<title>{{ .Title }} - {{ .Site.Title }}</title>
-{{ end }}
-
-{{ define "head" }}
-{{ range .AlternativeOutputFormats -}}
-<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
-{{ end -}}
-<meta property="og:title" content="{{ .Site.Title }} {{ .Title }}" />
-<meta property="og:type" content="website" />
-<meta property="og:url" content="{{ .Permalink }}" />
-{{ with .Params.img_header }}
-<meta property="og:image" content="{{ . }}" />{{ end }}
-{{with .Params.meta}}
-<meta property="og:description" content="{{.}}">
-<meta name="description" content="{{.}}">
-{{end}}
-{{ end }}
-
 {{ define "main" }}
 <main>
   <section class='container l__projects js-shuffle'>

--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -1,22 +1,3 @@
-{{ define "title"}}
-<title>{{ .Title }} - {{ .Site.Title }}</title>
-{{ end }}
-
-{{ define "head" }}
-{{ range .AlternativeOutputFormats -}}
-<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
-{{ end -}}
-<meta property="og:title" content="{{.Title}}" />
-<meta property="og:type" content="website" />
-<meta property="og:url" content="{{.Permalink}}" />
-<meta property="og:image" content="" />
-{{with .Params.meta}}
-<meta property="og:description" content="{{.}}">
-<meta name="description" content="{{.}}">
-{{end}}
-{{ end }}
-
-
 {{ define "main" }}
 <main>
   <p>section template</p>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,21 +1,3 @@
-{{ define "title"}}
-<title>{{ .Title }} - {{ .Site.Title}}</title>
-{{ end }}
-
-{{ define "head" }}
-{{ range .AlternativeOutputFormats -}}
-<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
-{{ end -}}
-<meta property="og:title" content="{{ .Title }}" />
-<meta property="og:type" content="website" />
-<meta property="og:url" content="{{ .Permalink }}" />
-{{ with .Params.img_header }}<meta property="og:image" content="{{ . }}" />{{ end }}
-{{with .Params.meta}}
-<meta property="og:description" content="{{.}}">
-<meta name="description" content="{{.}}">
-{{end}}
-{{ end }}
-
 {{ define "main" }}
 <main>
   <div class="container l__content">

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -1,21 +1,3 @@
-{{ define "title"}}
-<title>{{ .Title }} - {{ strings.FirstUpper .Section }} -  {{ .Site.Title}}</title>
-{{ end }}
-
-{{ define "head" }}
-{{ range .AlternativeOutputFormats -}}
-<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
-{{ end -}}
-<meta property="og:title" content="{{ .Site.Title }} - {{ strings.FirstUpper .Section }}: {{ .Title }}" />
-<meta property="og:type" content="website" />
-<meta property="og:url" content="{{ .Permalink }}" />
-<meta property="og:image" content="" />
-{{with .Params.meta}}
-<meta property="og:description" content="{{.}}">
-<meta name="description" content="{{.}}">
-{{end}}
-{{ end }}
-
 {{ define "main" }}
 <main>
   <header class="l__blog__header container">

--- a/layouts/_default/team.html
+++ b/layouts/_default/team.html
@@ -1,22 +1,3 @@
-{{ define "title"}}
-<title>{{ .Title }} - {{ .Site.Title }}</title>
-{{ end }}
-
-{{ define "head" }}
-{{ range .AlternativeOutputFormats -}}
-<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
-{{ end -}}
-<meta property="og:title" content="{{ .Site.Title }} {{ .Title }}" />
-<meta property="og:type" content="website" />
-<meta property="og:url" content="{{ .Permalink }}" />
-{{ with .Params.img_header }}<meta property="og:image" content="{{ . }}" />{{ end }}
-{{with .Params.meta}}
-<meta property="og:description" content="{{.}}">
-<meta name="description" content="{{.}}">
-{{end}}
-{{ end }}
-
-
 {{ define "main" }}
 <main>
   <div class="container l__team">

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,21 +1,3 @@
-{{ define "title"}}
-<title>{{ .Title }} - {{ .Site.Title }}</title>
-{{ end }}
-
-{{ define "head" }}
-{{ range .AlternativeOutputFormats -}}
-<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
-{{ end -}}
-<meta property="og:title" content="{{ .Site.Title }} {{ .Title }}" />
-<meta property="og:type" content="website" />
-<meta property="og:url" content="{{ .Permalink }}" />
-{{ with .Params.img_social }}<meta property="og:image" content="{{ . }}" />{{ end }}
-{{with .Params.meta}}
-<meta property="og:description" content="{{.}}">
-<meta name="description" content="{{.}}">
-{{end}}
-{{ end }}
-
 {{ define "main" }}
 <main>
   <header class="l__blog__header container">

--- a/layouts/_default/topics.html
+++ b/layouts/_default/topics.html
@@ -1,21 +1,3 @@
-{{ define "title"}}
-<title>{{ .Title }} - {{ .Site.Title }}</title>
-{{ end }}
-
-{{ define "head" }}
-{{ range .AlternativeOutputFormats -}}
-<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
-{{ end -}}
-<meta property="og:title" content="{{ .Site.Title }} {{ .Title }}" />
-<meta property="og:type" content="website" />
-<meta property="og:url" content="{{ .Permalink }}" />
-{{ with .Params.img_social }}<meta property="og:image" content="{{ . }}" />{{ end }}
-{{with .Params.meta}}
-<meta property="og:description" content="{{.}}">
-<meta name="description" content="{{.}}">
-{{end}}
-{{ end }}
-
 {{ define "main" }}
 <main>
   <div class="container">

--- a/layouts/_default/verein.html
+++ b/layouts/_default/verein.html
@@ -1,21 +1,3 @@
-{{ define "title"}}
-<title>{{ .Title }} - {{ .Site.Title }}</title>
-{{ end }}
-
-{{ define "head" }}
-{{ range .AlternativeOutputFormats -}}
-<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
-{{ end -}}
-<meta property="og:title" content="{{ .Site.Title }} {{ .Title }}" />
-<meta property="og:type" content="website" />
-<meta property="og:url" content="{{ .Permalink }}" />
-{{ with .Params.img_header }}<meta property="og:image" content="{{ . }}" />{{ end }}
-{{with .Params.meta}}
-<meta property="og:description" content="{{.}}">
-<meta name="description" content="{{.}}">
-{{end}}
-{{ end }}
-
 {{ define "main" }}
 <main>
   <section class="l__verein container align-items-end">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,18 +1,3 @@
-{{ define "title"}}
-<title>OKF - Open Knowledge Foundation Deutschland e.V.</title>
-{{ end }}
-
-{{ define "head" }}
-<meta property="og:title" content="OKF DE" />
-<meta property="og:type" content="website" />
-<meta property="og:url" content="https://okfn.de" />
-{{ with .Params.img_header }}<meta property="og:image" content="{{ . }}" />{{ end }}
-{{with .Params.meta}}
-<meta property="og:description" content="{{.}}">
-<meta name="description" content="{{.}}">
-{{end}}
-{{ end }}
-
 {{ define "main" }}
 <main>
   <div class="l__home">

--- a/layouts/jobs/single.html
+++ b/layouts/jobs/single.html
@@ -1,29 +1,3 @@
-{{ define "title"}}
-<title>{{ .Title }} - {{ strings.FirstUpper .Section }} - {{ .Site.Title}}</title>
-{{ end }}
-
-{{ define "head" }}
-{{ range .AlternativeOutputFormats -}}
-<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
-{{ end -}}
-<meta property="og:title" content="{{ .Title }}" />
-<meta property="og:type" content="article" />
-<meta property="og:url" content="{{ .Permalink }}" />
-<meta property="article:published_time" content="{{ .Date }}" />
-
-<meta property="og:description" content="{{ truncate 200 .Content }}">
-<meta name="description" content="{{ truncate 200 .Content }}">
-<meta name="twitter:description" content="{{ truncate 200 .Content}}">
-<meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="{{ .Title }}">
-<meta name="twitter:site" content="@{{ .Site.Params.twitter }}">
-<meta name="twitter:creator" content="@{{ .Site.Params.twitter }}">
-{{with .Params.image}}
-  <meta property="og:image" content='{{ $.Site.BaseURL }}/{{ trim .src "/"}}'>
-  <meta name="twitter:image" content='{{ $.Site.BaseURL }}/{{ trim .src "/"}}'>
-{{end}}
-{{ end }}
-
 {{ define "main" }}
 <main>
   <article class="c__post--single">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,16 +1,47 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+{{ hugo.Generator }}
 
-<link rel="apple-touch-icon" sizes="180x180" href="/files/favicon/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/files/favicon/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/files/favicon/favicon-16x16.png">
-<link rel="manifest" href="/files/favicon/manifest.json">
-<link rel="mask-icon" href="/files/favicon/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/files/favicon/favicon.ico">
-<meta name="msapplication-TileColor" content="#ffffff">
-<meta name="msapplication-config" content="/files/favicon/browserconfig.xml">
-<meta name="theme-color" content="#ffffff">
+<!-- SEO stuff -->
+<meta name="robots" content="index,follow">
+<meta name="googlebot" content="index,follow">
+<meta name="google" content="nositelinkssearchbox">
+<meta name="google" content="notranslate">
 
+<meta name="rating" content="General">
+<meta name="referrer" content="no-referrer">
+<meta name="format-detection" content="telephone=no">
+
+    <!-- Description -->
+  {{ if lt (len .Summary) 150 }}
+    <meta name="description" content="{{ .Summary | plainify }}">
+  {{ else }}
+    <meta name="description" content="{{ .Summary | plainify | truncate 150 }}">
+  {{ end }}
+
+  <meta name="keywords" content={{ delimit .Site.Params.keywords ", " }} />
+
+  
+      <!-- Author -->
+  {{ if (isset .Params "author") }}
+    <meta property="article:author" content="{{ .Params.author }}">
+  {{ else }}
+    <meta property="article:author" content="{{ .Site.Params.author }}">
+  {{ end }}
+  
+<!-- Twitter Card and open Graph-->
+  {{- partial "head_openGraph.html" . }}
+
+<!-- Icons -->
+  {{- partial "head_favicon.html" . }}
+
+
+  {{ range .AlternativeOutputFormats -}}
+    <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
+  {{ end -}}
+
+
+<!-- bundling -->
 <link rel="preload" href="/fonts/apercu-bold-pro.woff" as="font" type="font/woff" crossorigin>
 <link rel="preload" href="/fonts/apercu-medium-pro.woff" as="font" type="font/woff" crossorigin>
 <link rel="preload" href="/fonts/apercu-regular-pro.woff" as="font" type="font/woff" crossorigin>
@@ -18,3 +49,13 @@
 {{ $style := resources.Get "sass/main.sass" | resources.ToCSS | resources.Minify | resources.Fingerprint }}
 <link rel="stylesheet" href="{{$style.RelPermalink}}">
 {{- partial "js.html" . -}}
+
+
+<link rel="canonical" href="{{ .Permalink }}" />
+
+{{ $ctitle := ( printf "%s - %s" .Title .Site.Title ) }}
+{{ if not .IsHome }}
+  {{ $ctitle = ( printf "%s : %s - %s" .Title .Site.Title .Site.Params.Subtitle) }}
+{{ end }}
+
+<title>{{ $ctitle }}</title>

--- a/layouts/partials/head_favicon.html
+++ b/layouts/partials/head_favicon.html
@@ -1,0 +1,9 @@
+<link rel="apple-touch-icon" sizes="180x180" href="/files/favicon/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/files/favicon/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/files/favicon/favicon-16x16.png">
+<link rel="manifest" href="/files/favicon/manifest.json">
+<link rel="mask-icon" href="/files/favicon/safari-pinned-tab.svg" color="#5bbad5">
+<link rel="shortcut icon" href="/files/favicon/favicon.ico">
+<meta name="msapplication-TileColor" content="#ffffff">
+<meta name="msapplication-config" content="/files/favicon/browserconfig.xml">
+<meta name="theme-color" content="#ffffff">

--- a/layouts/partials/head_openGraph.html
+++ b/layouts/partials/head_openGraph.html
@@ -1,0 +1,39 @@
+<!--  OpenGraph and Twitter Card Stuff starts here -->
+{{ $permalink := "/files/favicon/apple-touch-icon.png" | absURL }}
+{{ $imgalt := print .Site.Params.subtitle }}
+
+{{ if (isset .Params "image") }}
+  {{ $permalink = print .Params.image.src | absURL }}
+  {{ if (isset .Params.image "title") }}
+    {{ $imgalt = .Params.image.title }}
+  {{ end }}
+{{ end }}
+
+  <!-- Twitter card meta tags can be validated at https://cards-dev.twitter.com/validator -->
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site:id" content="{{ .Site.Params.twitter_site_id}}">
+
+{{ if (isset .Params "twitter_creator_id") }}
+  <meta name="twitter:creator:id" content="{{ .Params.twitter_creator_id }}">
+{{ end }}
+
+  <!-- add tags to description -->
+{{ if (isset .Params "tags") }}
+  {{ $tagstring := " " }}
+  {{ range  .Params.tags}}
+    {{ $tagstring = (print $tagstring "#" (replace . " " "" ) " ") }}
+  {{ end }}
+  <meta name="twitter:description" content="{{ print (.Summary | plainify | truncate (sub 199 (len $tagstring))) $tagstring }}">
+  {{ else }}
+  <meta name="twitter:description" content="{{ .Summary | plainify | truncate 199 }}">
+{{ end }}
+
+
+<meta property="og:url" content="{{ .Permalink }}">
+<meta property="og:type" content="website">
+<meta property="og:title" content="{{ .Title | plainify | truncate 70 }}">
+<meta property="og:description" content="{{ .Summary | plainify | truncate 150 }}">
+<meta property="og:site_name" content="{{ .Site.Title }}">
+<meta property="og:locale" content="{{ .Site.LanguageCode }}">
+<meta property="og:image" content="{{  $permalink }}">
+<meta property="og:image:alt" content="{{ $imgalt }}">

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -1,33 +1,3 @@
-{{ define "title"}}
-<title>{{ .Title }} - {{ strings.FirstUpper .Section }} - {{ .Site.Title}}</title>
-{{ end }}
-
-{{ define "head" }}
-{{ range .AlternativeOutputFormats -}}
-<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
-{{ end -}}
-<meta property="og:title" content="{{ .Title }}" />
-<meta property="og:type" content="article" />
-<meta property="og:url" content="{{ .Permalink }}" />
-<meta property="article:published_time" content="{{ .Date }}" />
-{{ with .Params.tags }}
-  {{ range . }}
-    <meta property="article:tag" content="{{ . }}" />
-  {{ end }}
-{{ end }}
-<meta property="og:description" content="{{ truncate 200 .Content }}">
-<meta name="description" content="{{ truncate 200 .Content }}">
-<meta name="twitter:description" content="{{ truncate 200 .Content}}">
-<meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="{{ .Title }}">
-<meta name="twitter:site" content="@{{ .Site.Params.twitter }}">
-<meta name="twitter:creator" content="@{{ .Site.Params.twitter }}">
-{{ if (isset .Params "image") }}
-<meta property="og:image" content='{{ .Site.BaseURL }}/{{ trim .Params.image.src "/"}}' />
-<meta name="twitter:image" content='{{ .Site.BaseURL }}/{{ trim .Params.image.src "/"}}'>
-{{end}}
-{{ end }}
-
 {{ define "main" }}
 <main>
   <article class="c__post--single">

--- a/layouts/projektfilter/single.html
+++ b/layouts/projektfilter/single.html
@@ -1,16 +1,3 @@
-{{ define "title"}}
-<title>{{ .Title }} - {{ strings.FirstUpper .Section }} - {{ .Site.Title}}</title>
-{{ end }}
-
-{{ define "head" }}
-{{ range .AlternativeOutputFormats -}}
-<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
-{{ end -}}
-<meta property="og:title" content="{{ .Title }} - {{ strings.FirstUpper .Section }} - {{ .Site.Title}}" />
-<meta property="og:type" content="website" />
-<meta property="og:url" content="{{ .Permalink }}" />
-{{ end }}
-
 {{ define "main" }}
 <main>
   <section class="container l__projects">

--- a/layouts/themen/single.html
+++ b/layouts/themen/single.html
@@ -1,21 +1,3 @@
-{{ define "title"}}
-<title>{{ .Title }} - {{ strings.FirstUpper .Section }} - {{ .Site.Title }}</title>
-{{ end }}
-
-{{ define "head" }}
-{{ range .AlternativeOutputFormats -}}
-<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
-{{ end -}}
-<meta property="og:title" content="{{ .Site.Title }} {{ .Title }}" />
-<meta property="og:type" content="website" />
-<meta property="og:url" content="{{ .Permalink }}" />
-{{ with .Params.img_social }}<meta property="og:image" content="{{ . }}" />{{ end }}
-{{with .Params.meta}}
-<meta property="og:description" content="{{.}}">
-<meta name="description" content="{{.}}">
-{{end}}
-{{ end }}
-
 {{ define "main" }}
 <main>
   <div class="container l__topic">


### PR DESCRIPTION
Page Partials refactored > removed head and title elements
Implemented head & title in head.html

Favicons and openGraph metadata are now in their corresponding partial.
Added some global Configuration and extended the Archetypes with the twitter_id

should resolve https://github.com/okfde/okfn.de/issues/68