### PR TITLE
Add link to 2021 annual report on transparency page

### DIFF
--- a/content/transparenz.en.md
+++ b/content/transparenz.en.md
@@ -35,6 +35,7 @@ Our external data protection officer is Beata-Konstanze Hubrig from [Rechtsanwal
 ### 5. Annual reports [DE]
 Transparancy has to be lived and not just demanded, and thus, since 2017, we provide our annual financial and activity report following the guidelines of the Social Reporting Standard.
 
+- [Jahresbericht 2021](https://2021.okfn.de/) <br>
 - [Jahresbericht 2020](https://2020.okfn.de/) <br>
 - [Tätigkeitsbericht 2019](https://2019.okfn.de/) <br>
 - [Tätigkeitsbericht 2018](https://2018.okfn.de/) <br>

--- a/content/transparenz.md
+++ b/content/transparenz.md
@@ -37,6 +37,7 @@ Wer Transparenz fordert, muss auch selbst transparent sein, vor allem in der Fin
 
 [comment]: # (!Achtung: Den aktuellen Bericht KEINESFALLS schon hier verlinken, bevor nicht 1. die Mitgliederversammlung ihn abgesegnet hat und 2. der Wirtschaftsprüfer die Zahlen freigegeben hat!)
 
+- [Jahresbericht 2021](https://2021.okfn.de/) <br>
 - [Jahresbericht 2020](https://2020.okfn.de/) <br>
 - [Tätigkeitsbericht 2019](https://2019.okfn.de/) <br>
 - [Tätigkeitsbericht 2018](https://2018.okfn.de/) <br>


### PR DESCRIPTION
The annual report of 2021 is not linked on the transparency page.