### PR TITLE
Use `publishedDate` instead of `published`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Hugo setup
         uses: peaceiris/actions-hugo@v2.4.13
         with:
-          hugo-version: '0.134.3'
           extended: true
       - run: hugo
       - run: pwd

--- a/content/blog/2014/2014-12-14-open-science-sum-up-november.markdown
+++ b/content/blog/2014/2014-12-14-open-science-sum-up-november.markdown
@@ -1,18 +1,15 @@
 ---
 author: Stefan Kasberger
-date: 2014-12-14 19:27:55
 image:
   src: http://openscienceasap.org/wp-content/uploads/2014/12/MapoftheMoon-580x580.jpg
   title: Map of the Moon, cc by 2.0 scan by UCL Mathematical and Physical Sciences, original work is public domain
 layout: post
-published: true
 status: publish
 tags:
 - Open Science
 title: Open Science Sum-Up November
 type: post
-
-
+publishedDate: 2014-12-14 19:27:55
 ---
 
 Der [monatliche Open Science Sum-Up](http://openscienceasap.org/social/monthly-sum-up/) fasst aktuelle Geschehnisse zu Open Science zusammen und gibt einen Ausblick auf nächste wichtige Ereignisse: Weltweit mit Schwerpunkt auf Österreich und Deutschland sowie zu openscienceASAP.

--- a/content/blog/2015/2015-05-12-praktikum-bei-code-for-germany.markdown
+++ b/content/blog/2015/2015-05-12-praktikum-bei-code-for-germany.markdown
@@ -1,6 +1,6 @@
 ---
 author: Fiona Krakenbuerger
-date: 2015-05-12 14:25
+date: 2015-05-12
 image:
   src: /files/blog/2015/04/codeforde.jpg
   title: 

--- a/content/blog/2015/2015-05-18-event-open-data-fighting-corruption.markdown
+++ b/content/blog/2015/2015-05-18-event-open-data-fighting-corruption.markdown
@@ -1,6 +1,6 @@
 ---
 author: Mara Mendes
-date: 2015-05-18 11:25
+date: 2015-05-18
 image:
   src: /files/blog/2015/05/digiwhist.jpg
 layout: post

--- a/content/blog/2015/2015-05-25-event-open-data-G7-Gipfel-charter.markdown
+++ b/content/blog/2015/2015-05-25-event-open-data-G7-Gipfel-charter.markdown
@@ -1,6 +1,6 @@
 ---
 author: Christian Heise
-date: 2015-05-25 18:11
+date: 2015-05-25
 image:
   src: http://farm4.staticflickr.com/3752/9075252444_43b30267fa_c.jpg
 layout: post

--- a/content/blog/2015/2015-05-27-klausurheberrecht.markdown
+++ b/content/blog/2015/2015-05-27-klausurheberrecht.markdown
@@ -1,6 +1,6 @@
 ---
 author: Arne Semsrott
-date: 2015-05-27 18:42
+date: 2015-05-27
 image:
   src: https://netzpolitik.org/wp-upload/pruefung-300x225.jpg
 layout: post

--- a/content/blog/2015/2015-06-03-ifg-gebuehren.markdown
+++ b/content/blog/2015/2015-06-03-ifg-gebuehren.markdown
@@ -1,6 +1,6 @@
 ---
 author: Arne Semsrott
-date: 2015-06-03 11:42
+date: 2015-06-03
 image:
   src: https://netzpolitik.org/wp-upload/2111661914_047d8ca339_z-300x177.jpg
   license: CC BY 2.0 via flickr/matze_ott

--- a/content/blog/2015/2015-06-04-Stellenauschreibung-Buchhaltung.markdown
+++ b/content/blog/2015/2015-06-04-Stellenauschreibung-Buchhaltung.markdown
@@ -1,6 +1,6 @@
 ---
 author: Kristina Klein
-date: 2015-06-04 14:05
+date: 2015-06-04
 image:
   src: /files/blog/2015/06/images-people-working-office-coffee-9228.jpg
   title: Athmo

--- a/content/blog/2015/2015-06-05-g7-summit-open-data-charter-deutschland.markdown
+++ b/content/blog/2015/2015-06-05-g7-summit-open-data-charter-deutschland.markdown
@@ -1,6 +1,6 @@
 ---
 author: Christian Heise
-date: 2015-06-05 08:00
+date: 2015-06-05
 image:
   src: http://farm4.staticflickr.com/3752/9075252444_43b30267fa_c.jpg
   title:

--- a/content/blog/2015/2015-06-11-jugund-hackt-ost.markdown
+++ b/content/blog/2015/2015-06-11-jugund-hackt-ost.markdown
@@ -1,6 +1,6 @@
 ---
 author: Paula Glaser
-date: 2015-06-09 10:00
+date: 2015-06-09
 image:
   src: /files/blog/2015/06/17987867593_a11540c288_k.jpg
   title: Logo Entwicklungsbarometer

--- a/content/blog/2015/2015-07-16-stadtgeschichten-codeforde.markdown
+++ b/content/blog/2015/2015-07-16-stadtgeschichten-codeforde.markdown
@@ -1,6 +1,6 @@
 ---
 author: Eileen Wagner
-date: 2015-07-16 12:00
+date: 2015-07-16
 image:
   src: /files/blog/2015/07/stadtgeschichten.png
   title: Stadtgeschichten

--- a/content/blog/2015/2015-07-20-Stellenausschreibung-Open-Budgets.markdown
+++ b/content/blog/2015/2015-07-20-Stellenausschreibung-Open-Budgets.markdown
@@ -1,6 +1,6 @@
 ---
 author: Fiona Krakenbuerger
-date: 2015-07-20 12:00
+date: 2015-07-20
 image:
   src: /files/blog/2015/07/jobs.jpg
   title: Jobs bei OKFDE

--- a/content/blog/2015/2015-07-22-mit-daten-gutes-tun.markdown
+++ b/content/blog/2015/2015-07-22-mit-daten-gutes-tun.markdown
@@ -1,6 +1,6 @@
 ---
 author: Tobias Pfaff
-date: 2015-07-22 16:00
+date: 2015-07-22
 image:
   src: /files/blog/2015/07/open-impact.png
   title: OpenImpact

--- a/content/blog/2015/2015-07-23-Code-und-Ethik.markdown
+++ b/content/blog/2015/2015-07-23-Code-und-Ethik.markdown
@@ -1,6 +1,6 @@
 ---
 author: Paula Glaser
-date: 2015-07-23 17:00
+date: 2015-07-23
 image:
   src: http://medialepfade.de/wp-content/uploads/2015/07/codeundethik.jpg
 layout: post

--- a/content/blog/2015/2015-08-13-Stellenausschreibung-DIGIWHIST.markdown
+++ b/content/blog/2015/2015-08-13-Stellenausschreibung-DIGIWHIST.markdown
@@ -1,6 +1,6 @@
 ---
 author: Mara Mendes
-date: 2015-08-14 12:00
+date: 2015-08-14
 image:
   src: /files/blog/2015/07/digiwhist.jpg
   title: Jobs bei OKFDE

--- a/content/blog/2016/2016-03-31-public-procurement-digital-era.md
+++ b/content/blog/2016/2016-03-31-public-procurement-digital-era.md
@@ -2,7 +2,7 @@
 authors:
 - Mara Mendes
 - Mihaly Fazekas
-date: 2016-03-30 23:33
+date: 2016-03-30
 image:
   src: /files/blog/2016/03/FileStack_retouched.jpg
   title: "Public procurement in Europe needs to enter the digital era"

--- a/content/blog/2016/2016-08-01-prototypefund-launch.md
+++ b/content/blog/2016/2016-08-01-prototypefund-launch.md
@@ -1,9 +1,8 @@
 ---
 author: Julia Kloiber
-date: 2016-08-01 09:00:00
 image:
   src: /files/blog/2016/08/PrototypeFundLogo.png
-  license: 
+  license: null
   title: Prototype Fund!
 layout: post
 tags:
@@ -15,7 +14,7 @@ tags:
 - BMBF
 title: Hello World! <br> Hello Prototype Fund!
 type: post
-published: true
+publishedDate: 2016-08-01 09:00:00
 ---
 
 Nach über einem Jahr Planung und Konzeption freuen wir uns sehr darüber, endlich live zu sein! Mit dem [Prototype Fund](http://prototypefund.de) haben wir ein Programm ins Leben gerufen, das wir uns seit vielen Jahren selbst wünschen. Schon lange sind wir als gemeinnützige Organisation in den Bereichen Freies Wissen, Open Data und Civic Tech unterwegs. Wir entwickeln Tools, helfen dabei Communitys aufzubauen, veranstalten Events und vieles mehr. Aus eigener Erfahrung und derer vieler engagierter Menschen aus unser Community wissen wir, wie schwierig es sein kann, finanzielle Unterstützung für gemeinnützige Vorhaben oder für Projekte in neuen Themenfeldern zu bekommen.
@@ -48,4 +47,3 @@ Innovationen lassen sich schwer planen. Oftmals gehen der Entwicklung einer neue
 ###Der Prototype Fund als Prototyp
 
 Auch das Programm selbst verstehen wir als Prototyp. Wir wollen von und mit der Community lernen und das Programm laufend anpassen und weiterentwickeln. Dafür haben wir drei Jahre und vier Runden lang Zeit. In den nächsten Jahren wollen wir tolle Projekte fördern, neue Themenschwerpunkte erforschen, ein Netzwerk aufbauen und lernen, wie Förderprogramme der Zukunft aussehen müssen. Feedback und Kontakt zur Community sind für uns deshalb besonders wichtig!
-

--- a/content/blog/2016/2016-08-08-okf-at-ogp.md
+++ b/content/blog/2016/2016-08-08-okf-at-ogp.md
@@ -1,7 +1,7 @@
 ---
 authors:
 - Mara Mendes
-date: 2016-07-31 15:00
+date: 2016-07-31
 image:
   src: /files/blog/2016/08/OKF-at-OGP.jpg
   title: OGP   

--- a/content/blog/2016/2016-08-18-obs-studie.md
+++ b/content/blog/2016/2016-08-18-obs-studie.md
@@ -1,7 +1,7 @@
 ---
 authors:
 - Arne Semsrott
-date: 2016-08-18 12:00
+date: 2016-08-18
 image:
   src: /files/blog/2016/08/obs-cover.jpg
   title: OBS-Studie   

--- a/content/blog/2016/2016-09-02-OpenBudgets-Datenschule-at-EA-Campus_Event.md
+++ b/content/blog/2016/2016-09-02-OpenBudgets-Datenschule-at-EA-Campus_Event.md
@@ -2,7 +2,7 @@
 authors:
 - Anna Alberts
 - Moritz Neujeffski
-date: 2016-09-02 15:00
+date: 2016-09-02
 image:
   src: /files/blog/2016/09/EA_CAMPUS.png
   title: European Alternatives Campus Event 16

--- a/content/blog/2016/2016-09-26-5jahrefds.md
+++ b/content/blog/2016/2016-09-26-5jahrefds.md
@@ -1,7 +1,7 @@
 ---
 authors:
 - Arne Semsrott
-date: 2016-09-26 23:00
+date: 2016-09-26
 image:
   src: /files/logos/Logo_okfde_black.png
   title: FragDenStaat-Geburtstag

--- a/content/blog/2016/2016-09-28-tagderinformationsfreiheit.md
+++ b/content/blog/2016/2016-09-28-tagderinformationsfreiheit.md
@@ -1,7 +1,7 @@
 ---
 authors:
 - Arne Semsrott
-date: 2016-09-28 14:00
+date: 2016-09-28
 image:
   src: /files/blog/2016/09/000000.jpg
   title: IFG-Kunstedition

--- a/content/blog/2017/2017-02-21-okf-sucht-neue-geschaeftsfuehrung.md
+++ b/content/blog/2017/2017-02-21-okf-sucht-neue-geschaeftsfuehrung.md
@@ -1,21 +1,20 @@
 ---
-authors: 
+authors:
 - OKF
-date: 2017-02-21 08:00:00
 image:
   src: /files/blog/2017/02/okf-team.png
-  title: 
+  title: null
   license: CC BY 2.0
-  license_url: 
+  license_url: null
 tags:
 - Ausschreibung
 - Jobs
 type: post
 layout: post
 card: true
-published: true
-jobs:
-title: "OKF DE sucht neue/n Geschäftsführer/in!"
+jobs: null
+title: OKF DE sucht neue/n Geschäftsführer/in!
+publishedDate: 2017-02-21 08:00:00
 ---
 
 <b>+++ Bewerbungsfrist um eine Woche auf 16. März verlängert! +++</b>

--- a/content/blog/2017/2017-02-21-open-data-day.md
+++ b/content/blog/2017/2017-02-21-open-data-day.md
@@ -1,18 +1,17 @@
 ---
-authors: 
+authors:
 - Fiona Krakenbürger
-date: 2017-02-21 10:00:00
 image:
   src: /files/blog/2017/02/odd17.png
-  title: 
+  title: null
 tags:
 - Events
 - Open Data
 type: post
 layout: post
 card: true
-published: true
-title: "International Open Data Day am 04. März"
+title: International Open Data Day am 04. März
+publishedDate: 2017-02-21 10:00:00
 ---
 
 <h3>Am 04. März laden Aktivistinnen auf der ganzen Welt zum <a href="http://opendataday.org">International Open Data Day</a> ein.</h3><br>
@@ -30,4 +29,3 @@ Dieses Jahr legen die OK Labs ein vielfältiges Programm mit den unterschiedlich
 *	In <a href="http://codeforhamburg.org">Hamburg</a> gibt es als Auftakt bereits am Freitag eine ganztägige Veranstaltung, das <a href="http://offenestadt.info">"Forum Offene Stadt"</a> gemeinsam mit der Körber-Stiftung. Dazu haben wir schon letzte Woche einen <a href="http:/codefor.de/blog/forum-offene-stadt-hamburg">Blogpost</a> geschrieben.<br>
 
 Das ist selbstverständlich nur ein kleiner Auszug, schaut am Besten selber mal in die <a href="http://de.opendataday.org">lange lange Liste von Events</a> und besucht ein Lab in eurer Nähe! Wir wünschen allen Labs einen wunderbaren Open Data Day. Folgt dem Hashtag <a href="https://twitter.com/search?src=typd&q=ODD17">#ODD17</a> auf Twitter, um zu sehen, was in den Labs und auf der ganzen Welt am 04. März passiert.
-

--- a/content/blog/2017/2017-03-02-ranking.md
+++ b/content/blog/2017/2017-03-02-ranking.md
@@ -1,10 +1,9 @@
 ---
-authors: 
+authors:
 - Arne Semsrott
-date: 2017-03-02 14:00:00
 image:
   src: /files/blog/2017/02/ranking.jpg
-  title: 
+  title: null
 tags:
 - Transparenz
 - Informationsfreiheit
@@ -12,8 +11,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Erstes deutsches Transparenzranking: Bund schneidet schlecht ab"
+title: 'Erstes deutsches Transparenzranking: Bund schneidet schlecht ab'
+publishedDate: 2017-03-02 14:00:00
 ---
 
 Am 2. März 2017 hat die Open Knowledge Foundation Deutschland das erste Transparenz-Ranking herausgegeben, das in Zusammenarbeit mit der Mehr Demokratie entstanden ist. Das Ergebnis der Untersuchung: In vielen Bundesländern wird den Bürger/innen der Zugang zu Behördeninformationen schwer oder sogar ganz unmöglich gemacht.

--- a/content/blog/2017/2017-03-28-OGP-zivilgesellschaftlichen-Ideen.md
+++ b/content/blog/2017/2017-03-28-OGP-zivilgesellschaftlichen-Ideen.md
@@ -1,27 +1,25 @@
 ---
-authors: 
+authors:
 - Johanna zum Felde
 - Walter Palmetshofer
-date: 2017-03-28 01:00:00
 image:
   src: /files/blog/2017/03/Timeline2.png
-  title: 
-  license: "Source: BMI (Stand 28.03.2017)"
-  license_url: "http://www.verwaltung-innovativ.de/DE/Internationales/OGP/zeitlicher_ablauf/zeitlicher_ablauf_node.html"
+  title: null
+  license: 'Source: BMI (Stand 28.03.2017)'
+  license_url: http://www.verwaltung-innovativ.de/DE/Internationales/OGP/zeitlicher_ablauf/zeitlicher_ablauf_node.html
 tags:
 - OGP
-- Transparenz 
+- Transparenz
 - Offene Daten
 - Open Government
 - EITI
-type: post 
-layout: post 
+type: post
+layout: post
 card: true
-published: true
-title: "Open Government Partnership: Unsere Vorschläge für den Nationalen Aktionsplan" 
-
-
+title: 'Open Government Partnership: Unsere Vorschläge für den Nationalen Aktionsplan'
+publishedDate: 2017-03-28 01:00:00
 ---
+
 [Update 19.05.17](https://okfn.de/blog/2017/03/OGP-zivilgesellschaftlichen-Ideen/#Update-Dialogworkshop)
 
 Für den Nationalen Aktionsplan Open Government Partnership wurden in den letzten Wochen 270 konkrete Ideen gesammelt. Die [Ergebnisse dieser zivilgesellschaftlichen Ideensammlung](https://opengovpartnership.de/files/2017/03/170323_Zivilgesellschaftliche_Empfehlungen_NAP_OGP.pdf) wurden nun der Bundesregierung übergeben. Wir sind Teil des [Arbeitskreis Open Government Partnership](https://opengovpartnership.de/), haben den Prozess koordiniert und werden weiterhin folgende Teilbereiche vorantreiben:
@@ -279,4 +277,3 @@ Auflistung der Mitglieder: https://opengovpartnership.de/arbeitskreis
 Koordination: Johanna zum Felde
 
 E-Mail: info@ogphub.de
-

--- a/content/blog/2017/2017-03-28-datensummit2017.md
+++ b/content/blog/2017/2017-03-28-datensummit2017.md
@@ -1,19 +1,18 @@
 ---
-authors: 
+authors:
 - OKF
-date: 2017-03-28 12:45:00
 image:
   src: /files/blog/2017/03/Artboard.jpg
-  title: 
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - Datensummit
-type: post 
-layout: post 
+type: post
+layout: post
 card: true
-published: true
-title: "Datensummit 2017 - Das Programm ist da!" 
+title: Datensummit 2017 - Das Programm ist da!
+publishedDate: 2017-03-28 12:45:00
 ---
 
 Wir freuen uns schon sehr auf unseren [Datensummit am 28. & 29. April in Berlin](https://datensummit.de/)!

--- a/content/blog/2017/2017-04-05-esif-data-quality-index.md
+++ b/content/blog/2017/2017-04-05-esif-data-quality-index.md
@@ -2,12 +2,11 @@
 authors:
 - Anna Alberts
 - Michael Peters
-date: 2017-04-04 09:00:00
 image:
   src: /files/blog/2017/03/Subsidystory.png
   title: Subsidystories
   license: CC 0
-  license_url:
+  license_url: null
 tags:
 - EU
 - Open Data
@@ -16,9 +15,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-
-title: "Slovenia Ranks Highest in ESIF Data Quality Index by OpenBudgets.eu."
+title: Slovenia Ranks Highest in ESIF Data Quality Index by OpenBudgets.eu.
+publishedDate: 2017-04-04 09:00:00
 ---
 
 <p>
@@ -78,4 +76,3 @@ The current funding period shows more machine readable data formats and the data
 <p>
 Read the full <a href="http://openbudgets.eu/assets/resources/Report-OpenBudgets-ESIF Data-Quality-Index.pdf">Report</a>.
 </p>
-

--- a/content/blog/2017/2017-04-05-open data-aus-sicht.md
+++ b/content/blog/2017/2017-04-05-open data-aus-sicht.md
@@ -1,12 +1,11 @@
 ---
 authors:
 - Miles Heekeren
-date: 2017-04-05 01:00:00
 image:
   src: /files/blog/2017/04/open-data-blogbild.jpg
-  title: 
-  license: 
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - Praktikant
 - Open Data
@@ -14,12 +13,9 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-
-title: "Open Data aus Sicht eines 14-Jährigen"
+title: Open Data aus Sicht eines 14-Jährigen
+publishedDate: 2017-04-05 01:00:00
 ---
-
-
 
 <h1> Wer bin ich ? </h1>
 
@@ -165,4 +161,3 @@ Warum Pünktlichkeit wichtig ist.
 Die Seite <a href="https://w3schools.com">w3schools.com</a> hilft sehr gut, wenn man zum ersten Mal Html benutzt.
 Außerdem konnte ich mich an ein Raster von der Okf halten, dies half mir auch sehr gut.
 Ich habe meine Markdown Datei mit <a href="http://dillinger.io/">dillinger.io</a> geschrieben, die Website ist sehr gut, wenn man kein extra Programm zum schreiben des Html Codes runterladen möchte, außerdem ist Sie sehr überischtlich aufgebaut.
-

--- a/content/blog/2017/2017-04-12-deklaration-mf.md
+++ b/content/blog/2017/2017-04-12-deklaration-mf.md
@@ -1,7 +1,6 @@
 ---
 authors:
 - OKF
-date: 2017-04-12 07:00:00
 image:
   src: /files/blog/2017/04/lautsprecher.jpg
   title: Nahverkehr
@@ -13,9 +12,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-
-title: "Für Meinungsfreiheit - gegen das NetzDG"
+title: Für Meinungsfreiheit - gegen das NetzDG
+publishedDate: 2017-04-12 07:00:00
 ---
 
 Die Open Knowledge Foundation Deutschland unterstützt die "Deklaration für die Meinungsfreiheit". In Reaktion auf die Verabschiedung des Netzwerkdurchsetzungsgesetzes (NetzDG) durch das Bundeskabinett am 5. April 2017 zeigen wir gemeinsam mit einer breiten Allianz von Wirtschaftsverbänden, netzpolitischen Vereinen, Bürgerrechtsorganisationen und Rechtsexperten, dass der Gesetzentwurf nicht dem Anspruch genügt, die Meinungsfreiheit adäquat zu wahren. 

--- a/content/blog/2017/2017-04-12-digitalmat.md
+++ b/content/blog/2017/2017-04-12-digitalmat.md
@@ -1,24 +1,22 @@
 ---
 authors:
 - Arne Semsrott
-date: 2017-04-12 06:00:00
 image:
   src: /files/blog/2017/04/index.png
-  title: 
-  license: 
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - NRW
 - Digital-O-Mat
 type: post
 layout: post
 card: true
-published: true
-
-title: "Digitale Politik in 8 Klicks!"
+title: Digitale Politik in 8 Klicks!
+publishedDate: 2017-04-12 06:00:00
 ---
 
- Am 14. Mai wird in Nordrhein-Westfalen ein neuer Landtag gewählt. Was sind die jeweiligen Positionen der Parteien zu wichtigen digitalen Themen?
+Am 14. Mai wird in Nordrhein-Westfalen ein neuer Landtag gewählt. Was sind die jeweiligen Positionen der Parteien zu wichtigen digitalen Themen?
 
 Mit dem Digital-O-Maten, den wir gemeinsam mit Wikimedia und weiteren netzpolitisch engagierten Organisationen entwickelt haben, 
 können alle BesucherInnen erfahren, mit welcher Partei sie die größten Übereinstimmungen haben. Ein schneller Überblick in acht Klicks!

--- a/content/blog/2017/2017-04-17-Update-offene-Nahverkehrsdaten.md
+++ b/content/blog/2017/2017-04-17-Update-offene-Nahverkehrsdaten.md
@@ -2,12 +2,11 @@
 authors:
 - Walter Palmetshofer
 - Maximilian Richt
-date: 2017-04-17 12:00:00
 image:
   src: /files/blog/2017/04/rdn-vrs-avv.jpg
   title: VRS und AVV geben nun offene Fahrplandaten heraus
-  license: 
-  license_url:
+  license: null
+  license_url: null
 tags:
 - Open Data
 - Nahverkehr
@@ -15,11 +14,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-
-title: "Und es bewegt sich doch: Beim öffentlichen Nahverkehr"
-
-
+title: 'Und es bewegt sich doch: Beim öffentlichen Nahverkehr'
+publishedDate: 2017-04-17 12:00:00
 ---
 
 Seit dem Launch unserer Plattform [rettedeinennahverkehr.de](https://rettedeinennahverkehr.de/) gibt es einige erfreuliche Entwicklungen:
@@ -71,4 +67,4 @@ Und mal wieder steht eine große Frage im Raum:
 
 Falls es so ein Beispiel doch gibt - [Andrew Stott](https://twitter.com/DirDigEng) und wir (`opentransport@okfn.de`) freuen uns auf Hinweise.
 
-Und auch in den UK werden die Forderungen nach mehr Open Data im Verkehrsbereich lauter: ["The Case for Government Investment to Incentivise Data Sharing in the UK Intelligent Mobility Sector"](https://ts.catapult.org.uk/intelligent-mobility/im-resources/opendata/) (via @peterkwells)	
+Und auch in den UK werden die Forderungen nach mehr Open Data im Verkehrsbereich lauter: ["The Case for Government Investment to Incentivise Data Sharing in the UK Intelligent Mobility Sector"](https://ts.catapult.org.uk/intelligent-mobility/im-resources/opendata/) (via @peterkwells)

--- a/content/blog/2017/2017-05-07-republica.md
+++ b/content/blog/2017/2017-05-07-republica.md
@@ -1,19 +1,18 @@
 ---
 authors:
 - OKF
-date: 2017-05-07 05:00:00
 image:
   src: /files/blog/2017/05/republica17_RGB.jpg
-  title: 
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - republica
 type: post
 layout: post
 card: true
-published: true
-title: "Love out Loud: Smart und Rebel Cities, State of the Open und Geld für Open Source"
+title: 'Love out Loud: Smart und Rebel Cities, State of the Open und Geld für Open Source'
+publishedDate: 2017-05-07 05:00:00
 ---
 
 Die re:publica geht wieder los! Vom 8. bis 10. Mai treffen sich in Berlin wieder Tausende Menschen und diskutieren über alle möglichen Digitalthemen. Wir sind wie jedes Jahr zahlreich vertreten. Zu diesen Gelegenheiten könnt ihr Mitglieder aus unserem Team treffen: 

--- a/content/blog/2017/2017-05-11-daswardatensummit.md
+++ b/content/blog/2017/2017-05-11-daswardatensummit.md
@@ -1,12 +1,11 @@
 ---
 authors:
 - OKF
-date: 2017-05-11 15:00:00
 image:
   src: /files/blog/2017/03/Artboard.jpg
-  title: 
-  license: 
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - Datensummit
 - Open Data
@@ -17,9 +16,10 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Das war der Datensummit ‘17 – Das Community-Festival der OKF"
+title: Das war der Datensummit ‘17 – Das Community-Festival der OKF
+publishedDate: 2017-05-11 15:00:00
 ---
+
 Nach vier Monaten Vorbereitung auf Hochtouren und zwei Tagen geballtem Input zu Open Data, Civic Tech und Data Literacy haben wir ausgeschlafen und lassen Revue passieren: den Datensummit ‘17 – unser erstes zweitägiges Festival, das vom Bundesministerium für Verkehr und digitale Infrastruktur gefördert wurde. 
 
 Rund 280 Teilnehmerinnen durften wir am ersten Tag im Erich-Klausener-Saal des BMVIs begrüßen und müssen zugeben, dass wir mit unseren pinken Programmflyern, bunten Armbändern und zehn Kästen Club Mate eine nicht alltägliche Veranstaltung für ein Ministerium organisiert haben. Aber schließlich ging es genau darum:
@@ -44,4 +44,4 @@ Im Wahlsalon kamen Datenbegeisterte aus Community, Politik und Journalismus zusa
 
 Alle Vorträge des ersten Tages findet ihr in unserem [Youtube-Kanal](https://www.youtube.com/playlist?list=PL9h-RCl9wnxr6JUKz1wotehA-uUpHYwis) und die [Fotos beider Tage](https://www.flickr.com/photos/okfde/sets/72157680549129692) hat der beste Fotograf unseres Teams Leonard Wolf zusammengestellt. 
 
-Schließlich möchten wir noch einmal den Mitarbeiterinnen des Verkehrsministeriums, Event-Consult, all den Helfern und Teilnehmerinnen der beiden großartigen Tage danken. Wir sehen uns beim nächsten Datensummit! 
+Schließlich möchten wir noch einmal den Mitarbeiterinnen des Verkehrsministeriums, Event-Consult, all den Helfern und Teilnehmerinnen der beiden großartigen Tage danken. Wir sehen uns beim nächsten Datensummit!

--- a/content/blog/2017/2017-05-17-wikidata-für-openglam.md
+++ b/content/blog/2017/2017-05-17-wikidata-für-openglam.md
@@ -1,7 +1,6 @@
 ---
 authors:
 - Helene Hahn
-date: 2017-05-17 09:00:00
 image:
   src: /files/blog/2017/05/wikidata.png
   title: Wikidata
@@ -15,8 +14,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "A gentle introduction to Wikidata - für Kulturinstitutionen"
+title: A gentle introduction to Wikidata - für Kulturinstitutionen
+publishedDate: 2017-05-17 09:00:00
 ---
 
 Gemeinsam mit der Servicestelle Digitalisierung Berlin (digiS) und Wikimedia Deutschland bieten wir am 09. Juni einen Workshop zu Wikidata und den Potenzialen für Kulturinstitutionen an. Die Teilnahme ist kostenlos.
@@ -58,4 +57,3 @@ Agenda
 
 Ort: Zuse Institute Berlin (ZIB), Takustraße 7, 14195 Berlin
 Anmeldung: [helene.hahn@okfn.de](mailto:helene.hahn@okfn.de)
-

--- a/content/blog/2017/2017-05-18-erfolg-odgesetz.md
+++ b/content/blog/2017/2017-05-18-erfolg-odgesetz.md
@@ -1,20 +1,20 @@
 ---
-authors: 
+authors:
 - Arne Semsrott
-date: 2017-05-18 07:00:00
 image:
   src: /files/blog/2017/05/odgesetz.jpg
-  title: 
-  license:
-  license_url: 
+  title: null
+  license: null
+  license_url: null
 tags:
-- "Open-Data-Gesetz"
+- Open-Data-Gesetz
 type: post
 layout: post
 card: true
-published: true
-title: "Änderungen im Bundestag: Open-Data-Gesetz wird besser" 
+title: 'Änderungen im Bundestag: Open-Data-Gesetz wird besser'
+publishedDate: 2017-05-18 07:00:00
 ---
+
 Am Schluss geht es ganz schnell: In der Nacht zu Donnerstag wird der Bundestag voraussichtlich das neue [Open-Data-Gesetz](https://okfn.de/blog/tags/open-data-gesetz/) beschließen. Um 23:30 soll die "Änderung des E-Government-Gesetzes" als Teil eines Gesetzesmarathons verabschiedet werden.
 
 Das Gesetz wird [besser als zuletzt erwartet](http://dip21.bundestag.de/dip21/btd/18/124/1812406.pdf). Wie der Innenausschuss gestern in einer nicht-öffentlichen Sitzung ohne Anhörung von Sachverständigen beschlossen hat, fallen im Entwurf der Regierungsfraktionen einige restriktive Regelungen weg, die der Kabinettsentwurf noch vorgesehen hatte. Damit gehen CDU/CSU und SPD zumindest auf einige unserer Forderungen ein.

--- a/content/blog/2017/2017-06-09-der-Prototype-Fund-sucht-Unterstuetzung.md
+++ b/content/blog/2017/2017-06-09-der-Prototype-Fund-sucht-Unterstuetzung.md
@@ -1,7 +1,6 @@
 ---
 authors:
 - Fiona Krakenbürger
-date: 2017-06-09 10:00:00
 image:
   src: /files/blog/2016/08/PrototypeFundLogo.png
   title: Prototype Fund Logo
@@ -11,10 +10,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Der Prototype Fund sucht Unterstützung"
-
-
+title: Der Prototype Fund sucht Unterstützung
+publishedDate: 2017-06-09 10:00:00
 ---
 
 Wir – Fiona, Eileen, Elisa und Julia – arbeiten seit über einem Jahr am <a href="https://prototypefund.de">Prototype Fund</a>. Das Projekt ist ein Förderprogramm, das Softwareentwickler*innen, Hacker*innen und Kreative dabei unterstützt, ihre Ideen vom Konzept bis zur ersten Demo zu entwickeln und als Open-Source-Prototypen zu veröffentlichen. Unser Ziel ist es, bestehende Strukturen und Narrative im Bereich der Innovation und Innovationsförderung aufzubrechen und dass mehr digitale Innovationen für die Gesellschaft entstehen. Um das zu erreichen, probieren wir laufend Neues aus und entwickeln das Programm weiter. Jetzt suchen wir dabei Verstärkung.
@@ -78,4 +75,3 @@ Wenn du Interesse hast, dann schick uns deine Bewerbung bis einschließlich 18. 
 Die Bewerbungsgespräche werden voraussichtlich Ende Juni stattfinden.
 
 Wir freuen uns auf dich!
-

--- a/content/blog/2017/2017-06-22-Moderner-Staat.md
+++ b/content/blog/2017/2017-06-22-Moderner-Staat.md
@@ -1,12 +1,11 @@
 ---
-authors: 
+authors:
 - Walter Palmetshofer
-date: 2017-06-22 07:00:00
 image:
   src: /files/blog/2017/06/digitale-agenda-3.jpg
-  title: 
-  license:
-  license_url: 
+  title: null
+  license: null
+  license_url: null
 tags:
 - Open-Data-Gesetz
 - EITI
@@ -15,10 +14,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Digitale Agenda Stellungnahme & Fachgespräch: Moderner Staat - Chancen durch Digitalisierung" 
-
-
+title: 'Digitale Agenda Stellungnahme & Fachgespräch: Moderner Staat - Chancen durch Digitalisierung'
+publishedDate: 2017-06-22 07:00:00
 ---
 
 Der Ausschuss für [Digitale Agenda](https://www.bundestag.de/ada) des Bundestags befasste sich letzte Woche, am 21.06.2017, in einem öffentlichen Fachgespräch mit dem Thema ["Moderner Staat - Chancen durch Digitalisierung"](https://www.bundestag.de/presse/hib/2017_06/-/511466) und wir waren auch dabei. 

--- a/content/blog/2017/2017-06-23-Wahldaten-Wikidata-Hackathon.md
+++ b/content/blog/2017/2017-06-23-Wahldaten-Wikidata-Hackathon.md
@@ -1,22 +1,19 @@
 ---
-authors: 
+authors:
 - OKF
-date: 2017-06-22 07:00:00
 image:
   src: /files/blog/2017/06/ulm.jpg
-  title: 
-  license:
-  license_url: 
+  title: null
+  license: null
+  license_url: null
 tags:
 - Wahlen
 - Wikidata
 type: post
 layout: post
 card: true
-published: true
-title: "Ulm Wikidata Hackathon" 
-
-
+title: Ulm Wikidata Hackathon
+publishedDate: 2017-06-22 07:00:00
 ---
 
 Vom 23. bis 25. Juni fand im [Verschwörhaus in Ulm](https://verschwoerhaus.de/) der #wahldaten-Hackathon mit Wikidata statt. 

--- a/content/blog/2017/2017-06-27-2030Watch-Ausschreibung.md
+++ b/content/blog/2017/2017-06-27-2030Watch-Ausschreibung.md
@@ -1,12 +1,11 @@
 ---
-authors: 
+authors:
 - Rebecca Varghese Buchholz
-date: 2017-06-27 10:00:00
 image:
   src: /files/blog/2017/06/2030-Watch.jpg
-  title: 
-  license:
-  license_url: 
+  title: null
+  license: null
+  license_url: null
 tags:
 - 2030Watch
 - Ausschreibung
@@ -14,10 +13,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Teilzeit-Entwickler/in bei 2030Watch gesucht" 
-
-
+title: Teilzeit-Entwickler/in bei 2030Watch gesucht
+publishedDate: 2017-06-27 10:00:00
 ---
 
 <b>Entwickler/in (Schwerpunkt Web Development) bei 2030Watch gesucht!</b>
@@ -37,4 +34,4 @@ Die Open Knowledge Foundation Deutschland (OKF-DE) ist ein Verein in Berlin, der
 
 Wenn Du Interesse hast, dann schick uns Deine Bewerbung (CV, GitHub oder ähnliches Profil und Anschreiben) bis zum 15. Juli an <a href="mailto:2030-watch@okfn.de">2030-watch@okfn.de</a>. 
 
-Bei Fragen, melde Dich gerne bei <a href="mailto:rebecca.buchholz@okfn.de">Rebecca Varghese Buchholz</a> 
+Bei Fragen, melde Dich gerne bei <a href="mailto:rebecca.buchholz@okfn.de">Rebecca Varghese Buchholz</a>

--- a/content/blog/2017/2017-06-28-Persoenliche-Daten.md
+++ b/content/blog/2017/2017-06-28-Persoenliche-Daten.md
@@ -1,22 +1,19 @@
 ---
-authors: 
+authors:
 - Walter Palmetshofer
-date: 2017-06-29 23:59:00
 image:
   src: /files/blog/2017/06/mydata.png
-  title: 
-  license:
-  license_url: 
+  title: null
+  license: null
+  license_url: null
 tags:
 - Persönliche Daten
 - mydata
 type: post
 layout: post
 card: true
-published: true
-title: "Digitale Souveränität" 
-
-
+title: Digitale Souveränität
+publishedDate: 2017-06-29 23:59:00
 ---
 
 Am 29. Juni wurde in Berlin das Gutachten ["Digitale Souveränität: Gutachten des Sachverständigenrats für Verbraucherfragen"](http://www.svr-verbraucherfragen.de/wp-content/uploads/Gutachten_Digitale_Souver%C3%A4nit%C3%A4t_.pdf) präsentiert. Zusammen mit Anna Alberts und Arne Semsrott habe ich dafür eine Studie zum [Wert persönlicher Daten](http://www.svr-verbraucherfragen.de/wp-content/uploads/Open_Knowledge_Foundation_Studie.pdf) erstellt. Sie ist zusätzlich zum Beiratsgutachten und einer weitere Studie von Volker Grassmuck, Rüdiger Weis und Stefan Lucks veröffentlicht worden: ["Technologien für und wider Digitale Souveränität"](http://www.svr-verbraucherfragen.de/wp-content/uploads/Weis_Lucks_Grassmuck_Studie_.pdf). 

--- a/content/blog/2017/2017-07-05-stellenausschreibung-assistenz-der-geschäftsführung.md
+++ b/content/blog/2017/2017-07-05-stellenausschreibung-assistenz-der-geschäftsführung.md
@@ -1,19 +1,18 @@
 ---
 authors:
 - OKF
-date: 2017-07-05
 image:
   src: /files/blog/2017/02/okf-team.png
-  title: 
+  title: null
   license: CC BY 2.0
-  license_url: 
+  license_url: null
 tags:
 - Jobs
 type: post
 layout: post
 card: true
-title: "Assistenz der Geschäftsführung (60% Arbeitszeit)"
-published: true
+title: Assistenz der Geschäftsführung (60% Arbeitszeit)
+publishedDate: 2017-07-05
 ---
 
 ### Wer wir sind

--- a/content/blog/2017/2017-07-13-Open-Data-Gesetz-tritt-in-Kraft.md
+++ b/content/blog/2017/2017-07-13-Open-Data-Gesetz-tritt-in-Kraft.md
@@ -1,12 +1,11 @@
 ---
-authors: 
+authors:
 - Walter Palmetshofer
-date: 2017-07-13 00:10:00
 image:
   src: /files/blog/2017/07/egov-gesetz.png
-  title: 
-  license:
-  license_url: 
+  title: null
+  license: null
+  license_url: null
 tags:
 - Open-Data-Gesetz
 - Policy
@@ -14,10 +13,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Öffentliche Ankündigung: Das Open-Data-Gesetz ist in Kraft" 
-
-
+title: 'Öffentliche Ankündigung: Das Open-Data-Gesetz ist in Kraft'
+publishedDate: 2017-07-13 00:10:00
 ---
 
 <br>

--- a/content/blog/2017/2017-07-14-offenheit.md
+++ b/content/blog/2017/2017-07-14-offenheit.md
@@ -1,14 +1,13 @@
 ---
-authors: 
+authors:
 - Christian Heise
 - Andreas Pawelke
 - Arne Semsrott
-date: 2017-07-13 00:10:00
 image:
   src: /files/blog/2017/07/zivilgesellschaft.jpg
-  title: 
-  license:
-  license_url: 
+  title: null
+  license: null
+  license_url: null
 tags:
 - Open-Data-Gesetz
 - Policy
@@ -18,8 +17,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Wir müssen in die Zivilgesellschaft investieren" 
+title: Wir müssen in die Zivilgesellschaft investieren
+publishedDate: 2017-07-13 00:10:00
 ---
 
 Hoffnung allein reicht nicht. Angesichts von Donald, Brexit und Orbán, angesichts der großen Stimmengewinne von rechtsextremen Parteien bei Wahlen in Frankreich, Österreich und den Niederlande sind die demokratischen Kräfte in Europa gefordert, die Demokratie attraktiver zu machen.

--- a/content/blog/2017/2017-07-21-projektleitung-jugend-hackt.md
+++ b/content/blog/2017/2017-07-21-projektleitung-jugend-hackt.md
@@ -1,21 +1,20 @@
 ---
 authors:
 - OKF
-date: 2017-07-21
 image:
   src: /files/blog/2017/07/StellenausschreibungJH.jpg
-  title:
-  license: 
-  license_url: 
+  title: null
+  license: null
+  license_url: null
 tags:
 - Jobs
 type: post
 layout: post
 card: true
-title: "Projektleitung Jugend hackt bei der OKF DE (30-40h, ab sofort)"
-published: true
+title: Projektleitung Jugend hackt bei der OKF DE (30-40h, ab sofort)
+publishedDate: 2017-07-21
 ---
-    
+
 ### Wer wir sind
 Jugend hackt ist ein preisgekröntes Förderprogramm für junge Menschen zwischen 12 und 18 Jahren, die mit Code die Welt verbessern wollen. Jugend hackt ist ein gemeinsames Programm der Open Knowledge Foundation Deutschland e.V. (OKF DE) und von mediale pfade.org - Verein für Medienbildung e.V. 
 

--- a/content/blog/2017/2017-07-31-wechsel-gf.md
+++ b/content/blog/2017/2017-07-31-wechsel-gf.md
@@ -1,22 +1,21 @@
 ---
-authors: 
+authors:
 - OKF
-date: 2017-07-30 20:10:00
 image:
   src: /files/blog/2017/07/OKFDE_Logo_black.png
-  title: 
-  license:
-  license_url: 
+  title: null
+  license: null
+  license_url: null
 tags:
 - Geschäftsführung
 - In eigener Sache
 type: post
 layout: post
 card: true
-published: true
-title: "In eigener Sache: Wechsel der Geschäftsführung bei der Open Knowledge Foundation Deutschland" 
+title: 'In eigener Sache: Wechsel der Geschäftsführung bei der Open Knowledge Foundation Deutschland'
+publishedDate: 2017-07-30 20:10:00
 ---
-    
+
 Schweren Herzens müssen wir in diesen Tagen unsere langjährige Geschäftsführerin Kristina Klein in die USA ziehen lassen. Seit 2014 hat Kristina den großen Wachstums- und Professionalisierungsprozess bei der Open Knowledge Foundation Deutschland koordiniert und alle Fäden der Organisation mit Herz, Hirn und Humor zusammengehalten. Wir sind sehr traurig, dass Kristina uns verlässt. Wir sind uns aber auch sicher, dass wir mit ihr in der Zukunft weiter intensiv zusammen arbeiten werden.
     
 Gleichzeitig freuen wir uns sehr, dass wir mit Nadine Evers eine großartige neue Geschäftsführerin finden konnten, die uns ab sofort zur Seite stehen wird. Nadine war zuvor unter anderem Geschäftsführerin des Stiftungskolleges der Robert Bosch Stiftung sowie Referentin und Projektleiterin beim Auswärtigen Amt und beim Deutschen Roten Kreuz. Mit der Wahl von Nadine wollen wir auch ein klares Zeichen für die konsequenten Weiterentwicklung und Professionalisierung der Open Knowledge Foundation Deutschland setzen. Wir freuen uns sehr mit ihr eine leidenschaftliche und sehr erfahrene neue Geschäftsführerin in unseren Reihen begrüßen zu dürfen. Sie ist zu erreichen unter nadine.evers@okfn.de.

--- a/content/blog/2017/2017-08-01-interview-datenschule-bildungscent.md
+++ b/content/blog/2017/2017-08-01-interview-datenschule-bildungscent.md
@@ -1,12 +1,11 @@
 ---
-authors: 
+authors:
 - Jasmin Helm
-date: 2017-08-01 08:00:00
 image:
   src: /files/blog/2017/08/ds-und-bc.jpg
   title: Team Datenschule mit BildungsCent
-  license: "CC-BY 3.0, Team der Datenschule mit BildungsCent e.V., Foto: Leonard Wolf" 
-  license_url: "https://creativecommons.org/licenses/by/3.0/"
+  license: 'CC-BY 3.0, Team der Datenschule mit BildungsCent e.V., Foto: Leonard Wolf'
+  license_url: https://creativecommons.org/licenses/by/3.0/
 tags:
 - schuldaten
 - ngos
@@ -15,8 +14,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Interview der Datenschule mit BildungsCent: Über Schuldaten, Digitalisierung & die gemeisame Datenarbeit"
+title: 'Interview der Datenschule mit BildungsCent: Über Schuldaten, Digitalisierung & die gemeisame Datenarbeit'
+publishedDate: 2017-08-01 08:00:00
 ---
 
 In den vergangenen Monaten haben wir bei der [Datenschule](https://datenschule.de) gemeinsam mit unserem Partner [BildungsCent e.V.](http://www.bildungscent.de/) intensiv an Schuldaten gearbeitet. Mit Silke Ramelow, Vorstandsvorsitzende von BildungsCent, ließen wir die Zeit Revue passieren und sprachen in einem Interview über die Chancen der Digitalisierung für gemeinnützige Organisationen, die Zusammenarbeit an den Daten und unser gemeinsames Projekt [JedeSchule.de](https://jedeschule.de).  

--- a/content/blog/2017/2017-08-16-Erster-OGP-Aktionsplan-verabschiedet.md
+++ b/content/blog/2017/2017-08-16-Erster-OGP-Aktionsplan-verabschiedet.md
@@ -1,12 +1,11 @@
 ---
-authors: 
+authors:
 - Walter Palmetshofer
-date: 2017-08-16 13:10:00
 image:
   src: /files/blog/2017/03/Timeline2.png
-  title: 
-  license:
-  license_url: 
+  title: null
+  license: null
+  license_url: null
 tags:
 - Open-Data
 - EITI
@@ -14,10 +13,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Erster OGP Aktionsplan verabschiedet" 
-
-
+title: Erster OGP Aktionsplan verabschiedet
+publishedDate: 2017-08-16 13:10:00
 ---
 
 Die Bundesregierung hat den ersten Aktionsplan Open Government Partnership [beschlossen](http://www.bmi.bund.de/SharedDocs/Pressemitteilungen/DE/2017/08/ogp-aktionsplan.html).

--- a/content/blog/2017/2017-08-29-digitalomat.md
+++ b/content/blog/2017/2017-08-29-digitalomat.md
@@ -1,16 +1,15 @@
 ---
 authors:
 - Arne Semsrott
-date: 2017-08-29 10:00:00
 image:
   src: /files/blog/2017/08/digitalomat.jpg
 type: post
 layout: post
 card: true
-published: true
 tags:
 - Digital-O-Mat
-title: "Digital-O-Mat geht online: Entscheidungshilfe zur Bundestagswahl"
+title: 'Digital-O-Mat geht online: Entscheidungshilfe zur Bundestagswahl'
+publishedDate: 2017-08-29 10:00:00
 ---
 
 Ab sofort können alle Wahlberechtigten ein neues Online-Tool als Entscheidungshilfe für die Bundestagswahl nutzen: Mit 12 Klicks verrät der [Digital-O-Mat](https://bund.digital-o-mat.de/) Wählerinnen und Wählern, mit welcher Partei sie bei netzpolitischen Themen auf einer Wellenlänge liegen.

--- a/content/blog/2017/2017-09-06-Erster-EITI-Bericht-veroeffentlicht.md
+++ b/content/blog/2017/2017-09-06-Erster-EITI-Bericht-veroeffentlicht.md
@@ -1,22 +1,19 @@
 ---
-authors: 
+authors:
 - Walter Palmetshofer
-date: 2017-09-06 01:00:00
 image:
   src: /files/blog/2017/09/EITI-abstimmung-09082017.jpg
-  title: 
-  license:
-  license_url: 
+  title: null
+  license: null
+  license_url: null
 tags:
 - Open-Data
 - EITI
 type: post
 layout: post
 card: true
-published: true
-title: "Erster deutscher EITI-Bericht veröffentlicht" 
-
-
+title: Erster deutscher EITI-Bericht veröffentlicht
+publishedDate: 2017-09-06 01:00:00
 ---
 
 Am 9. August wurde in der 10. Sitzung der MSG (Multi-Stakerholder-Group) der 1. EITI Bericht einstimmig beschlossen. Wir bedanken uns herzlichst bei den KollegInnen der MSG und den MitarbeiterInnnen des EITI-Sekretariat für eine erfolgreiche jahrelange Zusammenarbeit. Am 23. August wurde nach Oslo verschickt, heute um 16:00 wird er in Berlin präsentiert. Hier ist der [1. Bericht](www.d-eiti.de/wp-content/uploads/2017/08/1_D-EITI_Bericht_-fuer_-2016.pdf).

--- a/content/blog/2017/2017-09-13-public-code.md
+++ b/content/blog/2017/2017-09-13-public-code.md
@@ -1,16 +1,15 @@
 ---
 authors:
 - Arne Semsrott
-date: 2017-09-13 09:00:00
 image:
   src: /files/blog/2017/09/pmpc.jpg
 type: post
 layout: post
 card: true
-published: true
 tags:
 - Open Software
-title: "Public Money? Public Code! Öffentlich finanzierte Software muss Open Source werden"
+title: Public Money? Public Code! Öffentlich finanzierte Software muss Open Source werden
+publishedDate: 2017-09-13 09:00:00
 ---
 
 Die digitalen Dienste der öffentlichen Verwaltungen sind die zentrale Infrastruktur demokratischer Staaten im 21. Jahrhundert. Um Vertrauen in die Systeme zu stärken, müssen Behörden die volle Kontrolle über sie haben. Aufgrund restriktiver Softwarelizenzen ist dies jedoch selten der Fall.

--- a/content/blog/2017/2017-09-30-ODINE-Open-Data-Incubator-for-Europe.md
+++ b/content/blog/2017/2017-09-30-ODINE-Open-Data-Incubator-for-Europe.md
@@ -1,18 +1,15 @@
 ---
-authors: 
+authors:
 - Walter Palmetshofer
-date: 2017-09-30
 image:
   src: /files/blog/2017/09/ODINE_Logo_RGB.png
 tags:
 - Open Data
 type: post
 layout: post
-published: true
 card: true
-title: "ODINE - Open Data Incubator for Europe erfolgreich abgeschlossen!" 
-
-
+title: ODINE - Open Data Incubator for Europe erfolgreich abgeschlossen!
+publishedDate: 2017-09-30
 ---
 
 [ODINE](https://opendataincubator.eu/), das mit Abstand beste und startup- & SME-freundlichste Programm von H2020, ging erfolgreich zu Ende. Insgesamt gab es 5.4 Millionen Euro für 57 Open Data Projekte und Firmen in 18 Ländern.

--- a/content/blog/2017/2017-09-31-Energy-Hack-2017.md
+++ b/content/blog/2017/2017-09-31-Energy-Hack-2017.md
@@ -1,8 +1,7 @@
 ---
-authors: 
+authors:
 - Martin Koll
 - Walter Palmetshofer
-date: 2017-10-04 06:00:00
 image:
   src: /files/blog/2017/09/energyhack-dark.jpg
 tags:
@@ -10,11 +9,9 @@ tags:
 - Energyhack
 type: post
 layout: post
-published: true
 card: true
-title: "Rückblick Energyhack 2017: Du hast die Wahl!" 
-
-
+title: 'Rückblick Energyhack 2017: Du hast die Wahl!'
+publishedDate: 2017-10-04 06:00:00
 ---
 
 Am 22. und 23. September fand der dritte Energyhack von [Stromnetz Berlin](https://www.stromnetz-berlin.de/) und der Open Knowledge Foundation statt. Passend zum Wahlwochende lautete das Motto "Du hast die Wahl". Wir haben uns sehr über euer großes Interesse gefreut und wollen an dieser Stelle allen die nicht dabei sein konnten einen Überblick geben was alles an dem Wochenende passierte und welche Projekte entstanden sind.

--- a/content/blog/2017/2017-10-16-openpolitischer-abend.md
+++ b/content/blog/2017/2017-10-16-openpolitischer-abend.md
@@ -1,7 +1,6 @@
 ---
-authors: 
+authors:
 - OKF
-date: 2017-10-27 08:00:00
 image:
   src: /files/blog/2017/10/openpolitischerAbend_01.gif
 tags:
@@ -9,8 +8,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Der erste openpolitische Abend: NSU, Verfassungsschutz und Transparenz" 
+title: 'Der erste openpolitische Abend: NSU, Verfassungsschutz und Transparenz'
+publishedDate: 2017-10-27 08:00:00
 ---
 
 Wir freuen uns sehr, euch alle zu unserem ersten openpolitischen Abend einzuladen! 

--- a/content/blog/2017/2017-10-31-Durchblick-beim-Rohstoffabbau.md
+++ b/content/blog/2017/2017-10-31-Durchblick-beim-Rohstoffabbau.md
@@ -1,22 +1,19 @@
 ---
-authors: 
+authors:
 - Walter Palmetshofer
-date: 2017-10-31 01:00:00
 image:
   src: /files/blog/2017/10/EITI-20171019_ausblick-edda-mueller.jpg
-  title: 
-  license:
-  license_url: 
+  title: null
+  license: null
+  license_url: null
 tags:
 - Open-Data
 - EITI
 type: post
 layout: post
 card: true
-published: true
-title: "Durchblick beim Rohstoffabbau" 
-
-
+title: Durchblick beim Rohstoffabbau
+publishedDate: 2017-10-31 01:00:00
 ---
 
 Im Rahmen der Alternativen Rohstoffwoche luden am 19.10.2017 das Forum Ökologisch Soziale Marktwirtschaft, das Forum Umwelt und Entwicklung, die Open Knowledge Foundation Deutschland und Transparency International Deutschland e.V. zur Diskussion bzgl. der Veröffentlichung des [ersten EITI-Transparenzbericht](www.d-eiti.de/wp-content/uploads/2017/08/1_D-EITI_Bericht_-fuer_-2016.pdf). Der Bericht informiert über den deutschen Rohstoffsektor und die mit der Rohstoffförderung verbundenen Finanzströme zwischen Unternehmen und Staat. Sorgt der erste D-EITI-Bericht für mehr Durchblick im deutschen Rohstoffsektor? Wo steht der erste D-EITI-Bericht im internationalen Vergleich? 
@@ -43,8 +40,4 @@ Ausblick Prof. Dr. Edda Müller
 
 
 Von der Podiumsdiskussion mit Anne Miehe (Referentin Ressourceneffizienz/Rohstoffpolitik international beim Bundesministerium für Umwelt, Naturschutz, Bau und Reaktorsicherheit), Christoph Heinrich (Warth&Klein Grant Thornton AG,  Unabhängiger Verwalter D-EITI), Matthias Wachter (Abteilungsleiter Sicherheit und Rohstoffe BDI e.V., MSG-Mitglied D-EITI) unter der Moderation von Cathrin Klenck (Referentin Forum Umwelt und Entwicklung, stellv. MSG-
-Mitglied D-EITI) gibt es leider keine Aufnahme. 
-
-
-
-
+Mitglied D-EITI) gibt es leider keine Aufnahme.

--- a/content/blog/2017/2017-11-03-Open-Government Partnership.md
+++ b/content/blog/2017/2017-11-03-Open-Government Partnership.md
@@ -1,7 +1,6 @@
 ---
 authors:
 - Michael Peters
-date: 2017-11-02 08:00:00
 image:
   src: /files/blog/2017/10/ogp-civil-society.jpg
 tags:
@@ -9,10 +8,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Was macht eigentlich die Open Government Partnership"
-
-
+title: Was macht eigentlich die Open Government Partnership
+publishedDate: 2017-11-02 08:00:00
 ---
 
 Die Open Government Partnership ist ein internationales Netzwerk, welches sich für offenes Regierungs- und Verwaltungshandeln [einsetzt](https://www.opengovpartnership.org/open-government-declaration). Ins Leben gerufen wurde es 2011 durch den damaligen US-Präsident [Obama](https://obamawhitehouse.archives.gov/the-press-office/2011/09/20/fact-sheet-open-government-partnership) und Ziel des Netzwerks ist es, die Arbeit des öffentlichen Sektors (Politik, Regierung, Verwaltung und Justiz) offener, transparenter, partizipativer und kooperativer zu gestalten. Dazu hat die OGP einen partizipativen Ansatz etabliert, bei dem nationale Regierungen mit der Zivilgesellschaft gemeinsam Ideen für ein offeneres Regierungshandeln entwickeln. Sie unterstützen dabei sowohl die Regierungen der 75 Mitgliedstaaten, als auch die Zivilgesellschaft, durch unabhängige Forschung, Beratung und best-practice Beispiele.

--- a/content/blog/2017/2017-12-29-Steuern.md
+++ b/content/blog/2017/2017-12-29-Steuern.md
@@ -1,8 +1,7 @@
 ---
-authors: 
+authors:
 - Max Kasy
 - Walter Palmetshofer
-date: 2017-12-29 11:00:00
 image:
   src: /files/blog/2017/12/tax-zucman.jpg
 tags:
@@ -12,11 +11,9 @@ tags:
 - Transparenzregister
 type: post
 layout: post
-published: true
 card: true
-title: "Steuern" 
-
-
+title: Steuern
+publishedDate: 2017-12-29 11:00:00
 ---
 
 Ende 2017 waren die Paradise Papers in aller Munde. Nach #Luxleaks und #Panamapapers war es die nächste mediale Runde für die Steueroptimierungsfälle. Dazu gab es am 29.12.17 einen ["Taxation" Talk am 34c3 - Video](http://media.ccc.de/v/34c3-9047-taxation) und [Slides](https://docs.google.com/presentation/d/16ZzpmHCTJfpfGmDQ1I-4gdja5LNSD8jXQp-DMTWvzwA/edit#slide=id.g267d994495_0_0).

--- a/content/blog/2018/2018-01-19-PSI-Hearing.md
+++ b/content/blog/2018/2018-01-19-PSI-Hearing.md
@@ -1,7 +1,6 @@
 ---
-authors: 
+authors:
 - Walter Palmetshofer
-date: 2018-01-19 02:30:00
 image:
   src: /files/blog/2018/01/eu-flag.jpg
 tags:
@@ -9,11 +8,9 @@ tags:
 - Open data
 type: post
 layout: post
-published: true
 card: true
-title: "Live aus Brüssel: Anhörung zur neuen PSI-Richtlinie" 
-
-
+title: 'Live aus Brüssel: Anhörung zur neuen PSI-Richtlinie'
+publishedDate: 2018-01-19 02:30:00
 ---
 
 Am 19.01.18 fand das Hearing zur neuen PSI-Richtlinie in Brüssel statt. PSI steht für "Public Sector Information". Dabei geht es beispielsweise um die Weiterverwendung offener Daten. Walter Palmetshofer hat an dem Hearing teilnehmen.
@@ -50,4 +47,3 @@ Upcoming eine Zusammenfassung der Statements.
 
 At current implementation speed:
 ![Make your bets.](/files/blog/2018/01/marsvseu.jpg "Close call")
-

--- a/content/blog/2018/2018-01-25-assistenz-der-buchhaltung.md
+++ b/content/blog/2018/2018-01-25-assistenz-der-buchhaltung.md
@@ -1,18 +1,17 @@
 ---
 author: OKF
-date: 2018-01-26 
 image:
   src: /files/blog/2017/01/flickr-state-library-of-queensland.jpg
   title: Flickr_State Library of Queensland
-  license: "CC0, Quelle: [Flickr](https://www.flickr.com/photos/statelibraryqueensland/3219069891/in/photolist-5Uszk2-9uR1dn-8njtj3-ajsBLH-bFoYtX-fmHa3L-fcvwEM-6Rs7a9-8amQJJ-dWXUzG-cqAKgJ-hKCuvT-qoHkXL-9D3vSu-8rWEFV-cL1xu1-6Ro4c6-6Ro3HX-8nYiep-6o6cpV-6pAPsT-6bJirV-9nw5zW-ecrAZB-c4cVC7-hHPTBe-dcE2YL-9WeSMp-cKXUgN-64ESGS-fepHQ1-qrf3jr-bUr4os-ec3yXd-bsu6Co-9M5sip-8o2y1s-8njtAL-8njs8S-dWXV4w-5J7Q2k-qh8Dht-8ngjUD-8vNAMa-4i7B9z-6pEXQf-5SGTuA-9s7jAX-8njsXS-ek1kNh)"
+  license: 'CC0, Quelle: [Flickr](https://www.flickr.com/photos/statelibraryqueensland/3219069891/in/photolist-5Uszk2-9uR1dn-8njtj3-ajsBLH-bFoYtX-fmHa3L-fcvwEM-6Rs7a9-8amQJJ-dWXUzG-cqAKgJ-hKCuvT-qoHkXL-9D3vSu-8rWEFV-cL1xu1-6Ro4c6-6Ro3HX-8nYiep-6o6cpV-6pAPsT-6bJirV-9nw5zW-ecrAZB-c4cVC7-hHPTBe-dcE2YL-9WeSMp-cKXUgN-64ESGS-fepHQ1-qrf3jr-bUr4os-ec3yXd-bsu6Co-9M5sip-8o2y1s-8njtAL-8njs8S-dWXV4w-5J7Q2k-qh8Dht-8ngjUD-8vNAMa-4i7B9z-6pEXQf-5SGTuA-9s7jAX-8njsXS-ek1kNh)'
 type: post
 layout: post
 card: true
 tags:
- - OKF
- - Jobs
-title: "Wir suchen eine Assistenz der Buchhaltung (Minijob oder studentische Hilfskraft, 10h, ab sofort)"
-published: true 
+- OKF
+- Jobs
+title: Wir suchen eine Assistenz der Buchhaltung (Minijob oder studentische Hilfskraft, 10h, ab sofort)
+publishedDate: 2018-01-26
 ---
 
 Die Open Knowledge Foundation Deutschland (OKF) ist ein gemeinnütziger Verein mit Sitz in

--- a/content/blog/2018/2018-01-29-big-data-with-local-impact.md
+++ b/content/blog/2018/2018-01-29-big-data-with-local-impact.md
@@ -1,21 +1,19 @@
 ---
-authors: 
+authors:
 - Mara Mendes
-date: 2018-01-29 07:00:00
 image:
   src: /files/blog/2018/01/Opentender_logos_CMYK.jpg
 tags:
 - event
 - Open data
 - digiwhist
-- public procurement 
+- public procurement
 type: post
 layout: post
-published: true
 card: true
-title: "Live Launch in Brüssel: Opentender.eu geht online " 
+title: 'Live Launch in Brüssel: Opentender.eu geht online '
+publishedDate: 2018-01-29 07:00:00
 ---
-
 
 Heute geht das Vergabeportal [opentender.eu](https://opentender.eu), mit Datensätzen aus 32 Ländern und der Europäischen Kommission, online. Opentender.eu bietet die Möglichkeit Vergabedaten strukturiert einzusehen und zu visualisieren. Risikoindikatoren informieren zusätzlich über die Effizienz und Transparenz von Ausschreibungen. 
 

--- a/content/blog/2018/2018-01-30-stellenausschreibung-administration.md
+++ b/content/blog/2018/2018-01-30-stellenausschreibung-administration.md
@@ -1,20 +1,19 @@
 ---
-authors: 
+authors:
 - OKF
-date: 2018-01-30 08:00:00
 image:
   src: /files/blog/2015/12/okfdebuero.jpg
-  title: 
-  license:
-  license_url: 
+  title: null
+  license: null
+  license_url: null
 tags:
 - Ausschreibung
 - Jobs
 type: post
 layout: post
 card: true
-published: true
-title: "Administrator*in bei der Open Knowledge Foundation Deutschland (50% E13/3, ab sofort)"
+title: Administrator*in bei der Open Knowledge Foundation Deutschland (50% E13/3, ab sofort)
+publishedDate: 2018-01-30 08:00:00
 ---
 
 Die Open Knowledge Foundation Deutschland ist ein gemeinnütziger Verein mit Sitz in Berlin, der sich seit 2011 für offenes Wissen, offene Daten, Transparenz und Beteiligung einsetzt. Unsere Arbeit ist unabhängig, überparteilich, gemeinnützig und interdisziplinär. Der Verein ist eine Dachorganisation für rund 20 Projekte mit hoher konzeptioneller und finanzieller Eigenverantwortung. 
@@ -57,6 +56,4 @@ Wir freuen uns insbesondere über die Bewerbungen von Frauen, Menschen mit Migra
  
 Bitte schicke uns Deine Bewerbung (Motivation, Erfahrungsnachweise, Lebenslauf) inkl. möglichem Beginn bis zum **21.02.2018** per E-Mail an <a href="mailto:jobs@okfn.de">jobs@okfn.de</a>. 
 
-Die Gespräche finden vom 27.02.-01.03.2018 in Berlin statt. Die innerdeutschen Reisekosten für die Bewerbungsgespräche übernehmen wir, sofern sie nicht von der Arbeitsagentur getragen werden. 
-
-
+Die Gespräche finden vom 27.02.-01.03.2018 in Berlin statt. Die innerdeutschen Reisekosten für die Bewerbungsgespräche übernehmen wir, sofern sie nicht von der Arbeitsagentur getragen werden.

--- a/content/blog/2018/2018-01-31-multimodale-Reiseinformationsdienste.md
+++ b/content/blog/2018/2018-01-31-multimodale-Reiseinformationsdienste.md
@@ -1,7 +1,6 @@
 ---
-authors: 
+authors:
 - Walter Palmetshofer
-date: 2018-01-31
 image:
   src: /files/blog/2018/01/scaling-okfde-nahverkehr.png
   title: Verkehrsdings
@@ -13,12 +12,9 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Zentrale Bereitstellung EU-weiter multimodaler Reiseinformationsdienste" 
-
-
+title: Zentrale Bereitstellung EU-weiter multimodaler Reiseinformationsdienste
+publishedDate: 2018-01-31
 ---
-
 
 Am 31.01.18 fand im BMVI ein Dialogforum zur zentralen Bereitstellung EU-weiter multimodaler Reiseinformationsdienste statt.
 Hintergrund dafür ist die [delegierte Verordnung (EU) Nr. 2017/1926](http://eur-lex.europa.eu/legal-content/DE/TXT/?uri=CELEX:32017R1926)

--- a/content/blog/2018/2018-02-05-Stellenausschreibung-2030-DS.md
+++ b/content/blog/2018/2018-02-05-Stellenausschreibung-2030-DS.md
@@ -1,22 +1,19 @@
 ---
-authors: 
+authors:
 - OKF
-date: 2018-02-05
 image:
   src: /files/blog/2015/12/okfdebuero.jpg
   title: OKF Büro
-  license: 
-  license_url: 
+  license: null
+  license_url: null
 tags:
 - Ausschreibung
 - Jobs
 type: post
 layout: post
 card: true
-published: true
-title: "Entwickler*in bei der Open Knowledge Foundation Deutschland (50% E13/3, ab sofort) für 2030 Watch und Demokratielabore"
-
-
+title: Entwickler*in bei der Open Knowledge Foundation Deutschland (50% E13/3, ab sofort) für 2030 Watch und Demokratielabore
+publishedDate: 2018-02-05
 ---
 
 <p style="background-color: #fffaed; padding: 50px;">

--- a/content/blog/2018/2018-02-07-Kommentare-zum-Koalitionsvertrag.md
+++ b/content/blog/2018/2018-02-07-Kommentare-zum-Koalitionsvertrag.md
@@ -1,13 +1,12 @@
 ---
-authors: 
+authors:
 - Walter Palmetshofer
-date: 2018-02-08
 image:
   src: /files/blog/2017/06/digitale-agenda-3.jpg
   title: Koalitionsvertrag
 tags:
 - Zivilgesellschaft
-- Transparenz 
+- Transparenz
 - Open Data
 - Open Source
 - Policy
@@ -15,10 +14,9 @@ tags:
 type: post
 layout: post
 card: true
-published: false
-title: "Kurze Kommentierung  Koalitonsvertrag 07.02 tl;dr Version" 
-
-
+title: Kurze Kommentierung  Koalitonsvertrag 07.02 tl;dr Version
+draft: 'true'
+publishedDate: 2018-02-08
 ---
 
 # OKFDE-relevante Punkte des [Koalitionsvertrages](https://www.cdu.de/system/tdf/media/dokumente/koalitionsvertrag_2018.pdf?file=1).
@@ -208,6 +206,3 @@ Als Optimisten hoffen wir natürlich, dass nach den teils "offenen" Absichtserkl
 <br>
 ps: Einer der Autoren ist Österreicher, sieht Deutschland punkto Rechtspopulismus noch als Fels in der Brandung und hofft der Schuss aus Österreich wurde gehört und die notwendigen Schritte (Transparenzgesetz, Lobbyregister, ...) werden gesetzt.
 <br>
-
-
-

--- a/content/blog/2018/2018-02-14-openschufa-english.md
+++ b/content/blog/2018/2018-02-14-openschufa-english.md
@@ -1,8 +1,7 @@
 ---
-authors: 
+authors:
 - Walter Palmetshofer
 - Arne Semsrott
-date: 2018-02-14
 image:
   src: /files/blog/2018/02/openschufa.png
   title: OpenSchufa
@@ -11,8 +10,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Get involved: We crack the Schufa!" 
+title: 'Get involved: We crack the Schufa!'
+publishedDate: 2018-02-14
 ---
 
 When applying for a loan, mobile phone contract, or even trying to rent an apartment in Germany, the [Schufa](https://en.wikipedia.org/wiki/Schufa) score - Germany's credit rating - is decisive. If you have a few "points" too little, your application is refused. (Computer says ["No"](https://youtu.be/AJQ3TM-p2QI?t=45) to your new smartphone or apartment.) However, the calculation of these credit scores - done by the private Schufa company - is fully intransparent. The formula is a trade secret, and as such not open to the public. 

--- a/content/blog/2018/2018-02-22-1-week-openschufa.md
+++ b/content/blog/2018/2018-02-22-1-week-openschufa.md
@@ -1,8 +1,7 @@
 ---
-authors: 
+authors:
 - Walter Palmetshofer
 - Arne Semsrott
-date: 2018-02-22 08:00
 image:
   src: /files/blog/2018/02/openschufa.png
   title: OpenSchufa
@@ -11,8 +10,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "One week of OpenSchufa - we crack the Schufa!" 
+title: One week of OpenSchufa - we crack the Schufa!
+publishedDate: 2018-02-22 08:00
 ---
 
 Last week we launched our newest project [OpenSCHUFA](http://openschufa.de) together with [AlgorithmWatch](https://algorithmwatch.org/de/).<br> 

--- a/content/blog/2018/2018-02-22-finanztransparenz.md
+++ b/content/blog/2018/2018-02-22-finanztransparenz.md
@@ -1,6 +1,6 @@
 ---
 authors: Michael Peters
-date: 2018-02-22 10:00
+date: 2018-02-22
 image: 
   src: /files/blog/2017/12/offener-haushalt.png
   title: Offenerhaushalt.de 

--- a/content/blog/2018/2018-02-23-upload-filter.md
+++ b/content/blog/2018/2018-02-23-upload-filter.md
@@ -1,7 +1,6 @@
 ---
-authors: 
+authors:
 - Walter Palmetshofer
-date: 2018-02-23
 image:
   src: /files/blog/2018/02/filter-article13.png
   title: Koalitionsvertrag
@@ -11,8 +10,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Upload-Filter: Wir brauchen deine Hilfe" 
+title: 'Upload-Filter: Wir brauchen deine Hilfe'
+publishedDate: 2018-02-23
 ---
 
 ## Europäischer Internet-Filter wird dein Recht auf Informationsfreiheit und auf freie Meinungsäußerung einschränken: Deine Hilfe wird benötigt!
@@ -61,4 +60,3 @@ Weitere Links:<br>
 [Netzpolitik-Artikel](https://netzpolitik.org/2018/eu-kommission-immer-mehr-plattformen-sollen-uploads-filtern/)<br>
 [copybuzz Artikel](http://copybuzz.com/pl/copyright/mep-voss-proposal-on-the-censorship-machine-art-13-not-die-beste-idee-either/)<br>
 [MEP Felix Reda](https://felixreda.eu/2018/02/voss-uploadfilter/)
-

--- a/content/blog/2018/2018-02-27-zweiteopenpolitischeabend.md
+++ b/content/blog/2018/2018-02-27-zweiteopenpolitischeabend.md
@@ -1,7 +1,6 @@
 ---
-authors: 
+authors:
 - OKF
-date: 2018-02-27 13:00:00
 image:
   src: /files/blog/2018/02/berlinmydata.png
 tags:
@@ -9,8 +8,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Der zweite openpolitische Abend: MyData in Berlin mit Antti \"Jogi\" Poikola und Nicola Jentzsch "
+title: 'Der zweite openpolitische Abend: MyData in Berlin mit Antti "Jogi" Poikola und Nicola Jentzsch '
+publishedDate: 2018-02-27 13:00:00
 ---
 
 Wir freuen uns sehr, euch alle zu unserem zweiten openpolitischen Abend einzuladen!

--- a/content/blog/2018/2018-03-08-praktikum-linus-okf-demokratielabore.md
+++ b/content/blog/2018/2018-03-08-praktikum-linus-okf-demokratielabore.md
@@ -1,6 +1,6 @@
 ---
 authors: Linus
-date: 2018-03-08 09:00
+date: 2018-03-08
 image: 
   src: /files/blog/2018/03/blog-linus.jpg
   title: 

--- a/content/blog/2018/2018-03-12-mord-kuciak.md
+++ b/content/blog/2018/2018-03-12-mord-kuciak.md
@@ -1,19 +1,19 @@
 ---
 authors: Arne Semsrott
-date: 2018-03-12 09:00
-image: 
+image:
   src: /files/blog/2018/03/jan-kuciak.jpg
-  title: 
-  license: "CC-BY-SA-2.0, Foto: Peter Tkac"
-  license_url: "https://creativecommons.org/licenses/by-sa/2.0/"
+  title: null
+  license: 'CC-BY-SA-2.0, Foto: Peter Tkac'
+  license_url: https://creativecommons.org/licenses/by-sa/2.0/
 type: post
 layout: post
 card: true
 tags:
 - pressefreiheit
 - informationsfreiheit
-title: "Mord an Ján Kuciak: Informationsfreiheit braucht Datenschutz"
-published: false
+title: 'Mord an Ján Kuciak: Informationsfreiheit braucht Datenschutz'
+draft: 'true'
+publishedDate: 2018-03-12 09:00
 ---
 
 Nach Recherchen der Journalistenorganisation OCCRP hängt der Tod des slowakischen Journalisten Ján Kuciak mit seinen Recherchen nach dem slowakischen Informationsfreiheitsgesetz zusammen. Den slowakischen Behörden wird vorgeworfen, im Rahmen einer Drittbeteiligung Kuciaks Daten an Dritte weitergeleitet zu haben – wodurch seine künftigen Mörder überhaupt erst auf seine Recherchen aufmerksam wurden.

--- a/content/blog/2018/2018-03-12-stellenausschreibung-ptf-kommunikation.md
+++ b/content/blog/2018/2018-03-12-stellenausschreibung-ptf-kommunikation.md
@@ -1,20 +1,19 @@
 ---
-authors: 
+authors:
 - OKF
-date: 2018-03-12
 image:
   src: /files/blog/2018/03/PrototypeFund-P-Logo.png
   title: Prototype Fund Logo
-  license: 
-  license_url: 
+  license: null
+  license_url: null
 tags:
 - Ausschreibung
 - Jobs
 type: post
 layout: post
 card: true
-published: true
-title: "Kommunikation und Projektmanagement (*/w/m) in Krankheitsvertretung"
+title: Kommunikation und Projektmanagement (*/w/m) in Krankheitsvertretung
+publishedDate: 2018-03-12
 ---
 
 Der Prototype Fund ist ein Förderprogramm, das Softwareentwickler*innen, Hacker*innen und Kreative dabei unterstützt, ihre Ideen vom Konzept bis zur ersten Demo zu entwickeln und als Open-Source-Prototypen zu veröffentlichen. Seit 2016 arbeiten wir (Adriana, Elisa, Fiona und Julia) daran, bestehende Strukturen und Narrative im Bereich der Innovation und Innovationsförderung aufzubrechen und mehr digitale Innovationen für die Gesellschaft möglich zu machen. Jetzt suchen wir dabei Verstärkung.
@@ -61,5 +60,3 @@ Laufzeit: Die Stelle ist eine Krankheitsvertretung und zunächst auf 6 Monate be
 Zeitl. Aufwand: 40h/Woche (Teilzeitregelung nach Absprache möglich)<br>
 Gehalt: nach TV-L E13/S1<br>
 Ort: Berlin<br>
-
-

--- a/content/blog/2018/2018-04-26-EU-Vorschlag-zur-Überarbeitung-der-PSI-Richtlinie.md
+++ b/content/blog/2018/2018-04-26-EU-Vorschlag-zur-Überarbeitung-der-PSI-Richtlinie.md
@@ -1,7 +1,6 @@
 ---
-authors: 
+authors:
 - Walter Palmetshofer
-date: 2018-04-26
 image:
   src: /files/blog/2018/01/scaling-okfde-nahverkehr.png
   title: PSI-Richtlinie
@@ -14,12 +13,10 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "EU-Vorschlag zur Überarbeitung der PSI-Richtlinie" 
-
+title: EU-Vorschlag zur Überarbeitung der PSI-Richtlinie
 aliases:
-  - /de/blog/2018/04/EU-Vorschlag-zur-Überarbeitung-der-PSI-Richtlinie/
-
+- /de/blog/2018/04/EU-Vorschlag-zur-Überarbeitung-der-PSI-Richtlinie/
+publishedDate: 2018-04-26
 ---
 
 Die EU hat den [Vorschlag zur Überarbeitung](https://ec.europa.eu/digital-single-market/en/proposal-revision-public-sector-information-psi-directive) der Richtlinie über die Weiterverwendung von Informationen des öffentlichen Sektors (PSI-Richtlinie) veröffentlicht. Sie ist auch bekannt als Open Data-Richtline.

--- a/content/blog/2018/2018-04-26-republica18.md
+++ b/content/blog/2018/2018-04-26-republica18.md
@@ -1,7 +1,6 @@
 ---
-authors: 
+authors:
 - OKFDE
-date: 2018-04-26
 image:
   src: /files/blog/2018/04/rp18.jpg
   title: re:publica 18
@@ -12,8 +11,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "OKFDE auf der re:publica 18" 
+title: OKFDE auf der re:publica 18
+publishedDate: 2018-04-26
 ---
 
 Vom 2. - 4. Mai findet die größte Konferenz der digitalen Gesellschaft re:publica in Berlin statt. Auch in diesem Jahr sind wir mit zahlreichen Talks vertreten. Hier eine kleine Übersicht der von uns organisierten Sessions! Fall ihr da seid, kommt doch vorbei: 
@@ -50,4 +49,4 @@ Freitag 04.05.2018  16:46 - 17:14 Stage T
 Noch ein Hinweis: Im [POP-UP Makerspace](https://re-publica.com/en/news/gig-republica-2018-we-what-we-create-together) könnt ihr die gesamten drei Tage unsere Freunde von [CADUS e.V.](https://www.cadus.org/en/) und ihrem Crisis Response Makerspace treffen. CADUS e.V. übernimmt humanitäre medizinische Hilfe in Krisengebieten dieser Welt und setzt sich mit eigen entwickelten Produkten für offene Technologien ein. Auf der re:publica werden sie außerdem Vorträge und Workshops halten und ihre Airborne Emergency Response Unit vorstellen.
 
 [Crisis Response Makerspaces](https://18.re-publica.com/de/session/crisis-response-makerspaces), CADUS e.V.
-Donnerstag, 3.5.2018, 16:15 Stage 2. 
+Donnerstag, 3.5.2018, 16:15 Stage 2.

--- a/content/blog/2018/2018-05-07-nachhaltiges-buero.markdown
+++ b/content/blog/2018/2018-05-07-nachhaltiges-buero.markdown
@@ -1,24 +1,21 @@
 ---
 author: Tanja Zagel
-date: 2018-05-25 
-image: 
-  src: 
-  title: 
-  license: 
-  license_url: 
+image:
+  src: null
+  title: null
+  license: null
+  license_url: null
 type: post
 layout: post
 card: true
-published: false
 tags:
 - okf
 - büro
 - nachhaltigkeit
 - sustainability
-
-
-
-title: "Schmierpapier, my love"
+title: Schmierpapier, my love
+draft: 'true'
+publishedDate: 2018-05-25
 ---
 
 Wenn man 20 Getränkekästen in den 3. Stock schleppt, hat man Zeit, über die grundsätzlichen Dinge des Lebens nachzudenken. Warum ist der Aufzug kaputt? Was machen wir, wenn er kaputt bleibt? Warum wuchten wir Wasser in Flaschen und Kästen die Treppen hinauf, wenn wir auch einfach den Wasserhahn aufmachen könnten?
@@ -41,11 +38,3 @@ Ein paar Sachen haben wir schon gelernt:
 ### Bits & Bäume 
 
 Wenn es so viele Berührungspunkte zwischen dem Thema Nachhaltigkeit und der guten Gestaltung unserer digitalen Gesellschaft gibt, dann könnte man ja direkt noch mehr daraus machen. Haben wir uns gedacht. Und wir machen noch mehr daraus: Wir freuen uns, die erste [Bits & Bäume - Die Konferenz für Digitalisierung und Nachhaltigkeit] (https://www.bits-und-baeume.org/) mitzuorganisieren: 17.-18. November, Berlin - Save the date!
-
-
-
-
-
-
-
-

--- a/content/blog/2018/2018-05-08-Job-Communitymanager-Jugend-hackt.md
+++ b/content/blog/2018/2018-05-08-Job-Communitymanager-Jugend-hackt.md
@@ -1,23 +1,21 @@
 ---
-authors: 
+authors:
 - OKF
-date: 2018-05-08
 image:
   src: /files/blog/2018/05/22252106205_c92c62c8ec_z.jpg
-  title: Jugend hackt 
-  license: 
-  license_url: 
+  title: Jugend hackt
+  license: null
+  license_url: null
 tags:
 - Ausschreibung
 - Jobs
 type: post
 layout: post
 card: true
-published: false
-title: "Online Community-Manager (m/w/*) für Jugend hackt (20h)"
-jobs: "Online Community-Manager (m/w/*) für Jugend hackt (20h)"
-
-
+title: Online Community-Manager (m/w/*) für Jugend hackt (20h)
+jobs: Online Community-Manager (m/w/*) für Jugend hackt (20h)
+draft: 'true'
+publishedDate: 2018-05-08
 ---
 
 Die Open Knowledge Foundation Deutschland ist ein gemeinnütziger Verein mit Sitz in Berlin, der sich seit 2011 für offenes 
@@ -70,4 +68,4 @@ Für das Online Community Management von Jugend hackt suchen wir eine begeisteru
 Wir möchten die Stelle im Idealfall zu August 2018 besetzen. Sie ist zunächst befristet bis 31.12.2019. Wir freuen uns insbesondere über die Bewerbungen von Frauen, Menschen mit Migrationshintergrund und Menschen anderer Gruppen, die in der IT-Welt unterrepräsentiert sind. Von Bewerbungsfotos und Angaben zu Alter und Familienstand bitten wir abzusehen.
 Bitte schicke uns Deine Bewerbung (Motivation, Erfahrungsnachweise, Lebenslauf) inkl. möglichem Beginn <b> bis zum 22. Mai </b> per E-Mail an jobs@jugendhackt.org.
 
-Die innerdeutschen Reisekosten für die Bewerbungsgespräche übernehmen wir, sofern sie nicht von der Arbeitsagentur getragen werden. 
+Die innerdeutschen Reisekosten für die Bewerbungsgespräche übernehmen wir, sofern sie nicht von der Arbeitsagentur getragen werden.

--- a/content/blog/2018/2018-05-08-Job-Design-Lead-Jugend-hackt.md
+++ b/content/blog/2018/2018-05-08-Job-Design-Lead-Jugend-hackt.md
@@ -1,23 +1,21 @@
 ---
-authors: 
+authors:
 - OKF
-date: 2018-05-08
 image:
   src: /files/blog/2018/05/22252106205_c92c62c8ec_z.jpg
-  title: Jugend hackt 
-  license: 
-  license_url: 
+  title: Jugend hackt
+  license: null
+  license_url: null
 tags:
 - Ausschreibung
 - Jobs
 type: post
 layout: post
 card: true
-published: false
-title: "Design-Lead (20h)"
-jobs: "Design-Lead (20h)"
-
-
+title: Design-Lead (20h)
+jobs: Design-Lead (20h)
+draft: 'true'
+publishedDate: 2018-05-08
 ---
 
 Die Open Knowledge Foundation Deutschland ist ein gemeinnütziger Verein mit Sitz in Berlin, der sich seit 2011 für offenes Wissen, offene Daten, Transparenz und Beteiligung einsetzt. Unsere Arbeit ist unabhängig, überparteilich, gemeinnützig und interdisziplinär. Der Verein ist eine Dachorganisation für rund 20 Projekte mit hoher konzeptioneller und finanzieller Eigenverantwortung. 
@@ -61,4 +59,4 @@ Für die Position des Design Leads im Projekt Jugend Hackt sind wir auf der Such
 Wir möchten die Stelle im Idealfall zu August 2018 besetzen. Sie ist zunächst befristet bis 31.12.2019. Wir freuen uns insbesondere über die Bewerbungen von Frauen, Menschen mit Migrationshintergrund und Menschen anderer Gruppen, die in der IT-Welt unterrepräsentiert sind. Von Bewerbungsfotos und Angaben zu Alter und Familienstand bitten wir abzusehen.
 Bitte schicke uns Deine Bewerbung (Motivation, Portfolio mit ausführlichen Projektbeschreibungen und deiner Rolle, Lebenslauf) inkl. möglichem Beginn <b> bis zum 22. Mai </b> per E-Mail an jobs@jugendhackt.org.
 
-Die innerdeutschen Reisekosten für die Bewerbungsgespräche übernehmen wir, sofern sie nicht von der Arbeitsagentur getragen werden. 
+Die innerdeutschen Reisekosten für die Bewerbungsgespräche übernehmen wir, sofern sie nicht von der Arbeitsagentur getragen werden.

--- a/content/blog/2018/2018-05-08-Job-Entwicklerin-oder-Entwickler-Jugend-hackt.md
+++ b/content/blog/2018/2018-05-08-Job-Entwicklerin-oder-Entwickler-Jugend-hackt.md
@@ -1,23 +1,21 @@
 ---
-authors: 
+authors:
 - OKF
-date: 2018-05-08
 image:
   src: /files/blog/2018/05/22252106205_c92c62c8ec_z.jpg
-  title: Jugend hackt 
-  license: 
-  license_url: 
+  title: Jugend hackt
+  license: null
+  license_url: null
 tags:
 - Ausschreibung
 - Jobs
 type: post
 layout: post
 card: true
-published: false
-title: "Entwickler*in (20h)"
-jobs: "Entwickler*in (20h)"
-
-
+title: Entwickler*in (20h)
+jobs: Entwickler*in (20h)
+draft: 'true'
+publishedDate: 2018-05-08
 ---
 
 Die Open Knowledge Foundation Deutschland ist ein gemeinnütziger Verein mit Sitz in Berlin, der sich seit 2011 für offenes Wissen, offene Daten, Transparenz und Beteiligung einsetzt. Unsere Arbeit ist unabhängig, überparteilich, gemeinnützig und interdisziplinär. Der Verein ist eine Dachorganisation für rund 20 Projekte mit hoher konzeptioneller und finanzieller Eigenverantwortung. 
@@ -60,4 +58,4 @@ Wir suchen eine*n Entwickler*in, die/der Lust hat, mit ihren/seinen Web-Developm
 Die Stelle ist zum nächstmöglichen Zeitpunkt zu besetzen und zunächst befristet bis 31.12.2019. Wir freuen uns insbesondere über die Bewerbungen von Frauen, Menschen mit Migrationshintergrund und Menschen anderer Gruppen, die in der IT-Welt unterrepräsentiert sind. Von Bewerbungsfotos und Angaben zu Alter und Familienstand bitten wir abzusehen.
 Bitte schicke uns Deine Bewerbung (Motivation, Erfahrungsnachweise, Lebenslauf) inkl. möglichem Beginn <b> bis zum 22. Mai </b>  per E-Mail an jobs@jugendhackt.org.
 
-Die innerdeutschen Reisekosten für die Bewerbungsgespräche übernehmen wir, sofern sie nicht von der Arbeitsagentur getragen werden. 
+Die innerdeutschen Reisekosten für die Bewerbungsgespräche übernehmen wir, sofern sie nicht von der Arbeitsagentur getragen werden.

--- a/content/blog/2018/2018-05-08-Job-Projektleitung-Fundraising-und-Lab-Aufbau-Jugend-hackt.md
+++ b/content/blog/2018/2018-05-08-Job-Projektleitung-Fundraising-und-Lab-Aufbau-Jugend-hackt.md
@@ -1,23 +1,21 @@
 ---
-authors: 
+authors:
 - OKF
-date: 2018-05-08
 image:
   src: /files/blog/2018/05/22252106205_c92c62c8ec_z.jpg
-  title: Jugend hackt 
-  license: 
-  license_url: 
+  title: Jugend hackt
+  license: null
+  license_url: null
 tags:
 - Ausschreibung
 - Jobs
 type: post
 layout: post
 card: true
-published: false
-title: "Projektleitung Fundraising und Lab-Aufbau für Jugend hackt (32h)"
-jobs: "Projektleitung Fundraising und Lab-Aufbau für Jugend hackt (32h)"
-
-
+title: Projektleitung Fundraising und Lab-Aufbau für Jugend hackt (32h)
+jobs: Projektleitung Fundraising und Lab-Aufbau für Jugend hackt (32h)
+draft: 'true'
+publishedDate: 2018-05-08
 ---
 
 Die Open Knowledge Foundation Deutschland ist ein gemeinnütziger Verein mit Sitz in Berlin, der sich seit 2011 für offenes 
@@ -64,4 +62,4 @@ Für die Projektleitung Fundraising und Lab-Aufbau suchen wir eine begeisterungs
 Wir möchten die Stelle im Idealfall zu August 2018 besetzen. Sie ist zunächst befristet bis 31.12.2019. Wir freuen uns insbesondere über die Bewerbungen von Frauen, Menschen mit Migrationshintergrund und Menschen anderer Gruppen, die in der IT-Welt unterrepräsentiert sind. Von Bewerbungsfotos und Angaben zu Alter und Familienstand bitten wir abzusehen.
 Bitte schicke uns Deine Bewerbung (Motivation, Erfahrungsnachweise, Lebenslauf) inkl. möglichem Beginn <b> bis zum 22. Mai </b> per E-Mail an jobs@jugendhackt.org.
 
-Die innerdeutschen Reisekosten für die Bewerbungsgespräche übernehmen wir, sofern sie nicht von der Arbeitsagentur getragen werden. 
+Die innerdeutschen Reisekosten für die Bewerbungsgespräche übernehmen wir, sofern sie nicht von der Arbeitsagentur getragen werden.

--- a/content/blog/2018/2018-05-15-Jahresbericht-2017.md
+++ b/content/blog/2018/2018-05-15-Jahresbericht-2017.md
@@ -1,7 +1,6 @@
 ---
-authors: 
+authors:
 - Bela Seeger
-date: 2018-05-15
 image:
   src: /files/blog/2018/05/jahresbericht.png
   title: Jahresbericht
@@ -14,10 +13,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Der Jahresbericht 2017 der Open Knowledge Foundation Deutschland" 
-
-
+title: Der Jahresbericht 2017 der Open Knowledge Foundation Deutschland
+publishedDate: 2018-05-15
 ---
 
 Unser [Jahresbericht 2017 ist online!](https://okfn.de/files/verein/OKFDE-Taetigkeitsbericht-2017.pdf)
@@ -34,6 +31,3 @@ offenen Lizenzen entwickeln können
 Freitag 12:45– 14:15 Uhr - Digitale Bildung offen gestalten – Mehr Reichweite für Bildungsangebote mit OpenEducational Ressources
 
 Mehr Details unter [DST18.okfn.de](http://dst18.okfn.de).
-
-
-

--- a/content/blog/2018/2018-05-16-openschufa-live-english.md
+++ b/content/blog/2018/2018-05-16-openschufa-live-english.md
@@ -1,8 +1,7 @@
 ---
-authors: 
+authors:
 - Arne Semsrott
 - Walter Palmetshofer
-date: 2018-05-16
 image:
   src: /files/blog/2018/02/openschufa.png
   title: OpenSchufa
@@ -11,8 +10,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "OpenSchufa is live!" 
+title: OpenSchufa is live!
+publishedDate: 2018-05-16
 ---
 
 Let's go! Today we launch the [data donation platform for our crowdsourcing project OpenSCHUFA](https://www.openschufa.de). At [openschufa.de](https://www.openschufa.de) all people can upload the data they requested from the SCHUFA. We will then analyze them together with our partner AlgorithmWatch to crack the SCHUFA algorithm.

--- a/content/blog/2018/2018-05-16-openschufa-live.md
+++ b/content/blog/2018/2018-05-16-openschufa-live.md
@@ -1,8 +1,7 @@
 ---
-authors: 
+authors:
 - Arne Semsrott
 - Walter Palmetshofer
-date: 2018-05-16
 image:
   src: /files/blog/2018/02/openschufa.png
   title: OpenSchufa
@@ -11,8 +10,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "OpenSchufa.de ist live - jetzt Daten spenden!" 
+title: OpenSchufa.de ist live - jetzt Daten spenden!
+publishedDate: 2018-05-16
 ---
 
 Los geht's! Heute launchen wir die [Datenspende-Plattform für unser Crowdsourcing-Projekt OpenSCHUFA](https://www.openschufa.de). Unter [openschufa.de](https://www.openschufa.de) können alle Menschen die Daten, die sie bei der SCHUFA über sich angefragt haben, hochladen. Wir werden sie dann gemeinsam mit unserem Partner AlgorithmWatch analysieren, um den SCHUFA-Algorithmus zu knacken.

--- a/content/blog/2018/2018-05-18-OHH-GIC.md
+++ b/content/blog/2018/2018-05-18-OHH-GIC.md
@@ -1,7 +1,6 @@
 ---
-authors: 
+authors:
 - Anna Alberts
-date: 2018-05-16
 image:
   src: /files/blog/2018/05/OHHGIC.jpg
   title: Offener Haushalt Workshops
@@ -10,10 +9,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Stimme bei der Google Impact Challenge für Offener Haushalt ab!" 
-
-
+title: Stimme bei der Google Impact Challenge für Offener Haushalt ab!
+publishedDate: 2018-05-16
 ---
 
 Die Google Impact Challenge „Kleine Taten“ unterstützt kleine Projekte in ganz Deutschland. Hilf uns, 20.000€ für Offener Haushalt zu erhalten. [Stimme hier ab!](https://impactchallenge.withgoogle.com/deutschland2018/charities/okfn)

--- a/content/blog/2018/2018-05-22-OKFDE-beim-Deutschen-Stiftungstag-2018.md
+++ b/content/blog/2018/2018-05-22-OKFDE-beim-Deutschen-Stiftungstag-2018.md
@@ -1,12 +1,11 @@
 ---
 authors:
 - Markus Neuschäfer, Tanja Zagel, Timo Lundelius, Walter Palmetshofer
-date: 2018-05-24
 image:
   src: /files/blog/2018/05/OKFDE-20180517-full.jpg
   title: Open Knowledge Foundation beim Deutschen Stiftungstag 2018
-  license:
-  license_url:
+  license: null
+  license_url: null
 tags:
 - OpenData
 - Transparenz
@@ -16,10 +15,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Open Knowledge Foundation beim Deutschen Stiftungstag 2018"
-
-
+title: Open Knowledge Foundation beim Deutschen Stiftungstag 2018
+publishedDate: 2018-05-24
 ---
 
 Der Deutsche Stiftungstag wird jedes Jahr vom Verband Deutscher Stiftungen als Informations- und Vernetzungsangebot für seine Mitglieder organisiert. Die diesjährige Ausgabe fand unter dem Motto [Update! - Stiftungen und Digitalisierung](https://www.stiftungen.org/fileadmin/stiftungen_org/Verband/Was_wir_tun/Veranstaltungen/DST/2018/DST18-Programm.pdf) vom 16. - 18. Mai in Nürnberg statt.

--- a/content/blog/2018/2018-06-01-OHH-Berlin.md
+++ b/content/blog/2018/2018-06-01-OHH-Berlin.md
@@ -1,7 +1,6 @@
 ---
-authors: 
+authors:
 - Anna Alberts
-date: 2018-06-01
 image:
   src: /files/blog/2018/06/ohhberlin.gif
   title: Offener Haushalt Berlin
@@ -10,10 +9,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Berlin Doppelhaushalt 2018/2019 im neuem Design und mit erweiterten Funktionen" 
-
-
+title: Berlin Doppelhaushalt 2018/2019 im neuem Design und mit erweiterten Funktionen
+publishedDate: 2018-06-01
 ---
 
 Der Berliner Senatsverwaltung hat die neue [Haushaltsvisualisierung]( https://www.berlin.de/sen/finanzen/haushalt/haushaltsplan/artikel.5697.php) des Landes Berlins veröffentlicht. Das Land Berlin ist damit das erste Bundesland, das seine Haushaltsdaten auf diese umfassende Weise für Bürger*innen leicht verständlich darstellt. Die Visualisierung ist ein gemeinsames Projekt des Teams Offener Haushalt der Open Knowledge Foundation Deutschland und der Berliner Senatsverwaltung für Finanzen. 
@@ -22,4 +19,4 @@ Die Bürger*innen können im Kachel-Diagramm über einen Soll-Ist-Vergleichen au
 
 Dies ist das erste Projekt nach dem Relaunch des Projekts  Offener Haushalt, bei dem wir gemeinsam mit der Verwaltung eine Reihe von Workshops durchgeführt und neue Visualisierungen entwickelt haben. Es ist der erste Schritt zum Ziel, dass die Verwaltung das Projekt Offener Haushalt in Zukunft durch Kooperationen und Schulungen eigenständig nutzen kann.
 
-Bitte unterstütz uns dabei auch in Zukunft Haushaltsdaten zu öffnen, indem ihr bei der Google Impact Challenge für uns [abstimmt](https://impactchallenge.withgoogle.com/deutschland2018/charities/okfn). 
+Bitte unterstütz uns dabei auch in Zukunft Haushaltsdaten zu öffnen, indem ihr bei der Google Impact Challenge für uns [abstimmt](https://impactchallenge.withgoogle.com/deutschland2018/charities/okfn).

--- a/content/blog/2018/2018-06-04-Neuer-Vorstand.md
+++ b/content/blog/2018/2018-06-04-Neuer-Vorstand.md
@@ -1,21 +1,18 @@
 ---
-authors: 
+authors:
 - OKF
-date: 2018-06-04
 image:
   src: /files/blog/2018/06/OKF.gif
   title: wave
-  license: 
-  license_url: 
+  license: null
+  license_url: null
 tags:
 - Vorstand
 type: post
 layout: post
 card: true
-published: true
-title: "Neuer Vorstand der Open Knowledge Foundation Deutschland gewählt"
-
-
+title: Neuer Vorstand der Open Knowledge Foundation Deutschland gewählt
+publishedDate: 2018-06-04
 ---
 
 Auf der Mitgliederversammlung des Open Knowledge Foundation Deutschland e.V. (OKF) wurde am 2. Juni 2018 ein neuer Vorstand gewählt.
@@ -32,4 +29,4 @@ Friedrich Lindenberg stand dem Team als stellvertretender Vorstandsvorsitzender 
 
 Sören Auer, Informatiker und Professor für Data Science and Digital Libraries an der Gottfried Wilhelm Leibniz Universität Hannover und Direktor der Technischen Informationsbibliothek in Hannover, hat die OKF unermüdlich mit seiner Expertise in den Bereichen Semantic Web und Offene Daten unterstützt. Die OKF konnte oft von seinen außergewöhnlichen Netzwerkfähigkeiten im akademischen Umfeld profitieren und seine langjährige Erfahrung hat die Organisation in vielen Bereichen gestärkt. Es ist ihm insbesondere zu verdanken, dass die OKF heute auf einem stabilen Fundament steht.
 
-Wir möchten uns ganz herzlich bei Christian, Friedrich und Sören für ihre langjährige Vorstandsarbeit bei der Open Knowledge Foundation Deutschland bedanken. Als Gründungsmitglieder haben sie eine unschätzbare Rolle bei den Erfolgen der heutigen Open Knowledge Foundation Deutschland gespielt. Wir werden ihnen auch in Zukunft eng verbunden bleiben. 
+Wir möchten uns ganz herzlich bei Christian, Friedrich und Sören für ihre langjährige Vorstandsarbeit bei der Open Knowledge Foundation Deutschland bedanken. Als Gründungsmitglieder haben sie eine unschätzbare Rolle bei den Erfolgen der heutigen Open Knowledge Foundation Deutschland gespielt. Wir werden ihnen auch in Zukunft eng verbunden bleiben.

--- a/content/blog/2018/2018-06-12-transparenz-register.md
+++ b/content/blog/2018/2018-06-12-transparenz-register.md
@@ -2,7 +2,6 @@
 authors:
 - Michael Peters
 - Moritz Neujeffski
-date: 2018-06-12
 image:
   src: /files/blog/2018/06/tale-of-three-men.jpg
   title: frankieleon, A tale of three men
@@ -18,8 +17,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Transparenzregister? Diesmal bitte transparent"
+title: Transparenzregister? Diesmal bitte transparent
+publishedDate: 2018-06-12
 ---
 
 *Geldwäsche, Steuerflucht und krumme Deals werden durch komplexe Firmengeflechte getarnt. Ein Transparenzregister ermöglicht Recherchen für JournalistInnen, BürgerInnen und GeschäftspartnerInnen. Die Daten sollten öffentlich und kostenlos zugänglich sein.*

--- a/content/blog/2018/2018-06-14-make-city-citylab-berlin.md
+++ b/content/blog/2018/2018-06-14-make-city-citylab-berlin.md
@@ -1,7 +1,6 @@
 ---
-authors: 
+authors:
 - OKF
-date: 2018-06-14
 image:
   src: /files/blog/2018/06/citylab-lageplan.jpg
   title: citylab.berlin
@@ -12,9 +11,10 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "make.city & citylab.berlin: Einladung zu Rundgang & Diskussion am 17. Juni" 
+title: 'make.city & citylab.berlin: Einladung zu Rundgang & Diskussion am 17. Juni'
+publishedDate: 2018-06-14
 ---
+
 Unser Konzept für ein <a href="http://citylab.berlin">citylab.berlin</a> als Digitalzentrum, Labor und Experimentierfeld in Berlin findet regen Anklang. Am kommenden Sonntag gibt es im Rahmen von <a href="http://makecity.berlin">makecity.berlin</a> kurzfristig einen Rundgang mit anschliessender Projektpräsentation- und Diskussionsveranstaltung.
 
 Alle interessierten BürgerInnen und Initiativen sind herzlich eingeladen! Die Gemeinschaftsstiftung Berlin Tempelhof, fixmyberlin, der THF-Beirat und die Open Knowledge Foundation freuen sich auf euer Kommen!

--- a/content/blog/2018/2018-06-25-EITI-Woche-in-Berlin.md
+++ b/content/blog/2018/2018-06-25-EITI-Woche-in-Berlin.md
@@ -1,22 +1,20 @@
 ---
-authors: 
+authors:
 - Walter Palmetshofer
-date: 2018-06-25
 image:
   src: /files/blog/2018/06/eiti-oil-platform.jpg
   title: EITI
 tags:
 - EITI
-- open data 
+- open data
 - transparency
 type: post
 layout: post
 card: true
-published: true
-title: "EITI-Woche in Berlin" 
-
-
+title: EITI-Woche in Berlin
+publishedDate: 2018-06-25
 ---
+
 Diese Woche findet in Berlin das [internationale Board-Meeting](https://eiti.org/document/40th-board-meeting) von [EITI](https://www.eiti.org) statt.
 
 EITI steht für Extractive Industry Transparency Initiative und bemüht sich um die Offenlegung der Zahlungsströme im Rohstoffsektor. 
@@ -210,4 +208,3 @@ Picture archives:<br>
 [BMWI](https://www.flickr.com/photos/okfde/sets/72157695420395142)<br>
 [Board meeting including civil society constituency, BMZ shrinking civic space, blockchain side event)](https://www.flickr.com/photos/okfde/albums/72157696919938241)<br>
 [dropbox - Thomas & Boris](https://www.dropbox.com/sh/kcdorf0qxz7a423/AABa-bhDYnaEwZZ58UA94E2Ua?dl=0)
-

--- a/content/blog/2018/2018-07-06-OpenSCHUFA-Zwischenbilanz.md
+++ b/content/blog/2018/2018-07-06-OpenSCHUFA-Zwischenbilanz.md
@@ -1,8 +1,7 @@
 ---
-authors: 
+authors:
 - Arne Semsrott
 - Walter Palmetshofer
-date: 2018-07-06
 image:
   src: /files/blog/2018/02/openschufa.png
   title: OpenSchufa
@@ -11,11 +10,10 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "OpenSCHUFA: Zwischenbilanz der Datenspende - noch immer gerne Daten spenden!" 
-
-
+title: 'OpenSCHUFA: Zwischenbilanz der Datenspende - noch immer gerne Daten spenden!'
+publishedDate: 2018-07-06
 ---
+
 Liebe Unterstützerinnen und Unterstützer,
 
 die Datenspende von OpenSCHUFA läuft jetzt seit sieben Wochen. Wir wollen Euch ein Update zum Fortschritt des Projekts geben, aber auch zu den Herausforderungen:
@@ -45,4 +43,3 @@ Euer OpenSCHUFA Team
 
 Weitere Infos:
 [Welt](https://www.welt.de/finanzen/article177303132/DSGVO-stellt-das-Abo-Modell-der-Schufa-infrage.html)
-

--- a/content/blog/2018/2018-07-13-PSI-Directive-joint-effort.md
+++ b/content/blog/2018/2018-07-13-PSI-Directive-joint-effort.md
@@ -1,7 +1,6 @@
 ---
-authors: 
+authors:
 - Walter Palmetshofer
-date: 2018-07-13
 image:
   src: /files/blog/2018/07/20180713-psi-screenshot.png
   title: PSI-Directive
@@ -13,10 +12,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "PSI Directive - joint effort by OKF and friends"  
-
-
+title: PSI Directive - joint effort by OKF and friends
+publishedDate: 2018-07-13
 ---
 
 Updates: 
@@ -64,4 +61,3 @@ We will coordinate the Open Knowledge Network and friends.
 
 On the 25th of October there will be a PSI-policy meeting at the [European Data Summit](http://www.kas.de/wf/en/17.78393/)<br>
 ~12:00/12:30 - 14:00, remote participation is possible, more infos walter@okfn.de.
-

--- a/content/blog/2018/2018-07-17-Policy-advocacy-with-a-twist.md
+++ b/content/blog/2018/2018-07-17-Policy-advocacy-with-a-twist.md
@@ -1,6 +1,5 @@
 ---
 authors: OKF
-date: 2018-07-17
 image:
   src: /files/blog/2018/06/tale-of-three-men.jpg
   title: frankieleon, A tale of three men
@@ -11,15 +10,13 @@ tags:
 - Open Data
 - Policy
 - Transparency
-
 type: post
 layout: post
 card: true
-published: true
-title: "Policy advocacy with a twist"
-
-
+title: Policy advocacy with a twist
+publishedDate: 2018-07-17
 ---
+
 At the Open Knowledge Foundation Deutschland we’ve been advocating for rules and regulation that open up closed systems and processes in areas such as data governance, financial transparency and algorithmic accountability. However, as a small organisation that largely runs on project grants and individual donations, we don’t have the resources to run large-scale advocacy campaigns. The key to success for us has been to rely on a combination of law, tech and crowd to address some of the most important policy issues in our field. Here are two examples to illustrate how we work.
 
 ### Pushing for transparency in lawmaking

--- a/content/blog/2018/2018-08-08-ogp-georgia.md
+++ b/content/blog/2018/2018-08-08-ogp-georgia.md
@@ -1,19 +1,17 @@
 ---
-authors: 
+authors:
 - Michael Peters
-date: 2018-08-07
 image:
   src: /files/blog/2018/08/OGP-Georgia.jpg
-  title: Copyright Richard Pietro 
+  title: Copyright Richard Pietro
 tags:
 - Open Government
 - Policy
-
 type: post
 layout: post
 card: true
-published: true
-title: "Rückblick: Open Government Global Summit 2018"
+title: 'Rückblick: Open Government Global Summit 2018'
+publishedDate: 2018-08-07
 ---
 
 Beim „5. Open Government Global Summit 2018“ der Open Government Partnership (OGP) in Tiflis tauschten sich vom 17. bis 19. Juli etwa 2000 Teilnehmer aus Regierung, Verwaltung und Zivilgesellschaft aus über 75 Ländern aus. 

--- a/content/blog/2018/2018-09-15-oparl-1-1-politik-bei-uns.md
+++ b/content/blog/2018/2018-09-15-oparl-1-1-politik-bei-uns.md
@@ -1,21 +1,19 @@
 ---
 authors: Ernesto Ruge
-date: 2018-09-17
 image:
   src: /files/blog/2018/09/oparl.png
-  title: "OParl: Der Standard für Ratsinformationssysteme"
+  title: 'OParl: Der Standard für Ratsinformationssysteme'
 tags:
 - Ratsinformationssystem
 - Transparenz
 - Kommunen
 - Schnittstelle
 - OParl
-
 type: post
 layout: post
 card: true
-published: true
-title: "OParl 1.1: Neue Version des Standards - und viel Aktivität"
+title: 'OParl 1.1: Neue Version des Standards - und viel Aktivität'
+publishedDate: 2018-09-17
 ---
 
 Vor zwei Jahren haben wir mit der [offenen Schnittstelle OParl](https://oparl.org) 1.0 den ersten großen Schritt zur Transparenz kommunaler Beschlüsse gemacht. Seitdem ist viel passiert:

--- a/content/blog/2018/2018-10-04-Labausschreibung-Jugend-hackt.md
+++ b/content/blog/2018/2018-10-04-Labausschreibung-Jugend-hackt.md
@@ -1,23 +1,22 @@
 ---
-authors: 
+authors:
 - OKF
-date: 2018-10-04
 image:
   src: /files/blog/2018/AusschreibungJH.jpg
-  title: Jugend hackt 
-  license: 
-  license_url: 
+  title: Jugend hackt
+  license: null
+  license_url: null
 tags:
 - Ausschreibung
 - Jobs
 type: post
 layout: post
 card: true
-published: true
-title: "Ausschreibung Jugend hackt Labs – Wir suchen regionale Partner-Organisationen!"
-jobs: "Ausschreibung Jugend hackt Labs – Wir suchen regionale Partner-Organisationen!"
+title: Ausschreibung Jugend hackt Labs – Wir suchen regionale Partner-Organisationen!
+jobs: Ausschreibung Jugend hackt Labs – Wir suchen regionale Partner-Organisationen!
 aliases:
 - /blog/2018/10/Labausschreibung-Jugend-hackt/
+publishedDate: 2018-10-04
 ---
 
 Seit 2013 wird Jugend hackt vom Open Knowledge Foundation Deutschland e.V. (OKF) und mediale pfade.org - Verein für Medienbildung e.V. veranstaltet. Jugend hackt ist ein Programm zur Förderung des Programmiernachwuchses im deutschsprachigen Raum mit gesellschaftspolitischen Fokus. Damit begegnet Jugend hackt zwei Herausforderungen: Erstens der sozialen Benachteiligung im Sinne einer Vereinzelung von Jugendlichen mit hohem Technikinteresse. Denn gerade die hohe Technikbegeisterung und die Zeit vor dem Computer verschiebt die engsten sozialen Kontakte häufig weg von der nächsten Umgebung hin zu ebenfalls technikaffinen Jugendlichen, die im ländlichen Raum seltener anzutreffen sind und deswegen Online stattfinden. Gerade gegenüber Eltern entsteht so einseitiger Rechtfertigungsdruck, da die quantitative Bewertung der Computernutzung meistens im Vordergrund steht. Zweitens greift das Programm den Umstand auf, dass die Digitalisierung der Welt große Veränderungen für die Menschen birgt und sensibilisiert mögliche zukünftige Programmierer/innen für ihre gesellschaftspolitische Verantwortung.

--- a/content/blog/2018/2018-10-04-anmeldung-bits-und-baeume.md
+++ b/content/blog/2018/2018-10-04-anmeldung-bits-und-baeume.md
@@ -1,6 +1,6 @@
 ---
 authors: OKF
-date: 2018-10-04 09:00
+date: 2018-10-04
 image: 
   src: /files/blog/2018/schwer-bit.jpg
   title: 

--- a/content/blog/2018/2018-10-18-Energyhack-2018.md
+++ b/content/blog/2018/2018-10-18-Energyhack-2018.md
@@ -2,7 +2,6 @@
 authors:
 - Martin Koll
 - Walter Palmetshofer
-date: 2018-10-18 06:00:00
 image:
   src: /files/blog/2018/10/Energyhack-2018.png
 tags:
@@ -11,12 +10,10 @@ tags:
 - Daseinsversorger
 type: post
 layout: post
-published: true
 card: true
-featured: "yellow"
+featured: yellow
 title: 'Rückblick Energyhack 2018: " Energyhack^2 - Energie für eine effiziente Stadt " !'
-
-
+publishedDate: 2018-10-18 06:00:00
 ---
 
 Energie für eine effiziente Stadt! Am 12. und 13. Oktober fand der vierte Energyhack von [Stromnetz Berlin](https://www.stromnetz-berlin.de/) und der Open Knowledge Foundation statt.

--- a/content/blog/2018/2018-10-31-Faires-Scoring.md
+++ b/content/blog/2018/2018-10-31-Faires-Scoring.md
@@ -2,7 +2,6 @@
 authors:
 - Arne Semsrott
 - Walter Palmetshofer
-date: 2018-10-31
 image:
   src: /files/blog/2018/02/openschufa.png
   title: OpenSchufa
@@ -11,12 +10,11 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "OpenSCHUFA: Verbrauchergerechtes Scoring"
-featured: "yellow"
-
-
+title: 'OpenSCHUFA: Verbrauchergerechtes Scoring'
+featured: yellow
+publishedDate: 2018-10-31
 ---
+
 Heute findet die Präsentation des Sachverständigenrates für Verbraucherfragen statt. Thema: Faires Scoring. Wir berichten live vor Ort.
 #fairesscoring #openschufa
 

--- a/content/blog/2018/2018-10-31-Stellenausschreibung-Programmmanagement-PTF.md
+++ b/content/blog/2018/2018-10-31-Stellenausschreibung-Programmmanagement-PTF.md
@@ -1,24 +1,20 @@
 ---
 authors:
 - OKF
-date: 2018-10-31 16:00:00
 image:
   src: /files/blog/2015/12/okfdebuero.jpg
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - Ausschreibung
 - Jobs
 type: post
 layout: post
 card: true
-published: true
-title: "Der Prototype Fund sucht Verstärkung: Programmbetreuung mit technischem Schwerpunkt"
-
-
+title: 'Der Prototype Fund sucht Verstärkung: Programmbetreuung mit technischem Schwerpunkt'
+publishedDate: 2018-10-31 16:00:00
 ---
-
 
 Der Prototype Fund ist ein Förderprogramm für Public Interest Tech, das als erstes in Deutschland selbstständige Softwareentwickler*innen, Hacker*innen und Kreative (auch als Teams) dabei unterstützt, ihre Open-Source-Ideen vom Konzept bis zur ersten Demo umzusetzen. Seit 2016 arbeiten wir (Adriana, Elisa, Fiona, Julia und Katharina) daran, bestehende Strukturen und Narrative im Bereich der Innovationsförderung aufzubrechen und mehr sinnvolle digitale Lösungen für die Gesellschaft möglich zu machen. Jetzt suchen wir dabei Verstärkung!
 Du arbeitest eigenständig und hast Lust, dich weiterzuentwickeln und Neues zu lernen? Du willst gemeinsam mit uns unser Pionier-Projekt unterstützen und voranbringen? Dann freuen wir uns auf deine Bewerbung:

--- a/content/blog/2018/2018-11-06-Eine-Chance-fuer-Open-Hardware-das-Recht-auf-Reparatur.md
+++ b/content/blog/2018/2018-11-06-Eine-Chance-fuer-Open-Hardware-das-Recht-auf-Reparatur.md
@@ -1,22 +1,19 @@
 ---
 authors:
 - Maximilian Voigt
-date: 2018-11-06 16:00:00
 image:
   src: /files/blog/2018/11/Open-source-hardware-logo.png
-  title:
+  title: null
   license: CC-BY-SA 1.0
-  license_url: "https://creativecommons.org/licenses/sa/1.0/deed.de"
+  license_url: https://creativecommons.org/licenses/sa/1.0/deed.de
 tags:
 - Open Hardware
 - Transparenz
 type: post
 layout: post
 card: true
-published: true
-title: "Eine Chance für Open Hardware: das Recht auf Reparatur"
-
-
+title: 'Eine Chance für Open Hardware: das Recht auf Reparatur'
+publishedDate: 2018-11-06 16:00:00
 ---
 
 In einer Zeit, in der große Teile der technischen Apparate Daten verarbeiten, hat die Forderung nach transparenter Technik einen hohen Stellenwert: Wie erfasst das Smartphone seine Umgebung, welche Daten werden erhoben und wohin gelangen sie? Open Source, das Offenlegen des technischen Aufbaus und die Verwendung von freien Lizenzen, ist hier das bekannte Schlagwort. **Während Open Source für den Bereich der Software ein verbreitetes Thema ist und freie Software weite Teile der Softwareentwicklung bereichert, steckt Open Source Hardware noch in den Kinderschuhen.** Schlimmer noch: Wer sich an die 50er und 60er Jahre erinnert, weiß, dass der Schaltplan oft fester Bestandteil erworbener Geräte war. Heute verschwinden sie immer mehr in verklebten Gehäusen und sollen möglichst wenige Gründe zum Öffnen geben – eine technische Dokumentation liefert nur die nötigsten Informationen.

--- a/content/blog/2018/2018-11-28-openschufa-ergebnisse.md
+++ b/content/blog/2018/2018-11-28-openschufa-ergebnisse.md
@@ -1,20 +1,19 @@
 ---
-authors: 
+authors:
 - Arne Semsrott
 - Walter Palmetshofer
-date: 2018-11-28 09:10:00
 image:
   src: /files/blog/2018/11/openschufa.jpg
-  title: 
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - OpenSchufa
 type: post
 layout: post
 card: true
-published: true
-title: "OpenSchufa: Die Ergebnisse (Updates)"
+title: 'OpenSchufa: Die Ergebnisse (Updates)'
+publishedDate: 2018-11-28 09:10:00
 ---
 
 Lange hat es gedauert, aber heute werden die ersten Analysen des OpenSchufa-Datensatzes veröffentlicht. Die Redaktionen vom [SpiegelOnline](http://www.spiegel.de/wirtschaft/service/schufa-so-funktioniert-deutschlands-einflussreichste-auskunftei-a-1239214.html) und dem [Bayerischen Rundfunk](https://www.br.de/nachrichten/wirtschaft/schufa-score-wie-menschen-unverschuldet-zum-risikofall-werden,RAheWGP) haben die anonymisierten Daten, die wir mithilfe von [OpenSchufa](https://okfn.de/blog/tags/openschufa/) im Frühjahr gesammelt haben, ausgewertet.  Herzlichen Dank an alle Personen, die uns für das Projekt [Geld](https://www.startnext.com/openschufa), Zeit und [Daten](https://www.openschufa.de/) gespendet haben!

--- a/content/blog/2018/2018-11-28-openschufa-first-results.md
+++ b/content/blog/2018/2018-11-28-openschufa-first-results.md
@@ -1,20 +1,19 @@
 ---
-authors: 
+authors:
 - Arne Semsrott
 - Walter Palmetshofer
-date: 2018-11-28
 image:
   src: /files/blog/2018/11/openschufa.jpg
-  title: 
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - OpenSchufa
 type: post
 layout: post
 card: true
-published: true
-title: "OpenSchufa: The first results"
+title: 'OpenSchufa: The first results'
+publishedDate: 2018-11-28
 ---
 
 Today the first analyses of OpenSchufa dataset are published. The data teams and editorial offices of Bayerischer Rundfunk and SpiegelOnline  have evaluated the anonymous data that we have collected with the help of our "mydata" project [OpenSchufa](https://okfn.de/blog/tags/openschufa/) since this spring.

--- a/content/blog/2018/2018-12-04-schufa-elektronische-auskuenfte.md
+++ b/content/blog/2018/2018-12-04-schufa-elektronische-auskuenfte.md
@@ -1,20 +1,19 @@
 ---
-authors: 
+authors:
 - Arne Semsrott
 - Walter Palmetshofer
-date: 2018-12-04
 image:
   src: /files/blog/2018/11/openschufa.jpg
-  title: 
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - OpenSchufa
 type: post
 layout: post
 card: true
-published: true
-title: "Schufa gibt nach: Elektronische Auskünfte ab 2019"
+title: 'Schufa gibt nach: Elektronische Auskünfte ab 2019'
+publishedDate: 2018-12-04
 ---
 
 Nach Monaten des Widerstands hat die Schufa zugesagt, künftig auch Daten-Auskünfte von Privatpersonen elektronisch zu beantworten. Das bestätigte der Hessische Datenschutzbeauftragte gegenüber OpenSchufa, unserer gemeinsamen Initiative mit AlgorithmWatch. Nach Artikel 15 der Datenschutzgrundverordnung (DS-GVO) ist die Schufa seit Mai dazu verpflichtet, Auskünfte nicht mehr nur wie bisher postalisch, sondern auch elektronisch zugänglich zu machen.
@@ -28,4 +27,3 @@ Trotz aller Kritik hält die Schufa an ihrer Mauertaktik fest. Sie nennt die bis
 Den Verweis auf vermeintliche Prüfungen durch die Bundesanstalt für Finanzdienstleistungsaufsicht (Bafin), den die Schufa noch im Februar als Verteidigung für ihr Vorgehen angegeben hatte, findet sich in der aktuellen Stellungnahme der Schufa nicht mehr wieder. Mit gutem Grund: Wie die Bafin uns [auf Anfrage mitteilte](https://fragdenstaat.de/anfrage/uberprufung-von-schufa-scores/109542/anhang/anschrIFG0312.pdf), ist die “Beschreibung der Aufgaben der BaFin auf der Internetseite der SCHUFA” aus Sicht der Bafin “missverständlich”. 
 
 Aber nicht nur die Schufa, auch weitere Auskunfteien brauchen mehr Transparenz.
-

--- a/content/blog/2018/2018-12-05-fragdenstaat-in-2018.md
+++ b/content/blog/2018/2018-12-05-fragdenstaat-in-2018.md
@@ -1,20 +1,19 @@
 ---
-authors: 
+authors:
 - Arne Semsrott
-date: 2018-12-05
 image:
   src: /files/blog/2018/12/fds.jpg
-  title: 
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - FragDenStaat
 - english
 type: post
 layout: post
 card: true
-published: true
-title: "Strengthening the Democratic Infrastructure"
+title: Strengthening the Democratic Infrastructure
+publishedDate: 2018-12-05
 ---
 
 <p>2018 proved, again, why we need to strengthen the infrastructure for democracy. This year, our freedom of information project <a href="https://fragdenstaat.de">FragDenStaat</a> has revealed how the Ministry of Family Affairs cooperates with the Domestic Intelligence Service, we have published the Ministry of the Interior's <a href="https://fragdenstaat.de/blog/2018/masterplan-english/">Master Plan on Migration</a> and documents on “<a href="https://fragdenstaat.de/blog/2018/exclusive-internal-diplomatic-report-concentration-camp-conditions-libyan-refugee-camps/">concentration camp-like prisons</a>”&nbsp;in Libya.</p>

--- a/content/blog/2018/2018-12-10-PSI-public-sector-information.md
+++ b/content/blog/2018/2018-12-10-PSI-public-sector-information.md
@@ -1,7 +1,6 @@
 ---
 authors:
 - Walter Palmetshofer
-date: 2018-12-10
 image:
   src: /files/blog/2018/10/LogoEC-el-svg.png
   title: PSI public sector information
@@ -12,11 +11,10 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "PSI public sector information"
-
-
+title: PSI public sector information
+publishedDate: 2018-12-10
 ---
+
 Opendata in Europe, on the re-use of public sector information, otherwise known as the PSI Directive, is an EU directive that encourages EU member states to make as much public sector information available for re-use as possible.<br>
 <i>Documents & upcoming English summary <a href="https://okfn.de/blog/2018/12/PSI-public-sector-information#english">below</a></i>.
 

--- a/content/blog/2018/2018-12-10-offenegesetze.md
+++ b/content/blog/2018/2018-12-10-offenegesetze.md
@@ -3,20 +3,19 @@ authors:
 - Johannes Filter
 - Stefan Wehrmeyer
 - Arne Semsrott
-date: 2018-12-24
 image:
   src: /files/blog/2018/12/offenegesetze.png
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - OffeneGesetze
 type: post
 layout: post
 card: true
-published: true
 featured: yellow
-title: "OffeneGesetze: Zentrale Dokumente der Demokratie erstmals frei zugänglich (Update)"
+title: 'OffeneGesetze: Zentrale Dokumente der Demokratie erstmals frei zugänglich (Update)'
+publishedDate: 2018-12-24
 ---
 
 *Update, 24.12.2018*: Das Justizministerium hat [als Reaktion auf OffeneGesetze bekanntgegeben](https://www.faz.net/aktuell/wirtschaft/diginomics/justizministerin-barley-nimmt-dumont-verlag-das-gesetzblatt-weg-15957231.html?GEPC=s3), künftig ein digitales Gesetzgebungsverfahren zu schaffen. Das Ministerium schaffe eine Plattform, auf der Bundesgesetzblätter "auch frei ausgedruckt, durchsucht und weiterverwendet werden können." Es solle einen uneingeschränkten Zugang geben.

--- a/content/blog/2018/2018-12-10-opening-laws-in-germany.md
+++ b/content/blog/2018/2018-12-10-opening-laws-in-germany.md
@@ -1,22 +1,21 @@
 ---
-authors: 
+authors:
 - Johannes Filter
 - Stefan Wehrmeyer
 - Arne Semsrott
-date: 2018-12-24
 image:
   src: /files/blog/2018/12/offenegesetze.png
-  title: 
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - OffeneGesetze
 - english
 type: post
 layout: post
 card: true
-published: true
-title: "OffeneGesetze: Opening Germany's Law Gazette (Update)"
+title: 'OffeneGesetze: Opening Germany''s Law Gazette (Update)'
+publishedDate: 2018-12-24
 ---
 
 **Update, 12/24/2018**: In response to OffeneGesetze, [the German Ministry of Justice has announced](https://www.faz.net/aktuell/wirtschaft/diginomics/justizministerin-barley-nimmt-dumont-verlag-das-gesetzblatt-weg-15957231.html?GEPC=s3) that it will create a digital legislative process in the coming years. The ministry is creating a platform on which federal law gazettes "can also be freely printed, searched and re-used". There should be unrestricted access, the Justice Minister Katarina Barley said.

--- a/content/blog/2019/2019-01-14-topf-secret.md
+++ b/content/blog/2019/2019-01-14-topf-secret.md
@@ -2,20 +2,19 @@
 authors:
 - Stefan Wehrmeyer
 - Arne Semsrott
-date: 2019-01-14
 image:
   src: /files/blog/2019/01/topfsecret.jpg
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - TopfSecret
 type: post
 layout: post
 card: true
-published: true
-title: "Jetzt mitmachen: Topf Secret!"
+title: 'Jetzt mitmachen: Topf Secret!'
 featured: yellow
+publishedDate: 2019-01-14
 ---
 
 Heute launchen wir gemeinsam mit foodwatch „Topf Secret“ – eine Plattform gegen Geheimniskrämerei bei Lebensmittelbehörden. Auf ihr können Verbraucher*innen Ergebnisse von Hygienekontrollen in Restaurants, Bäckereien, Supermärkten & Co. abfragen.

--- a/content/blog/2019/2019-01-15-pot-secret.md
+++ b/content/blog/2019/2019-01-15-pot-secret.md
@@ -1,21 +1,20 @@
 ---
-authors: 
+authors:
 - Stefan Wehrmeyer
 - Arne Semsrott
-date: 2019-01-15
 image:
   src: /files/blog/2019/01/topfsecret.jpg
-  title: 
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - TopfSecret
 - English
 type: post
 layout: post
 card: true
-published: true
-title: "Pot Secret - Freeing thousands of Food Safety Reports"
+title: Pot Secret - Freeing thousands of Food Safety Reports
+publishedDate: 2019-01-15
 ---
 
 Yesterday we launched ["Pot Secret"](https://fragdenstaat.de/kampagnen/lebensmittelkontrolle/) ("Topf Secret" in German) - a platform against secrecy at food authorities. Consumers can use this platform to obtain the results of food safety inspections in restaurants, bakeries, supermarkets and other food-processing businesses.

--- a/content/blog/2019/2019-01-22-open-data-directive.md
+++ b/content/blog/2019/2019-01-22-open-data-directive.md
@@ -1,10 +1,9 @@
 ---
-authors: 
+authors:
 - Walter Palmetshofer
-date: 2019-01-22
 image:
   src: /files/blog/2018/10/LogoEC-el-svg.png
-  title: Open Data directive, the directive formerly known as PSI public sector information 
+  title: Open Data directive, the directive formerly known as PSI public sector information
 tags:
 - PSI
 - Policy
@@ -12,9 +11,10 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Open Data directive, the directive formerly known as PSI public sector information" 
+title: Open Data directive, the directive formerly known as PSI public sector information
+publishedDate: 2019-01-22
 ---
+
 It's done. The Provisional Agreement for the PSI Directive soon to be known as Open Data Directive (directive on Open
 Data and the re-use of public sector information) is reached.
 

--- a/content/blog/2019/2019-01-23-Stellenausschreibung-Regionale-Koordination-Jugend-hackt-Lab-Ulm.md
+++ b/content/blog/2019/2019-01-23-Stellenausschreibung-Regionale-Koordination-Jugend-hackt-Lab-Ulm.md
@@ -1,23 +1,22 @@
 ---
 authors:
 - OKF
-date: 2019-01-23
 image:
   src: /files/blog/2019/01/Stellenausschreibung_ReKoUlm.jpg
   title: Jugend hackt
-  license:
-  license_url:
+  license: null
+  license_url: null
 tags:
 - Ausschreibung
 - Jobs
 type: post
 layout: post
 card: true
-published: true
-title: "Stellenausschreibung: Regionale Koordinator*in (w/m/d) für Jugend hackt Labregion in Ulm (20h)"
-jobs: "Stellenausschreibung: Regionale Koordinator*in (w/m/d) für Jugend hackt Labregion in Ulm (20h)"
+title: 'Stellenausschreibung: Regionale Koordinator*in (w/m/d) für Jugend hackt Labregion in Ulm (20h)'
+jobs: 'Stellenausschreibung: Regionale Koordinator*in (w/m/d) für Jugend hackt Labregion in Ulm (20h)'
 aliases:
-    - /blog/2019/01/Stellenausschreibung-Regionale-Koordination-Jugend-hackt-Lab-Ulm/
+- /blog/2019/01/Stellenausschreibung-Regionale-Koordination-Jugend-hackt-Lab-Ulm/
+publishedDate: 2019-01-23
 ---
 
 ### Wer wir sind

--- a/content/blog/2019/2019-02-06-finally-open-company-data.md
+++ b/content/blog/2019/2019-02-06-finally-open-company-data.md
@@ -1,11 +1,10 @@
 ---
-authors: 
+authors:
 - Stefan Wehrmeyer
 - Arne Semsrott
-date: 2019-02-06
 image:
   src: /files/blog/2019/speicherstadt.jpg
-  title: "Hamburg. Speicherstadt"
+  title: Hamburg. Speicherstadt
   license: CC BY 2.0
   license_url: https://creativecommons.org/licenses/by/2.0/de/
 tags:
@@ -14,9 +13,10 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Finally: Open Company Data!"
+title: 'Finally: Open Company Data!'
+publishedDate: 2019-02-06
 ---
+
 Today, together with [OpenCorporates](https://blog.opencorporates.com/2019/02/06/german-company-data-now-available-for-download-via-open-knowledge-deutschland/), we make information from the German company register and its announcements accessible as open data on [OffeneRegister.de](https://offeneregister.de/). For the first time, data such as the registered office, legal form and authorised representatives of 5.1 million German companies, foundations and associations are openly and freely available on the Internet.
 
 On the website, the data can be searched centrally, downloaded and reused via the programming interface (API). Reprints from the commercial register, for which handelsregister.de charges fees, are not included in the data.

--- a/content/blog/2019/2019-02-06-handelsregister.md
+++ b/content/blog/2019/2019-02-06-handelsregister.md
@@ -2,10 +2,9 @@
 authors:
 - Stefan Wehrmeyer
 - Arne Semsrott
-date: 2019-02-06
 image:
   src: /files/blog/2019/speicherstadt.jpg
-  title: "Hamburg. Speicherstadt"
+  title: Hamburg. Speicherstadt
   license: CC BY 2.0
   license_url: https://creativecommons.org/licenses/by/2.0/de/
 tags:
@@ -13,9 +12,9 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Das Handelsregister: Endlich offene Daten!"
+title: 'Das Handelsregister: Endlich offene Daten!'
 featured: yellow
+publishedDate: 2019-02-06
 ---
 
 Gemeinsam mit der Organisation [OpenCorporates](https://opencorporates.com/) veröffentlichen wir heute auf [OffeneRegister.de](https://offeneregister.de/) Informationen aus dem Handelsregister und den Handelsregisterbekanntmachungen als offene Daten. Damit sind Daten wie Sitz, Rechtsform und vertretungsberechtigte Personen von 5,1 Millionen deutschen Firmen, Stiftungen und Vereinen erstmals offen und frei im Internet verfügbar.

--- a/content/blog/2019/2019-02-14-Offene-Daten-fuer-Alle.md
+++ b/content/blog/2019/2019-02-14-Offene-Daten-fuer-Alle.md
@@ -1,10 +1,9 @@
 ---
-authors: 
+authors:
 - Walter Palmetshofer
-date: 2019-02-14
 image:
   src: /files/blog/2019/rollup-offenedatenfueralle.png
-  title: Offene Daten für Alle 
+  title: Offene Daten für Alle
 tags:
 - PSI
 - Policy
@@ -12,9 +11,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Offene Daten für Alle" 
-
+title: Offene Daten für Alle
+publishedDate: 2019-02-14
 ---
 
 Demnächst wird in Brüssel über die Open Data Verordnung (ehemals PSI Richtlinie) abgestimmt,

--- a/content/blog/2019/2019-02-23-Open-Government-mehr-Beteiligung.md
+++ b/content/blog/2019/2019-02-23-Open-Government-mehr-Beteiligung.md
@@ -1,12 +1,11 @@
 ---
-authors: 
+authors:
 - Michael Peters
-date: 2019-02-23
 image:
   src: /files/blog/2018/08/OGP-Georgia.jpg
-  title: "OGP Georgia"
-  license:
-  license_url:
+  title: OGP Georgia
+  license: null
+  license_url: null
 tags:
 - Open Government
 - Beteiligung
@@ -14,8 +13,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Open Government in Deutschland: mehr zivilgesellschaftliche Beteiligung"
+title: 'Open Government in Deutschland: mehr zivilgesellschaftliche Beteiligung'
+publishedDate: 2019-02-23
 ---
 
 In unseren westlichen Gesellschaften sinkt das Vertrauen in die Politik. Dabei spielt insbesondere auch die Intransparenz politischer Prozesse eine Rolle. Ein faktenbasierter öffentlicher Diskurs ist in Deutschland unter anderem häufig deswegen nicht möglich, weil Informationen zurückgehalten werden. Über Horst Seehofers sogenannten »Masterplan« wurde zum Beispiel monatelang diskutiert, ohne dass das Dokument je öffentlich war. Dabei hat die Bundesregierung mit dem Open Government Ansatz schon einen möglichen Lösungsansatz entdeckt, sie muss die Umsetzung in Deutschland aber auch flächendeckend verfolgen.

--- a/content/blog/2019/2019-02-26-Open-Data-Day.md
+++ b/content/blog/2019/2019-02-26-Open-Data-Day.md
@@ -1,20 +1,19 @@
 ---
-authors: 
+authors:
 - Michael Peters
-date: 2019-02-25
 image:
   src: /files/blog/2019/odd-karlsruhe.jpg
-  title: "ODD Karlsruhe"
-  license:
-  license_url:
+  title: ODD Karlsruhe
+  license: null
+  license_url: null
 tags:
 - Open Data
 - Zivilgesellschaft
 type: post
 layout: post
 card: true
-published: true
-title: "Der Open Data Day 2019"
+title: Der Open Data Day 2019
+publishedDate: 2019-02-25
 ---
 
 Am Samstag, 2. März 2019, findet weltweit der Open Data Day statt. Weltweit wird dieser von Aktivist*innen auf der ganzen Welt genutzt, um auf die Bedeutung offener Daten hinzuweisen. Auch in diesem Jahr organisieren zahlreiche Ehrenamtliche in den Open Knowledge Labs unseres Netzwerks Code for Germany Veranstaltungen rund um offene Daten.

--- a/content/blog/2019/2019-03-20-copyright-censorship.md
+++ b/content/blog/2019/2019-03-20-copyright-censorship.md
@@ -2,10 +2,9 @@
 authors:
 - Arne Semsrott
 - Stefan Wehrmeyer
-date: 2019-03-20
 image:
   src: /files/blog/2019/03/abmahnung-blog.jpg
-  title: "Abmahnschreiben von Gleiss Lutz"
+  title: Abmahnschreiben von Gleiss Lutz
   license: CC 0
 tags:
 - Zensurheberrecht
@@ -15,8 +14,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Copyright Censorship: We Got a Cease-and-Desist by the Government "
+title: 'Copyright Censorship: We Got a Cease-and-Desist by the Government '
+publishedDate: 2019-03-20
 ---
 
 The German government has threatened us in order to depublish a government report on the risks of glyphosate. The responsible Federal Institute for Risk Assessment (BfR), which reports to the Ministry of Agriculture of Julia Klöckner (CDU), accuses us of copyright infringement and demands that we sign a cease-and-desist declaration.

--- a/content/blog/2019/2019-03-20-zensurheberrecht.md
+++ b/content/blog/2019/2019-03-20-zensurheberrecht.md
@@ -2,10 +2,9 @@
 authors:
 - Arne Semsrott
 - Stefan Wehrmeyer
-date: 2019-03-20
 image:
   src: /files/blog/2019/03/abmahnung-blog.jpg
-  title: "Abmahnschreiben von Gleiss Lutz"
+  title: Abmahnschreiben von Gleiss Lutz
   license: CC 0
 tags:
 - Zensurheberrecht
@@ -14,9 +13,9 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Zensurheberrecht: Bundesregierung mahnt uns ab, wir wehren uns"
+title: 'Zensurheberrecht: Bundesregierung mahnt uns ab, wir wehren uns'
 featured: yellow
+publishedDate: 2019-03-20
 ---
 
 [Die Bundesregierung hat FragDenStaat für die Veröffentlichung eines staatlichen Gutachtens zu den Risiken von Glyphosat abgemahnt](https://fragdenstaat.de/zensurheberrecht/). Das zuständige Bundesinstitut für Risikobewertung (BfR), das dem Landwirtschaftsministerium von Julia Klöckner (CDU) untersteht, wirft uns eine Urheberrechtsverletzung vor und fordert von uns die Unterzeichnung einer Unterlassungserklärung.

--- a/content/blog/2019/2019-04-01-beteiligt-euch-jetzt-open-government.md
+++ b/content/blog/2019/2019-04-01-beteiligt-euch-jetzt-open-government.md
@@ -1,10 +1,9 @@
 ---
-authors: 
+authors:
 - Michael Peters
-date: 2019-04-01
-image: 
+image:
   src: /files/blog/2019/auftakt-ogpde-19.jpg
-  title: "OGP Auftakt Workshop"
+  title: OGP Auftakt Workshop
   license: CC 0
 tags:
 - Open Government
@@ -13,9 +12,9 @@ tags:
 type: post
 layout: post
 card: true
-published: true
 featured: blue
-title: "Beteiligt euch jetzt: Online Konsultation Open Government"
+title: 'Beteiligt euch jetzt: Online Konsultation Open Government'
+publishedDate: 2019-04-01
 ---
 
 Die Online Konsultation der Bundesregierung zum 2. Nationalen Aktionsplan im Rahmen der Open Government Partnership ist offiziell gestartet. Hier können Bürgerinnen und Bürger Vorschläge einreichen, welche die Bundesregierung und Verwaltung offener, transparenter und partizipativer gestalten und damit die Umsetzung von Open Government in Deutschland voranbringen.

--- a/content/blog/2019/2019-04-01-offene-daten-fuer-die-digitale-jugendbeteiligung.md
+++ b/content/blog/2019/2019-04-01-offene-daten-fuer-die-digitale-jugendbeteiligung.md
@@ -1,11 +1,10 @@
 ---
-authors: 
+authors:
 - Leonard Wolf
-date: 2019-04-01
-image: 
+image:
   src: /files/blog/2019/daten.jpg
-  title: "CC BY 4.0, OKF DE, Foto: Lea Pfau"
-  license: "CC BY 4.0, OKF DE, Foto: Lea Pfau"
+  title: 'CC BY 4.0, OKF DE, Foto: Lea Pfau'
+  license: 'CC BY 4.0, OKF DE, Foto: Lea Pfau'
 tags:
 - Open Data
 - Beteiligung
@@ -13,9 +12,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Offene Daten für die digitale Jugendbeteiligung"
-
+title: Offene Daten für die digitale Jugendbeteiligung
+publishedDate: 2019-04-01
 ---
 
 Von Auskünften über die Lärmbelästigung an Straßen und Barrierefreiheit von Bahnübergängen bis hin zu Einnahmen und Ausgaben einer Gemeinde: Offene Daten helfen uns nicht nur dabei, unsere Umwelt und gesellschaftliche Prozesse besser zu verstehen, sondern ermöglichen auch eine aktive Beteiligung und politische Teilhabe. Wir zeigen, welche Potentiale offene Daten für die digitale Jugendbeteiligung haben und teilen unser Wissen, das wir in den vergangenen Monaten dazu gesammelt haben. 

--- a/content/blog/2019/2019-04-02-copyright-censorship-update.md
+++ b/content/blog/2019/2019-04-02-copyright-censorship-update.md
@@ -2,10 +2,9 @@
 authors:
 - Arne Semsrott
 - Stefan Wehrmeyer
-date: 2019-04-02
 image:
   src: /files/blog/2019/03/abmahnung-blog.jpg
-  title: "Abmahnschreiben von Gleiss Lutz"
+  title: Abmahnschreiben von Gleiss Lutz
   license: CC 0
 tags:
 - Zensurheberrecht
@@ -15,9 +14,10 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Copyright Censorship: Cologne Court orders us to take down Glyphosate Report (Update)"
+title: 'Copyright Censorship: Cologne Court orders us to take down Glyphosate Report (Update)'
+publishedDate: 2019-04-02
 ---
+
 The Cologne Regional Court has issued an injunction ordering FragDenStaat to depublish a glyphosate report from the Federal Institute for Risk Assessment. The Federal Institute that belongs to Julia Klöckner’s Agriculture Ministry had already sent us a cease-and-desist letter.
 
 The glyphosate report was financed by the state and written by civil servants. The fact that copyright is being misused as a censorship right is an attack on freedom of the press! If necessary, we will take the case to the European Court of Justice.

--- a/content/blog/2019/2019-04-02-zensurheberrecht-einstweilige-verfuegung.md
+++ b/content/blog/2019/2019-04-02-zensurheberrecht-einstweilige-verfuegung.md
@@ -2,10 +2,9 @@
 authors:
 - Arne Semsrott
 - Stefan Wehrmeyer
-date: 2019-04-02
 image:
   src: /files/blog/2019/03/abmahnung-blog.jpg
-  title: "Abmahnschreiben von Gleiss Lutz"
+  title: Abmahnschreiben von Gleiss Lutz
   license: CC 0
 tags:
 - Zensurheberrecht
@@ -14,10 +13,11 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Zensurheberrecht: Landgericht Köln zwingt FragDenStaat, staatliches Glyphosat-Gutachten zu löschen"
+title: 'Zensurheberrecht: Landgericht Köln zwingt FragDenStaat, staatliches Glyphosat-Gutachten zu löschen'
 featured: blue
+publishedDate: 2019-04-02
 ---
+
 Das Landgericht Köln hat FragDenStaat per einstweiliger Verfügung verboten, ein Glyphosat-Gutachten des Bundesinstituts für Risikobewertung zu veröffentlichen. Das staatliche Institut von Landwirtschaftsministerin Julia Klöckner hatte FragDenStaat vorher bereits abgemahnt.
 
 Das Glyphosat-Gutachten ist staatlich finanziert und von Beamten erstellt worden. Dass das Urheberrecht als Zensurheberrecht missbraucht wird, ist ein Angriff auf die Pressefreiheit! Wenn es nötig ist, ziehen wir mit dem Fall bis vor den Europäischen Gerichtshof.
@@ -33,4 +33,3 @@ FragDenStaat wird Widerspruch gegen den Beschluss des Landgerichts einlegen. Das
 → Sämtliche Dokumente und Mitmach-Button: [fragdenstaat.de/zensurheberrecht/](https://fragdenstaat.de/zensurheberrecht/)
 
 Pressekontakt: Arne Semsrott, arne.semsrott@okfn.de, Telefonnummer: 030 57703666 2
-

--- a/content/blog/2019/2019-04-04-PSI-Open-Data-Richtlinie.md
+++ b/content/blog/2019/2019-04-04-PSI-Open-Data-Richtlinie.md
@@ -1,7 +1,6 @@
 ---
 authors:
 - Walter Palmetshofer
-date: 2019-04-04
 image:
   src: /files/blog/2018/10/LogoEC-el-svg.png
   title: PSI Open Data Richtlinie
@@ -12,10 +11,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "PSI public sector information"
-
-
+title: PSI public sector information
+publishedDate: 2019-04-04
 ---
 
 **Open Data: EU öffnet Datensilos des öffentlichen Sektors**

--- a/content/blog/2019/2019-04-05-Daten-für-alle-aber-wie.md
+++ b/content/blog/2019/2019-04-05-Daten-für-alle-aber-wie.md
@@ -1,20 +1,18 @@
 ---
-authors: 
+authors:
 - Andreas Pawelke
-date: 2019-04-04
-image: 
+image:
   src: /files/blog/2019/data-types.png
-  title: "Data Types"
+  title: Data Types
   license: CC 0
 tags:
 - Data Philantropy
 - Privacy
-
 type: post
 layout: post
 card: true
-published: true
-title: "Daten für alle - aber wie?"
+title: Daten für alle - aber wie?
+publishedDate: 2019-04-04
 ---
 
 Mit ihrem Daten-für-alle-Vorschlag, also einer gesetzlichen Pflicht zum Teilen von Daten, [die insbesondere für die Tech-Riesen gelten soll](https://www.handelsblatt.com/meinung/gastbeitraege/gastkommentar-die-tech-riesen-des-silicon-valleys-gefaehrden-den-fairen-wettbewerb/22900656.html), hat die SPD eine wichtige und längst überfällige Debatte über den Wert von Unternehmensdaten angestoßen. Diese beschränkt sich bislang jedoch wahlweise auf die [Sinnhaftigkeit einer allgemeinen gesetzlichen Verpflichtung](https://twitter.com/St_Heumann/status/1101380946220208129), die [technische Machbarkeit einer vollständigen Anonymisierung](https://www.stiftung-nv.de/de/publikation/daten-fuer-alle-innovation-fuer-wenige) zum Schutz persönlicher Daten oder die rechtlichen [Einschränkungen zur Datenweitergabe durch die europäische Datenschutzgrundverordnung](https://www.gq-magazin.de/auto-technik/article/daten-fuer-alle-warum-die-digitale-enteignung-von-google-und-facebook-nichts-bringt).
@@ -52,6 +50,4 @@ Ein Mehr an Klarheit und Struktur in den Begriffsdefinitionen, Zielen und Ansät
 
 Die Komplexität des Themas gekoppelt mit der begrenzten Erfahrung in der praktischen Umsetzung schreien jedenfalls förmlich nach einem [experimentellen und iterativen Vorgehen](https://www.nesta.org.uk/feature/innovation-methods/anticipatory-regulation/), das die notwendigen rechtlichen und datenschutztechnischen Rahmenbedingungen bereitstellt, um unterschiedliche Ansätze zu testen. Statt vorzugeben man werde die genaue (regulatorische) Antwort auf eine solch komplexe Herausforderung schon finden wenn man nur lange genug debattiert und Wissenschaftler sich darüber die Köpfe zerbrechen, ist es Zeit die Realität anzuerkennen: Weder wird es [eine einzige Lösung](https://www.cigionline.org/articles/reclaiming-data-trusts) geben, noch ist es möglich [jede potentielle Nutzung der Daten (gewollt oder ungewollt)](https://www.thestar.com/opinion/contributors/2019/02/28/secure-torontos-smart-neighbourhood-in-a-trust.html) vorherzusehen und zu regulieren.
 
-[Andere](https://www.gov.uk/government/news/digital-revolution-to-use-the-power-of-data-to-combat-illegal-wildlife-trade-and-reduce-food-waste) haben das bereits erkannt und erste Pilotprojekte gestartet, um genau jene praktischen Erfahrungen zu machen, die für eine effektive Regelsetzung zwingend notwendig sind. Die SPD wäre gut darin beraten, ein ähnliches Vorgehen zu wählen. Und vielleicht findet die Partei dadurch ja doch eine Möglichkeit, die Marktmacht der großen Tech-Unternehmen zu begrenzen. Dazu die [Ökonomin Mariana Mazzucato](https://www.technologyreview.com/s/611489/lets-make-private-data-into-a-public-good/%0A): "There is indeed no reason why the public’s data should not be owned by a public repository that sells the data to the tech giants, rather than vice versa.” 
-
-
+[Andere](https://www.gov.uk/government/news/digital-revolution-to-use-the-power-of-data-to-combat-illegal-wildlife-trade-and-reduce-food-waste) haben das bereits erkannt und erste Pilotprojekte gestartet, um genau jene praktischen Erfahrungen zu machen, die für eine effektive Regelsetzung zwingend notwendig sind. Die SPD wäre gut darin beraten, ein ähnliches Vorgehen zu wählen. Und vielleicht findet die Partei dadurch ja doch eine Möglichkeit, die Marktmacht der großen Tech-Unternehmen zu begrenzen. Dazu die [Ökonomin Mariana Mazzucato](https://www.technologyreview.com/s/611489/lets-make-private-data-into-a-public-good/%0A): "There is indeed no reason why the public’s data should not be owned by a public repository that sells the data to the tech giants, rather than vice versa.”

--- a/content/blog/2019/2019-04-10-digitalisierung-jugendarbeit-erfahrungen-demokratielabore.md
+++ b/content/blog/2019/2019-04-10-digitalisierung-jugendarbeit-erfahrungen-demokratielabore.md
@@ -1,11 +1,10 @@
 ---
 authors:
 - Demokratielabore-Team
-date: 2019-04-10
 image:
   src: /files/blog/2019/Essen.jpg
-  title: "CC BY 4.0, OKF DE, Foto: Lea Pfau"
-  license: "CC BY 4.0, OKF DE, Foto: Lea Pfau"
+  title: 'CC BY 4.0, OKF DE, Foto: Lea Pfau'
+  license: 'CC BY 4.0, OKF DE, Foto: Lea Pfau'
   license_url: https://creativecommons.org/licenses/by/4.0/
 tags:
 - Digitalisierung
@@ -13,8 +12,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Digitalisierung in der Jugendarbeit - unsere Erfahrungen mit den Demokratielaboren"
+title: Digitalisierung in der Jugendarbeit - unsere Erfahrungen mit den Demokratielaboren
+publishedDate: 2019-04-10
 ---
 
 Die Digitalisierung ist insbesondere im schulischen und außerschulischen Bereich ein viel diskutiertes Thema - von der Infrastruktur bis hin zu digitalen Kompetenzen. Doch wie wirkt sich die Digitalisierung konkret auf die Jugendarbeit aus? Wo gibt es Bedarfe und Potentiale? Und welche Tools und Methoden funktionieren besonders gut? Im Rahmen der [Demokratielabore](https://demokratielabore.de) konnten wir hierzu zahlreiche Erfahrungen sammeln, die wir mit euch teilen wollen. 

--- a/content/blog/2019/2019-05-02-transparenzgesetz-berlin-startet.md
+++ b/content/blog/2019/2019-05-02-transparenzgesetz-berlin-startet.md
@@ -2,10 +2,9 @@
 authors:
 - Arne Semsrott
 - Leonard Wolf
-date: 2019-05-02
 image:
   src: /files/blog/2019/05/transparenzgesetz-berlin.jpg
-  title: "Das Rathaus muss bald transparenter werden"
+  title: Das Rathaus muss bald transparenter werden
   license: CC 0
 tags:
 - Berlin
@@ -13,10 +12,11 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Ein Transparenzgesetz für Berlin: Volksbegehren startet im Juli"
+title: 'Ein Transparenzgesetz für Berlin: Volksbegehren startet im Juli'
 featured: blue
+publishedDate: 2019-05-02
 ---
+
 Milliardenschwere Bauvorhaben, Geheimverträge mit der Wirtschaft und Einflussnahme von Lobbyist*innen: Ein Bündnis zivilgesellschaftlicher Organisationen will jetzt Licht ins Dunkel der Berliner Verwaltung bringen. Dafür hat es ein eigenes Transparenzgesetz auf den Weg gebracht, das das Recht auf Informationen des Staates in Zukunft weitreichend stärken soll.
 
 Das <a href="https://volksentscheid-transparenz.de/">Bündnis Volksentscheid Transparenz</a>, zu dem unter anderem die Open Knowledge Foundation Deutschland, Mehr Demokratie, der Chaos Computer Club und die Digitale Gesellschaft zählen, hat dem Senat im April <a href="https://volksentscheid-transparenz.de/documents/BerlTG-E-6_clean.pdf">einen Gesetzentwurf vorgelegt</a>, nach dem Berliner Landes- und Bezirksbehörden proaktiv Informationen in einem zentralen Transparenzportal offenlegen müssen. Dazu zählen zum Beispiel Senatsbeschlüsse, Gutachten, Planungsunterlagen, Sponsoring-, Bau- und Umweltdaten sowie der Quelltext von Computerprogrammen der Verwaltung. Verträge über 100.000 Euro, die das Land Berlin oder die Bezirke schließen, müssten einen Monat vor Inkrafttreten veröffentlicht werden. Außerdem sollen Angaben zu Treffen von Regierungsmitgliedern mit Lobbyistinnen im Transparenzregister zu finden sein.

--- a/content/blog/2019/2019-05-03-transparenzregister-mit-open-data-geldwaesche-bekaempfen.md
+++ b/content/blog/2019/2019-05-03-transparenzregister-mit-open-data-geldwaesche-bekaempfen.md
@@ -1,10 +1,9 @@
 ---
 authors:
 - Michael Peters
-date: 2019-05-03
 image:
   src: /files/blog/2018/06/tale-of-three-men.jpg
-  title: "frankieleon, A tale of three men"
+  title: frankieleon, A tale of three men
   license: CC-BY
   license_url: https://creativecommons.org/licenses/by/2.0/
 tags:
@@ -15,10 +14,11 @@ tags:
 type: post
 layout: post
 card: true
-published: true
 featured: blue
-title: "Transparenzregister: Mit Open Data Geldwäsche bekämpfen"
+title: 'Transparenzregister: Mit Open Data Geldwäsche bekämpfen'
+publishedDate: 2019-05-03
 ---
+
 ### Donnerstag, 16. Mai 2019 | 13:00 – 14:30 Uhr Hotel nhow | Stralauer Allee 3 | 10245 Berlin-Friedrichshain
 #### Eine gemeinsame Veranstaltung von Transparency Deutschland und Open Knowledge Foundation Deutschland e.V.
 

--- a/content/blog/2019/2019-05-06-okfde-auf-der-rp19.md
+++ b/content/blog/2019/2019-05-06-okfde-auf-der-rp19.md
@@ -1,10 +1,9 @@
 ---
-authors: 
+authors:
 - OKFDE
-date: 2019-05-06
 image:
   src: /files/blog/2019/05/rp19_fyi2.jpg
-  title: re:publica 2019  
+  title: re:publica 2019
   license: CC-BY-SA
   license_url: https://creativecommons.org/licenses/by-sa/2.0/
 tags:
@@ -12,8 +11,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "OKFDE auf der re:publica 2019" 
+title: OKFDE auf der re:publica 2019
+publishedDate: 2019-05-06
 ---
 
 ## [tl;dr](https://19.re-publica.com/de/page/tldr): kurze Übersicht 
@@ -35,4 +34,3 @@ Mit 11 Beiträgen war die OKF in diesem Jahr vertreten. Vom traditionellen “St
 * [citylab Vorstellung - Adriana Groh & Benjamin Seibel](https://19.re-publica.com/en/session/citylab-berlin-vorstellung)
 * [openschufa - Lea Pfau & Patrick Stotz](https://19.re-publica.com/en/session/openschufa-resultate)
 * [Manifesto for technological sovereignty and digital rights for cities - Francesa Bria, Katalin Gennburg & Walter Palmetshofer](https://19.re-publica.com/en/session/manifesto-technological-sovereignty-digital-rights-cities)
-

--- a/content/blog/2019/2019-05-15-engagement-von-jugendlichen-im-digitalen-zeitalter.md
+++ b/content/blog/2019/2019-05-15-engagement-von-jugendlichen-im-digitalen-zeitalter.md
@@ -1,10 +1,9 @@
 ---
 authors:
 - Paula Grünwald
-date: 2019-05-15
 image:
   src: /files/blog/2019/05/paula-blog.jpg
-  title: "Paula"
+  title: Paula
   license: CC-BY Jugend hackt
   license_url: https://creativecommons.org/licenses/by/4.0/
 tags:
@@ -14,10 +13,11 @@ tags:
 type: post
 layout: post
 card: true
-published: true
 featured: blue
-title: "Engagement von Jugendlichen im digitalen Zeitalter"
+title: Engagement von Jugendlichen im digitalen Zeitalter
+publishedDate: 2019-05-15
 ---
+
 *Paula Grünwald, eine der drei Programmleitungen von Jugend hackt, wurde am 26.03.2019 als Expertin von der Sachverständigenkommission für den [Dritten Engagementbericht „Zukunft der Zivilgesellschaft: Junges Engagement im digitalen Zeitalter“](http://www.dritterengagementbericht.de/) eingeladen. Weil ihr dort vorgetragenes Statement einige für uns wichtige Forderungen enthält, veröffentlichen wir es auch an dieser Stelle*.
 
 ### Die Fragestellung: „Wie verändert sich aus Ihrer Sicht das Engagement von Jugendlichen und jungen Erwachsenen vor dem Hintergrund der Digitalisierung? Welche Herausforderungen und Vorteile ergeben sich dadurch für Ihre Arbeit?“

--- a/content/blog/2019/2019-05-20-Veranstaltungsbericht-Transparenzregister.md
+++ b/content/blog/2019/2019-05-20-Veranstaltungsbericht-Transparenzregister.md
@@ -2,10 +2,9 @@
 authors:
 - OKF
 - TI
-date: 2019-05-20
 image:
   src: /files/blog/2019/05/veranstaltung-okf-ti.JPG
-  title: "Podiumsdiskussion"
+  title: Podiumsdiskussion
   license: CC-BY
   license_url: https://creativecommons.org/licenses/by/2.0/
 tags:
@@ -16,10 +15,11 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-featured:
-title: "Veranstaltungsbericht: Mit Open Data Geldwäsche bekämpfen"
+featured: null
+title: 'Veranstaltungsbericht: Mit Open Data Geldwäsche bekämpfen'
+publishedDate: 2019-05-20
 ---
+
 ### Donnerstag, 16. Mai 2019 | 13:00 – 14:30 Uhr Hotel nhow | Stralauer Allee 3 | 10245 Berlin-Friedrichshain
 #### Eine gemeinsame Veranstaltung von Transparency Deutschland und Open Knowledge Foundation Deutschland e.V.
 

--- a/content/blog/2019/2019-05-23-wechsel-gf.md
+++ b/content/blog/2019/2019-05-23-wechsel-gf.md
@@ -1,12 +1,11 @@
 ---
-authors: 
+authors:
 - OKF
-date: 2019-06-10
 image:
   src: /files/blog/2017/07/OKFDE_Logo_black.png
-  title: "Open Knowledge Foundation Deutschland"
-  license:
-  license_url: 
+  title: Open Knowledge Foundation Deutschland
+  license: null
+  license_url: null
 tags:
 - Geschäftsführung
 - In eigener Sache
@@ -14,9 +13,9 @@ tags:
 type: post
 layout: post
 card: true
-published: true
 featured: blue
-title: "In eigener Sache: Wechsel der Geschäftsführung bei der Open Knowledge Foundation Deutschland" 
+title: 'In eigener Sache: Wechsel der Geschäftsführung bei der Open Knowledge Foundation Deutschland'
+publishedDate: 2019-06-10
 ---
 
 *Nach zwei Jahren als Geschäftsführerin verlässt Nadine Evers Mitte Juni die Open Knowledge Foundation Deutschland e.V.  

--- a/content/blog/2019/2019-06-09-OKF-Jahresbericht+Webseite.md
+++ b/content/blog/2019/2019-06-09-OKF-Jahresbericht+Webseite.md
@@ -3,21 +3,20 @@ authors:
 - Bela Seeger
 - Nadine Stammen
 - Lisa Passing
-date: 2019-06-09
 image:
   src: /files/blog/2019/06/websitescreenshot.png
-  title: "Webseitenredesign"
+  title: Webseitenredesign
   license: CC-BY
   license_url: https://creativecommons.org/licenses/by/4.0/
-tags:
-
+tags: null
 type: post
 layout: post
 card: true
-published: true
 featured: blue
-title: "OKF Jahresbericht 2018 + Webseite Redesign!"
+title: OKF Jahresbericht 2018 + Webseite Redesign!
+publishedDate: 2019-06-09
 ---
+
 ## Webseiten-Redesign
 
 Anfang des Jahres haben wir unsere Webseite grundlegend überarbeitet. Dazu haben wir Zielgruppeninterviews geführt, Nutzerberichte gesammelt und mit Hilfe des Teams an Prototypen gearbeitet. Neben unzähligen Feinheiten und Details haben wir daraufhin alle Sektionen inhaltlich und gestalterisch aktualisiert. Dabei ist unter anderem die neue [Profil-Sektion](/profil) entstanden, die unsere [Themen](/themen) (in welchen Bereichen arbeiten wir?) mit Zielen und Tätigkeiten ergänzt (was *tun* wir?). Auch haben wir uns auch die englischen Version unserer Webseite vorgenommen und diese aufpoliert (Danke Eileen Wagner!). Auf technischer Ebene sind wir von jekyll zu hugo gewechselt. 
@@ -35,4 +34,4 @@ Neben Informationen zu unserer Organisation, unseren Finanzen und Projekten find
 
 ### ⇒ [2018.okfn.de](https://2018.okfn.de)
 
-Viel Spaß beim schmökern wünscht das Team der OKF! 
+Viel Spaß beim schmökern wünscht das Team der OKF!

--- a/content/blog/2019/2019-06-18-projektmanagerin-fragdenstaat.md
+++ b/content/blog/2019/2019-06-18-projektmanagerin-fragdenstaat.md
@@ -1,12 +1,11 @@
 ---
-authors: 
+authors:
 - Arne Semsrott
-date: 2019-06-18
 image:
   src: /files/jobs/fds1.png
-  title: "FragDenStaat-Logo"
-  license:
-  license_url: 
+  title: FragDenStaat-Logo
+  license: null
+  license_url: null
 tags:
 - FragDenStaat
 - In eigener Sache
@@ -14,9 +13,9 @@ tags:
 type: post
 layout: post
 card: true
-published: true
 featured: blue
-title: "Neue Stelle bei FragDenStaat: Wir suchen Projektmanager*in! (75-100%, ab August 2019)"
+title: 'Neue Stelle bei FragDenStaat: Wir suchen Projektmanager*in! (75-100%, ab August 2019)'
+publishedDate: 2019-06-18
 ---
 
 ## Wer wir sind

--- a/content/blog/2019/2019-06-25-ausschreibung-geschaeftsfuehrung.md
+++ b/content/blog/2019/2019-06-25-ausschreibung-geschaeftsfuehrung.md
@@ -1,20 +1,18 @@
 ---
 authors:
 - OKF
-date: 2019-06-24
 image:
   src: /files/blog/2019/06/team-foto.jpg
-  title: "OKF Team 2018"
+  title: OKF Team 2018
   license: CC-BY
   license_url: https://creativecommons.org/licenses/by/2.0/
-tags:
-
+tags: null
 type: post
 layout: post
 card: true
-published: true
 featured: blue
-title: "Wir suchen eine*n Geschäftsführer*in, Bewerbungsfrist 28.07."
+title: Wir suchen eine*n Geschäftsführer*in, Bewerbungsfrist 28.07.
+publishedDate: 2019-06-24
 ---
 
 Die **Open Knowledge Foundation Deutschland (OKF)** setzt sich seit 2011 erfolgreich für dezentrale Teilhabe, offenes Wissen, digitales zivilgesellschaftliches Engagement und offene Innovation ein. Um die Wirksamkeit der OKF zu stärken und die Organisation in enger Zusammenarbeit mit Team und Board weiterzuentwickeln, suchen wir zum nächstmöglichen Zeitpunkt eine neue **Geschäftsführung (in Vollzeit)**.

--- a/content/blog/2019/2019-06-27-privatsphaere-oder-oeffentliches-interesse.md
+++ b/content/blog/2019/2019-06-27-privatsphaere-oder-oeffentliches-interesse.md
@@ -1,10 +1,9 @@
 ---
 authors:
 - Michael Peters
-date: 2019-06-27
 image:
   src: /files/blog/2018/06/tale-of-three-men.jpg
-  title: "frankieleon, A tale of three men"
+  title: frankieleon, A tale of three men
   license: CC-BY
   license_url: https://creativecommons.org/licenses/by/2.0/
 tags:
@@ -16,8 +15,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Privatsphäre oder öffentliches Interesse?"
+title: Privatsphäre oder öffentliches Interesse?
+publishedDate: 2019-06-27
 ---
 
 ### Ein Plädoyer für öffentliche Informationen zu wirtschaftlichen Eigentümern

--- a/content/blog/2019/2019-06-28-offener-Brief-zum-Vergabefall-HABA-Digital.md
+++ b/content/blog/2019/2019-06-28-offener-Brief-zum-Vergabefall-HABA-Digital.md
@@ -1,10 +1,9 @@
 ---
 authors:
 - Maximilian Voigt
-date: 2019-06-28
 image:
   src: /files/blog/2019/06/NRW_Schulministerium.jpg
-  title: "Ministerium für Schule und Bildung des Landes Nordrhein-Westfalen"
+  title: Ministerium für Schule und Bildung des Landes Nordrhein-Westfalen
   license: CC-BY
   license_url: https://creativecommons.org/licenses/by/2.0/
 tags:
@@ -13,9 +12,9 @@ tags:
 type: post
 layout: post
 card: true
-published: true
 featured: blue
-title: "Offener Brief an NRW nach fragwürdigem Auftrag an FDP-Großspenderin"
+title: Offener Brief an NRW nach fragwürdigem Auftrag an FDP-Großspenderin
+publishedDate: 2019-06-28
 ---
 
 In einem [Offenen Brief](https://github.com/okfde/okfn.de/blob/master/static/files/blog/2019/06/Offener%20Brief_Vergabeprozess%20Projekt%20_MobiDigNRW.pdf) zum Vergabeprozess des Projektes “Mobile Digitalwerkstatt” problematisieren wir gemeinsam mit zahlreichen Akteurinnen und Akteuren der Bildungspraxis kommerzielle Abhängigkeiten im Bildungsbereich. Anlässlich der [umstrittenen Beauftragung von HABA Digital](https://www.abgeordnetenwatch.de/blog/2019-06-28/fragwuerdiger-auftrag-fdp-grossspenderin) durch das FDP geführte Ministerium für Schule und Bildung des Landes Nordrhein-Westfalen fordern wir:
@@ -29,4 +28,4 @@ In einem [Offenen Brief](https://github.com/okfde/okfn.de/blob/master/static/fil
 * die Förderung einer nachhaltigen Zusammenarbeit auf Basis bestehender Strukturen sowie 
 * frei zugängliche Bildung und Schutz der Bildung vor lobbyistischen Einflüssen. 
 
-Bildung ist Gemeingut und sollte somit für alle zugänglich sein. Insbesondere vor dem Hintergrund des Digitalpaktes Schule ist es umso wichtiger, den Wettbewerb um die Förderungen gerecht zu gestalten und insbesondere nachhaltige, offene Ansätze zu berücksichtigen. Investitionen, die kurzsichtig in geschlossene und proprietäre Systeme getätigt werden, erschweren oder verhindern langfristig freie Bildung und stellen Abhängigkeiten her. 
+Bildung ist Gemeingut und sollte somit für alle zugänglich sein. Insbesondere vor dem Hintergrund des Digitalpaktes Schule ist es umso wichtiger, den Wettbewerb um die Förderungen gerecht zu gestalten und insbesondere nachhaltige, offene Ansätze zu berücksichtigen. Investitionen, die kurzsichtig in geschlossene und proprietäre Systeme getätigt werden, erschweren oder verhindern langfristig freie Bildung und stellen Abhängigkeiten her.

--- a/content/blog/2019/2019-07-18-Bits-und-Baeume-Publikation.md
+++ b/content/blog/2019/2019-07-18-Bits-und-Baeume-Publikation.md
@@ -2,10 +2,9 @@
 authors:
 - Juliane Krüger
 - Michael Peters
-date: 2019-07-18
 image:
   src: /files/blog/2019/07/BUB.png
-  title: "Bits&Bäume Logo"
+  title: Bits&Bäume Logo
   license: CC BY Schauschau
   license_url: https://creativecommons.org/licenses/by/3.0/
 tags:
@@ -18,8 +17,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Öffentliche Daten nützen – Umwelt schützen und Zivilgesellschaft stützen"
+title: Öffentliche Daten nützen – Umwelt schützen und Zivilgesellschaft stützen
+publishedDate: 2019-07-18
 ---
 
 _Eine leicht gekürzte Version dieses Artikels und viele weitere spannende Texte zur Schnittstelle von Digitalisierung und Nachhaltigkeit findet ihr in der frisch erschienenen Publikation des Konferenzteams [Bits&Bäume](https://bits-und-baeume.org/de): [„Was Bits und Bäume verbindet“](https://www.oekom.de/nc/buecher/gesamtprogramm/buch/was-bits-und-baeume-verbindet.html) – in Papierform und als pdf unter freier Lizenz._ 

--- a/content/blog/2019/2019-07-18-Offene-Daten-KI.md
+++ b/content/blog/2019/2019-07-18-Offene-Daten-KI.md
@@ -1,10 +1,9 @@
 ---
 authors:
 - Elisa Lindinger
-date: 2019-07-18
 image:
   src: /files/blog/2019/roboter.jpg
-  title: "Photo by Daniel Cheung on Unsplash"
+  title: Photo by Daniel Cheung on Unsplash
   license: Unsplash License
   license_url: https://unsplash.com/license
 tags:
@@ -13,8 +12,8 @@ tags:
 type: post
 layout: post
 card: true
-published: true
-title: "Öffentliche Daten und Künstliche Intelligenz – Unsere Kernthesen für die Enquete-Kommission"
+title: Öffentliche Daten und Künstliche Intelligenz – Unsere Kernthesen für die Enquete-Kommission
+publishedDate: 2019-07-18
 ---
 
 Im Rahmen der [Enquete-Kommission](https://www.bundestag.de/ausschuesse/weitere_gremien/enquete_ki) “Künstliche Intelligenz – Gesellschaftliche Verantwortung und wirtschaftliche, soziale und ökologische Potenziale” haben wir unsere Einschätzung dazu abgegeben, wie öffentliche Daten für eine sinnvolle Nutzung durch KI-Anwendungen bereitgestellt werden müssen. Hier sind unsere Kernthesen, die wir der Kommission bei ihrer Sitzung am 3. Juni 2019 unterbreitet haben: 
@@ -39,4 +38,4 @@ Auch öffentliche Daten können personenbezogen sein und deshalb eine Herausford
 - Gerade für die Entwicklung von Technologien mit großem Impact brauchen wir flexiblere und mutigere Formen von öffentlicher Förderung, die es der Zivilgesellschaft ermöglicht, diese Entwicklung zu beeinflussen.
 
 
-Die Sitzung kann [auf der Webseite des Bundestags](https://www.bundestag.de/dokumente/textarchiv/2019/kw23-pa-enquete-ki-644010) nachgeschaut werden. 
+Die Sitzung kann [auf der Webseite des Bundestags](https://www.bundestag.de/dokumente/textarchiv/2019/kw23-pa-enquete-ki-644010) nachgeschaut werden.

--- a/content/blog/2019/2019-08-05-ausschreibung-jh-pl.md
+++ b/content/blog/2019/2019-08-05-ausschreibung-jh-pl.md
@@ -1,20 +1,18 @@
 ---
 authors:
 - Paula Grünwald
-date: 2019-08-05
 image:
   src: /files/blog/2019/31632708378_9e627e19eb_z.jpg
-  title: "Sonja und Daniel vom Jugend hackt Programmleitungsteam"
+  title: Sonja und Daniel vom Jugend hackt Programmleitungsteam
   license: CC-BY
   license_url: https://creativecommons.org/licenses/by/4.0/
-tags:
-
+tags: null
 type: post
 layout: post
 card: true
-published: true
 featured: blue
-title: "Verstärke das Programmleitungsteam von Jugend hackt (80-100%, Bewerbungsschluss 10.10.2019)"
+title: Verstärke das Programmleitungsteam von Jugend hackt (80-100%, Bewerbungsschluss 10.10.2019)
+publishedDate: 2019-08-05
 ---
 
 [Jugend hackt](https://jugendhackt.org/) ist ein preisgekröntes Förderprogramm für programmier- und making-begeisterte Jugendliche zwischen 12 und 18 Jahren, die “mit Code die Welt verbessern” wollen. Jugend hackt ist ein gemeinsames Programm der Open Knowledge Foundation Deutschland e.V. mit mediale pfade.org - Verein für Medienbildung e.V. 

--- a/content/blog/2019/2019-09-04-bundesregierung-macht-kleine-fortschritte-auf-großer-baustelle.md
+++ b/content/blog/2019/2019-09-04-bundesregierung-macht-kleine-fortschritte-auf-großer-baustelle.md
@@ -1,20 +1,18 @@
 ---
 authors:
 - Michael Peters
-date: 2019-09-04
 image:
   src: /files/blog/2017/09/kanzleramt-cc0.jpg
-  title: "Bundeskanzleramt"
+  title: Bundeskanzleramt
   license: CC-0
   license_url: https://creativecommons.org/share-your-work/public-domain/cc0/
-tags:
-
+tags: null
 type: post
 layout: post
 card: true
-published: true
 featured: blue
-title: "Bundesregierung macht kleine Fortschritte auf großer Baustelle"
+title: Bundesregierung macht kleine Fortschritte auf großer Baustelle
+publishedDate: 2019-09-04
 ---
 
 Berlin 04.09.2019 - Unter dem Vorsitz von Bundeskanzlerin Angela Merkel hat das Bundeskabinett heute den 2. Nationalen Aktionsplan Open Government (2019-21) beschlossen. Der Bund bekennt sich bis 2021 zu neun Verpflichtungen, um ein offenes Regierungs- und Verwaltungshandeln mit Transparenz, offenen Daten und Bürgerbeteiligung dauerhaft zu verankern. Hinzu kommen fünf Verpflichtungen von Seiten der Länder Nordrhein-Westfalen, Sachsen und Schleswig-Holstein. [Bereits am Wochenende](https://www.youtube.com/watch?v=veJl8cL6HYM) kündigte die Kanzlerin den 2. Nationalen Aktionsplan an. Diese hochrangige politische Verortung des Themas begrüßen wir ausdrücklich.

--- a/content/blog/2019/2019-09-28-tag-der-informationsfreiheit-kunst.md
+++ b/content/blog/2019/2019-09-28-tag-der-informationsfreiheit-kunst.md
@@ -1,20 +1,18 @@
 ---
 authors:
 - Arne Semsrott
-date: 2019-09-28
 image:
   src: /files/blog/2019/09/000000-2019.jpg
-  title: "Bundeskanzleramt"
+  title: Bundeskanzleramt
   license: CC-0
   license_url: https://creativecommons.org/share-your-work/public-domain/cc0/
-tags:
-
+tags: null
 type: post
 layout: post
 card: true
-published: true
 featured: blue
-title: "Tag der Informationsfreiheit: Geschwärzte Kunst"
+title: 'Tag der Informationsfreiheit: Geschwärzte Kunst'
+publishedDate: 2019-09-28
 ---
 
 Der 28. September ist der internationale Tag der Informationsfreiheit. Wir feiern den Tag wie jedes Jahr mit einer neuen Kunstedition – diesmal mit drei Klassikern.

--- a/content/blog/2019/2019-09-30-Parlamentarisches-Frühstück-Open-Government.md
+++ b/content/blog/2019/2019-09-30-Parlamentarisches-Frühstück-Open-Government.md
@@ -1,21 +1,19 @@
 ---
 authors:
 - Michael Peters
-date: 2019-09-30
 image:
   src: /files/blog/2019/09/bundestag.jpg
-  title: "Das Reichstagsgebäude - Jürgen Matern"
+  title: Das Reichstagsgebäude - Jürgen Matern
   license: CC BY-SA 3.0
   license_url: https://creativecommons.org/licenses/by-sa/3.0/
-tags:
-
+tags: null
 type: post
 layout: post
 card: true
-published: true
 featured: blue
-title: "Parlamentarisches Frühstück zu Open Government"
-url: "/blog/2019/09/parlamentarisches-fruehstueck-open-gov/"
+title: Parlamentarisches Frühstück zu Open Government
+url: /blog/2019/09/parlamentarisches-fruehstueck-open-gov/
+publishedDate: 2019-09-30
 ---
 
 ### Mittwoch 16.10.2019, 8:00 - 9:15, Bundestag, Paul-Löbe-Haus (Raum 5.101 / 102)

--- a/content/blog/2019/2019-10-08-volksentscheid-endspurt.md
+++ b/content/blog/2019/2019-10-08-volksentscheid-endspurt.md
@@ -1,17 +1,15 @@
 ---
 authors:
 - Arne Semsrott
-date: 2019-10-08
 image:
   src: /files/blog/2019/10/liste-stift-volksentscheid.jpg
-tags:
-
+tags: null
 type: post
 layout: post
 card: true
-published: true
 featured: blue
-title: "Endspurt: Jetzt noch fürs Transparenzgesetz unterschreiben!"
+title: 'Endspurt: Jetzt noch fürs Transparenzgesetz unterschreiben!'
+publishedDate: 2019-10-08
 ---
 
 Noch bis zum 31. Oktober sammeln wir Unterschriften für den Volksentscheid. Bitte ladet euch jetzt die Unterschriftenliste herunter, [sammelt fünf Unterschriften und schickt sie uns](https://volksentscheid-transparenz.de/mitmachen/)!

--- a/content/blog/2019/2019-10-12-berlin-open-data-day-2019-BODDy.md
+++ b/content/blog/2019/2019-10-12-berlin-open-data-day-2019-BODDy.md
@@ -1,17 +1,15 @@
 ---
 authors:
 - Bela Seeger
-date: 2019-10-12
 image:
   src: /files/blog/2019/10/BODDy.png
-tags:
-
+tags: null
 type: post
 layout: post
 card: true
-published: true
 featured: blue
-title: "Einladung: Berlin Open Data Day am 5. November"
+title: 'Einladung: Berlin Open Data Day am 5. November'
+publishedDate: 2019-10-12
 ---
 
 Der Berlin Open Data Day 2019 findet am 5. November unter dem Thema 'Intelligent Data' statt. 

--- a/content/blog/2019/2019-10-17-forum-offene-stadt-code-for-germany-summit.md
+++ b/content/blog/2019/2019-10-17-forum-offene-stadt-code-for-germany-summit.md
@@ -1,21 +1,19 @@
 ---
 authors:
 - Julia Thomaschki
-date: 2019-10-17
 image:
   src: /files/blog/2019/10/summit-fos-pic.png
-  title: "FOS19-CFGSummit"
+  title: FOS19-CFGSummit
   license: CC BY 4.0
   license_url: https://creativecommons.org/licenses/by/4.0/
-tags:
-
+tags: null
 type: post
 layout: post
 card: true
-published: true
 featured: blue
-title: "FORUM Offene Stadt & Code for Germany Summit"
-url: "/blog/2019/10/forum-offene-stadt-code-for-germany-summit/"
+title: FORUM Offene Stadt & Code for Germany Summit
+url: /blog/2019/10/forum-offene-stadt-code-for-germany-summit/
+publishedDate: 2019-10-17
 ---
 
 Sommer Adieu, Hello Herbst!

--- a/content/blog/2019/2019-10-31-community-stelle-code-for-germany.md
+++ b/content/blog/2019/2019-10-31-community-stelle-code-for-germany.md
@@ -1,17 +1,16 @@
 ---
 authors:
 - Michael Peters
-date: 2019-10-31
 image:
   src: /files/blog/2019/10/CFG_logo.png
-  title: "CodeforGermany-logo"
-  license:
-  license_url:
+  title: CodeforGermany-logo
+  license: null
+  license_url: null
 type: post
 layout: post
 card: true
-published: true
-title: "Neuer Job bei Code for Germany: Wir suchen Communitybuilder*in! (80%, ab Januar 2020)"
+title: 'Neuer Job bei Code for Germany: Wir suchen Communitybuilder*in! (80%, ab Januar 2020)'
+publishedDate: 2019-10-31
 ---
 
 [Code for Germany](https://codefor.de/) ist eine deutschlandweite Community, die sich dafür einsetzt, das Potenzial der Digitalisierung für alle Menschen zugänglich zu machen. In 26 Städten treffen sich dazu technisch interessierte Menschen, um in den Open Knowledge Labs (kurz: OK Labs) zu coden, zu diskutieren und sich mit Bürger\*innen und politischen Vertreter\*innen auszutauschen.

--- a/content/blog/2019/2019-10-31-juristin-fragdenstaat.md
+++ b/content/blog/2019/2019-10-31-juristin-fragdenstaat.md
@@ -1,18 +1,16 @@
 ---
-authors: 
+authors:
 - Arne Semsrott
-date: 2019-10-31
 image:
   src: /files/jobs/fds1.png
-  title: "FragDenStaat-Logo"
-  license:
-  license_url:
+  title: FragDenStaat-Logo
+  license: null
+  license_url: null
 type: post
 layout: post
 card: true
-published: true
-published: true
-title: "Neuer Job bei FragDenStaat: Wir suchen Jurist*in! (60-100%, ab Februar 2020)" 
+title: 'Neuer Job bei FragDenStaat: Wir suchen Jurist*in! (60-100%, ab Februar 2020)'
+publishedDate: 2019-10-31
 ---
 
 ## Wer wir sind

--- a/content/blog/2019/2019-11-08-abc-der-offenheit.md
+++ b/content/blog/2019/2019-11-08-abc-der-offenheit.md
@@ -1,18 +1,18 @@
 ---
 authors:
 - OKF
-date: 2019-11-08
 image:
   src: /files/blog/2019/11/abc-offenheit-klein.jpg
-  title: "ABC der Offenheit"
+  title: ABC der Offenheit
   license: cc0
   license_url: https://creativecommons.org/share-your-work/public-domain/cc0/
 type: post
 layout: post
 card: true
-published: true
-title: "Das ABC der Offenheit"
+title: Das ABC der Offenheit
+publishedDate: 2019-11-08
 ---
+
 ### Was ist OPEN? Diese und andere Fragen beantwortet das ABC der Offenheit, eine [neu aufgelegte Broschüre](https://upload.wikimedia.org/wikipedia/commons/a/a9/ABC_der_Offenheit_-_Brosch%C3%BCre_%282019%29.pdf) von Wikimedia und Open Knowledge Foundation Deutschland.
 
 Open Data, Open Education, Open Government - Es gibt viele Bereiche, in denen Offenheit gefordert wird. Doch was bedeutet das eigentlich jeweils genau? Eine neu aufgelegte Broschüre von OKF und Wikimedia soll einen Einstieg in die Open-Welt bieten und die wichtigsten Fragen rund um freie Lizenzen klären.

--- a/content/blog/2019/2019-11-12-is-germany-ready-for-the-ogp-steering-committee.md
+++ b/content/blog/2019/2019-11-12-is-germany-ready-for-the-ogp-steering-committee.md
@@ -1,19 +1,19 @@
 ---
 authors:
 - Michael Peters
-date: 2019-11-12
 image:
   src: /files/blog/2019/11/reichstag-juergen-matern.jpg
-  title: "Reichstag"
+  title: Reichstag
   license: CC BY-SA 3.0
   license_url: https://creativecommons.org/licenses/by-sa/3.0
 type: post
 layout: post
 card: true
-published: true
 featured: blue
-title: "Is Germany ready for the OGP Steering Committee?"
+title: Is Germany ready for the OGP Steering Committee?
+publishedDate: 2019-11-12
 ---
+
 ### A critical review of the 2nd national action plan
 
 In October 2019 Germany is officially joining OGP’s steering committee, together with Indonesia. However, after the release of the second national action plan, the steering committee seems like premature praise. Or what us Germans would call it: Vorschusslorbeeren, which literally translates to receiving a roman laurel — before you’ve won the competition.

--- a/content/blog/2019/2019-11-22-umweltdatenschule-oekostrom-in-deutschland.md
+++ b/content/blog/2019/2019-11-22-umweltdatenschule-oekostrom-in-deutschland.md
@@ -1,19 +1,19 @@
 ---
 authors:
 - Maximilian Voigt
-date: 2019-11-21
 image:
   src: https://datenschule.de/files/blog/2019/11/Sysendammen_med_steinfyllingsdammen.jpg
-  title: "Steinfyllingsdam um 1980 by NVE"
+  title: Steinfyllingsdam um 1980 by NVE
   license: CC BY-SA 2.0
   license_url: https://creativecommons.org/licenses/by-sa/2.0/
 type: post
 layout: post
 card: true
-published: true
 featured: blue
-title: "Ökostrom in DE - Verbraucher* haben es schwer"
+title: Ökostrom in DE - Verbraucher* haben es schwer
+publishedDate: 2019-11-21
 ---
+
 Seit einigen Monaten beschäftigen wir uns im Rahmen des Projektes "[Umweltdatenschule](https://datenschule.de/projekte/umweltdatenschule/)" mit Daten rund um das Thema Energie. Gemeinsam mit [Robin Wood](https://www.robinwood.de/) arbeiten wir an einer Neuauflage des Ökostromberichtes, der mit interaktiven Modulen ausgestattet werden soll. Aus diesem Grund schauen wir uns die Ökostromanbieter in Deutschland, ihre Geschäftsmodelle, Herkunftsnachweise und Investitionsbemühungen genauer an. Hier berichten wir von Erkenntnissen, die sich aus unserer Recherche ergeben.
 
 ## Fast 100% des Ökostroms aus dem Ausland

--- a/content/blog/2019/2019-12-03-volksentscheid-33000-unterschriften-eingereicht.md
+++ b/content/blog/2019/2019-12-03-volksentscheid-33000-unterschriften-eingereicht.md
@@ -1,19 +1,19 @@
 ---
 authors:
-- "Arne Semsrott"
-date: 2019-12-03
+- Arne Semsrott
 image:
   src: /files/blog/2019/12/volksentscheid.jpg
-  title:
+  title: null
   license: CC-BY 4.0
   license_url: https://creativecommons.org/licenses/by/4.0/deed.de
 tags:
 - Transparenzgesetz
 type: post
 layout: post
-published: true
-title: "Volksentscheid Transparenz Berlin: 33.000 Unterschriften für mehr Transparenz"
+title: 'Volksentscheid Transparenz Berlin: 33.000 Unterschriften für mehr Transparenz'
+publishedDate: 2019-12-03
 ---
+
 Das Bündnis Volksentscheid Transparenz hat in weniger als vier Monaten 32.827 Unterschriften gesammelt! Heute hat die Initiative die Unterschriften an die zuständige Senatsverwaltung für Inneres übergeben.
 
 „Das Signal ist klar: Berlin braucht ein Transparenzgesetz. Um Korruption zu bekämpfen und Partizipation zu ermöglichen, muss das Land Berlin seine Aktenschränke öffnen“, sagt Arne Semsrott, Sprecher des Volksentscheids Transparenz.
@@ -31,4 +31,3 @@ Sollte der Senat den Gesetzentwurf nicht übernehmen, muss das Bündnis in der n
 → [mehr Infos](https://www.volksentscheid-transparenz.de/)
 
 → [Fotos der Übergabe-Aktion](https://www.flickr.com/photos/okfde/albums/72157710018426937)
-

--- a/content/blog/2019/2019-12-09-neuer-vorstand.md
+++ b/content/blog/2019/2019-12-09-neuer-vorstand.md
@@ -1,19 +1,18 @@
 ---
 authors:
 - OKF
-date: 2019-12-09
 image:
   src: /files/blog/2019/06/team-foto.jpg
   title: Das Team der OKF
-  license:
-  license_url:
+  license: null
+  license_url: null
 tags:
 - Vorstand
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Die Zukunft einer impulsgebenden Organisation im Vorstand aktiv mitgestalten!"
+title: Die Zukunft einer impulsgebenden Organisation im Vorstand aktiv mitgestalten!
+publishedDate: 2019-12-09
 ---
 
 Die Open Knowledge Foundation Deutschland ist ein gemeinnütziger Verein mit Sitz in Berlin. Seit 2011 sind wir maßgeblicher Motor für den selbstbestimmten Umgang mit Technologie und Daten, für Transparenz und Rechenschaft öffentlicher Institutionen und für politische Teilhabe und eine aktive Zivilgesellschaft.
@@ -68,5 +67,3 @@ Wenn Dich diese Herausforderungen reizen, freuen wir uns, mehr von Dir zu hören
 3. Falls beiderseits Interesse besteht, wollen wir Dich als Kandidat*in der Mitgliederversammlung zur Wahl stellen. Deren Votum ist letztlich bindend. 
 
 Wir freuen uns auf Deine Bewerbung!
-
-

--- a/content/blog/2019/2019-12-09-willkommen-henriette.md
+++ b/content/blog/2019/2019-12-09-willkommen-henriette.md
@@ -1,16 +1,15 @@
 ---
-authors: 
+authors:
 - OKF
-date: 2019-12-09
 image:
   src: /files/blog/2019/HL_1.jpeg
   title: Henriette Litta
-tags:
+tags: null
 type: post
 layout: post
-published: true
 featured: yellow
-title: "In eigener Sache: Henriette Litta übernimmt Geschäftsführung bei Open Knowledge Foundation Deutschland e.V."
+title: 'In eigener Sache: Henriette Litta übernimmt Geschäftsführung bei Open Knowledge Foundation Deutschland e.V.'
+publishedDate: 2019-12-09
 ---
 
 Wir freuen uns sehr, mit Beginn des neuen Jahres Dr. Henriette Litta als neue Geschäftsführerin der OKF DE begrüßen zu dürfen. Henriette hat uns im Auswahlprozess u. a. mit ihrer langjährigen Erfahrung in Führungspositionen im gemeinnützigen Sektor, ihrem Know-How in der Organisationsentwicklung im agilen Umfeld und nicht zuletzt aufgrund ihrer Identifikation mit den Werten und Zielen der OKF DE überzeugt.

--- a/content/blog/2019/2019-12-11-zensurheberrecht-glyphosat-neue-klage.md
+++ b/content/blog/2019/2019-12-11-zensurheberrecht-glyphosat-neue-klage.md
@@ -1,7 +1,6 @@
 ---
-authors: 
+authors:
 - Arne Semsrott
-date: 2019-12-11
 image:
   src: /files/blog/2019/12/glyphosat.jpg
   title: Zensurheberrecht
@@ -11,9 +10,9 @@ tags:
 - Zensurheberrecht
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Zensurheberrecht: Bundesregierung verklagt uns erneut wegen Glyphosat-Gutachten"
+title: 'Zensurheberrecht: Bundesregierung verklagt uns erneut wegen Glyphosat-Gutachten'
+publishedDate: 2019-12-11
 ---
 
 [Über 100.000 Euro](https://fragdenstaat.de/blog/2019/06/03/bmel-interne-doks/) hat das Bundesinstitut für Risikobewertung (BfR) für seine Rechtsstreite schon ausgegeben. Mit seiner einstweiligen Verfügung gegen uns ist es im Sommer [schon vor dem Landgericht Köln gescheitert](https://fragdenstaat.de/blog/2019/07/04/glyphosat-gutachten-hier-ist-es/). Aber jetzt verklagt das BfR von Bundeslandwirtschaftsministerin Julia Klöckner (CDU) uns erneut.

--- a/content/blog/2020/2020-01-10-mehr-transparenz-fuer-den-oekostrommarkt.md
+++ b/content/blog/2020/2020-01-10-mehr-transparenz-fuer-den-oekostrommarkt.md
@@ -1,7 +1,6 @@
 ---
 authors:
 - Maximilian Voigt
-date: 2020-01-10
 image:
   src: /files/blog/2019/12/oekostromreport_2020.png
   title: Ökostrombericht 2020
@@ -13,9 +12,9 @@ tags:
 - Open Data
 type: post
 layout: post
-published: true
 featured: blue
-title: "Ökostrombericht 2020: Mehr Transparenz für den Strommarkt"
+title: 'Ökostrombericht 2020: Mehr Transparenz für den Strommarkt'
+publishedDate: 2020-01-10
 ---
 
 Seit einigen Monaten arbeitet das Projekt [Umweltdatenschule](https://datenschule.de/projekte/umweltdatenschule/) gemeinsam mit der Umweltorganisation [ROBIN WOOD](https://www.robinwood.de/) an der Neuauflage des [Ökostromberichtes 2020, der nun online ist](https://www.robinwood.de/oekostromreport-2020). Mit dem Bericht werden acht von über 1200 Ökostromanbieter empfohlen, die nicht nur ausschließlich Ökostrom vertreiben, sondern auch nahezu keine wirtschaftlichen Verflechtungen zu Unternehmen der Kohle- und Atomenergie aufweisen sowie sich für eine nachhaltige Energiewende engagieren.

--- a/content/blog/2020/2020-01-23-ein-brief-zum-jahresbeginn.md
+++ b/content/blog/2020/2020-01-23-ein-brief-zum-jahresbeginn.md
@@ -1,7 +1,6 @@
 ---
 authors:
 - Andreas Pawelke
-date: 2020-01-23
 image:
   src: /files/blog/2020/01/jahresbeginn_2020.jpg
   title: OKF 2020 Ein Brief zum Jahresbeginn
@@ -17,9 +16,9 @@ tags:
 - community
 type: post
 layout: post
-published: true
 featured: blue
-title: "OKF 2020: Ein Brief zum Jahresbeginn"
+title: 'OKF 2020: Ein Brief zum Jahresbeginn'
+publishedDate: 2020-01-23
 ---
 
 Liebe Freund\*innen der OKF,

--- a/content/blog/2020/2020-02-06-prototype-fund-achte-runde.md
+++ b/content/blog/2020/2020-02-06-prototype-fund-achte-runde.md
@@ -2,7 +2,6 @@
 authors:
 - Patricia Leu
 - Katharina Meyer
-date: 2020-02-06
 image:
   src: /files/blog/2020/02/prototypefund.png
   title: 8. Runde des Prototype Fund
@@ -13,9 +12,9 @@ tags:
 - Public Interest Tech
 type: post
 layout: post
-published: true
 featured: blue
-title: "Der Prototype Fund geht in die 8. Runde: Förderung von bis zu 47.500 € für Open-Source-Projekte"
+title: 'Der Prototype Fund geht in die 8. Runde: Förderung von bis zu 47.500 € für Open-Source-Projekte'
+publishedDate: 2020-02-06
 ---
 
 Nachdem uns über die letzten sieben Runden Projektvorschläge zu so unterschiedlichen Schwerpunkten wie Machine Learning oder Vertrauen in und durch Technologie erreicht haben, wollen wir mit der Runde 8 bis zum 31.3.2020 noch einmal die ganze Bandbreite von Public Interest Technologie einfangen.

--- a/content/blog/2020/2020-02-26-frontex-rechnung-fragdenstaat.md
+++ b/content/blog/2020/2020-02-26-frontex-rechnung-fragdenstaat.md
@@ -1,7 +1,6 @@
 ---
 authors:
 - Arne Semsrott
-date: 2020-02-26
 image:
   src: /files/blog/2020/02/frontex-share.png
   title: Frontex
@@ -10,9 +9,9 @@ tags:
 - Frontex
 type: post
 layout: post
-published: true
 featured: blue
-title: "Frontex will 24.000 Euro von FragDenStaat"
+title: Frontex will 24.000 Euro von FragDenStaat
+publishedDate: 2020-02-26
 ---
 
 Eine EU-Behörde, die mit Waffen auf Flüchtlinge schießt. Nach Aussage des Chefs von Frontex [könnte das bald Wirklichkeit werden](https://www.zeit.de/2020/09/fabrice-leggeri-frontex-waffen-grenzwache-eu/komplettansicht). Frontex, die Europäische Grenzpolizei, hat in den vergangenen Jahren einen enormen Machtzuwachs erlebt. Sie hat inzwischen Milliarden Euro zur Verfügung, um sich eigene Flugzeuge, Schiffe und Autos zu kaufen – und darf an EU-Außengrenzen Waffen einsetzen.

--- a/content/blog/2020/2020-03-11-datenpolitik-gesellschaftspolitik.md
+++ b/content/blog/2020/2020-03-11-datenpolitik-gesellschaftspolitik.md
@@ -1,7 +1,6 @@
 ---
 authors:
 - Michael Peters
-date: 2020-03-11
 image:
   src: /files/blog/2020/03/data-joshua-sortino-unsplash.jpg
   title: Photo by Joshua Sortino on Unsplash
@@ -11,9 +10,9 @@ tags:
 - Zivilgesellschaft
 type: post
 layout: post
-published: true
 featured: blue
-title: "Datenpolitik ist Gesellschaftspolitik"
+title: Datenpolitik ist Gesellschaftspolitik
+publishedDate: 2020-03-11
 ---
 
 Die Bundesregierung plant ihre Datenstrategie und die Zivilgesellschaft ist gefragt! Mit der Strategie möchte sie eine langfristige Grundlage für Datennutzung, Open Data und den Umgang mit Datenschutz schaffen. Wie immer gilt dabei: öffentliche Daten nützen, private Daten schützen.

--- a/content/blog/2020/2020-03-23-ein-bisschen-Prototyp-und-dann.md
+++ b/content/blog/2020/2020-03-23-ein-bisschen-Prototyp-und-dann.md
@@ -1,7 +1,6 @@
 ---
-authors: 
+authors:
 - Ernesto Ruge
-date: 2020-03-23
 image:
   src: /files/blog/2020/03/2020-03-23-Prototyp-und-dann.jpg
   title: Photo by Charles Deluvio on Unsplash
@@ -10,9 +9,9 @@ tags:
 - Zivilgesellschaft
 type: post
 layout: post
-published: true
 featured: blue
-title: "Open Data: ein bisschen Prototyp und dann?"
+title: 'Open Data: ein bisschen Prototyp und dann?'
+publishedDate: 2020-03-23
 ---
 
 ### Wie können erfolgreiche ehrenamtliche Civic-Tech-Projekte nachhaltig betreut und weiterentwickelt werden?

--- a/content/blog/2020/2020-04-01-digiale-zivilgesellschaft.md
+++ b/content/blog/2020/2020-04-01-digiale-zivilgesellschaft.md
@@ -1,19 +1,19 @@
 ---
 author:
 - verschiedene
-date: 2020-04-01
 image:
-  src:
-  title:
+  src: null
+  title: null
 tags:
 - Digitalpolitik
 - Zivilgesellschaft
 type: post
 layout: post
-published: true
 featured: blue
-title: "Aus der Krise lernen: Digitale Zivilgesellschaft stärken!"
+title: 'Aus der Krise lernen: Digitale Zivilgesellschaft stärken!'
+publishedDate: 2020-04-01
 ---
+
 Mittwoch, 01. April 2020. Als zivilgesellschaftliche Organisationen, die sich für eine unabhängige digitale Infrastruktur und freien Zugang zu Wissen einsetzen, fordern wir: „Der Aufbau eines gemeinwohlorientierten digitalen Ökosystems muss endlich politische Priorität bekommen!“
 
 In Krisensituationen zeigt sich die Bedeutung von unabhängigen und belastbaren digitalen Infrastrukturen, die es Menschen, Organisationen und Firmen ermöglichen, ihren alltäglichen Aufgaben nachzukommen. Von den Umstellungen zur Eindämmung von Covid-19 haben bislang vor allem die großen Technologiekonzerne profitiert: Die Verlagerung des Lebens in die digitale Sphäre beschert ihnen größere Marktanteile, Nutzungszahlen und Datensammlungen. Um in Krisenzeiten nicht von ihnen abhängig zu sein, braucht es ein aktives digitales Ökosystem, das echte Wahlmöglichkeiten bietet.

--- a/content/blog/2020/2020-04-03-prototypefund-verlaengerung.md
+++ b/content/blog/2020/2020-04-03-prototypefund-verlaengerung.md
@@ -1,23 +1,23 @@
 ---
 authors:
 - Patricia Leu
-date: 2020-04-03
 image:
-  src: 
-  title:
+  src: null
+  title: null
 tags:
 - Prototype Fund
 - Public Interest Tech
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Der Prototype Fund geht in die Verlängerung"
+title: Der Prototype Fund geht in die Verlängerung
+publishedDate: 2020-04-03
 ---
+
 Lasst die Korken knallen! Wir freuen uns sehr, dass es nach der 8. Förderrunde, deren Bewerbungsfrist am 31. März 2020 zu Ende gegangen ist, nicht nur eine 9., sondern auch die 10., 11., 12., 13., 14., 15. und 16. Runde des Prototype Fund geben wird! Wer also die Einreichungsfrist für die 8. Runde verpasst haben sollte, hat nun also viele neue Gelegenheiten, sich mit einer Idee für Open-Source-Software aus dem Bereich [Public Interest Tech](https://prototypefund.de/about/public-interest-tech/) zu bewerben!
 
 Pro Runde erhalten 25 Projekte für einen Zeitraum von 6 Monaten bis zu 47.500 € Förderung vom Bundesministerium für Bildung und Forschung sowie Coachings, Beratung und Vernetzungsmöglichkeiten. Bereits 140 Teams konnten mit dieser Unterstützung Prototypen entwickeln - und das in so unterschiedlichen Bereichen wie [Nachhaltigkeit](https://prototypefund.de/projects/?filter=topics&topics=umwelt-nachhaltigkeit), [Solidarität](https://prototypefund.de/projects/?filter=topics&topics=solidaritaet), [Medien](https://prototypefund.de/projects/?filter=topics&topics=journalismus-medien)...
 
 Wir danken dem [Bundesministerium für Bildung und Forschung](https://www.bmbf.de/foerderungen/bekanntmachung-2891.html) für das Vertrauen, das sie nicht nur in den Prototype Fund sondern in die Idee von Open Source und Public Interest Tech sowie natürlich in die Förderprojekte setzen!
 
-Also: Auf 8 weitere Runden voller innovativer Ideen, kreativer Prototypen und gemeinsamer Lösungen für gesellschaftliche Herausforderungen! 
+Also: Auf 8 weitere Runden voller innovativer Ideen, kreativer Prototypen und gemeinsamer Lösungen für gesellschaftliche Herausforderungen!

--- a/content/blog/2020/2020-04-28-Jobs-Assistenz.md
+++ b/content/blog/2020/2020-04-28-Jobs-Assistenz.md
@@ -1,18 +1,17 @@
 ---
-authors: 
+authors:
 - Dr. Henriette Litta
-date: 2020-04-28
 image:
   src: /files/blog/2019/06/team-foto.jpg
-  title: "OKF Team"
-  license:
-  license_url:
+  title: OKF Team
+  license: null
+  license_url: null
 type: post
 layout: post
 card: true
-published: true
 featured: blue
-title: "Neuer Job bei der OKF: Wir suchen eine Assistenz der Geschäftsführung (Vollzeit oder Teilzeit, ab sofort, zunächst befristet auf 1 Jahr)" 
+title: 'Neuer Job bei der OKF: Wir suchen eine Assistenz der Geschäftsführung (Vollzeit oder Teilzeit, ab sofort, zunächst befristet auf 1 Jahr)'
+publishedDate: 2020-04-28
 ---
 
 ## Wer wir sind
@@ -74,6 +73,4 @@ Bitte schicke uns deine Bewerbung (Anschreiben, Lebenslauf) inkl. möglichem Beg
 
 Wir freuen uns insbesondere über die Bewerbungen von Frauen, Menschen mit Migrationshintergrund und Menschen anderer Gruppen, die generell und auch in unserer Welt unterrepräsentiert sind. 
  
-Die Gespräche finden zeitnah nach Bewerbungsschluss in Berlin statt bzw. remote per Videokonferenz. Die innerdeutschen Reisekosten für die Bewerbungsgespräche übernehmen wir, sofern sie nicht von der Arbeitsagentur getragen werden. 
-
-
+Die Gespräche finden zeitnah nach Bewerbungsschluss in Berlin statt bzw. remote per Videokonferenz. Die innerdeutschen Reisekosten für die Bewerbungsgespräche übernehmen wir, sofern sie nicht von der Arbeitsagentur getragen werden.

--- a/content/blog/2020/2020-05-12-communitytechnologien.md
+++ b/content/blog/2020/2020-05-12-communitytechnologien.md
@@ -1,22 +1,20 @@
 ---
 authors:
 - Patricia Leu
-date: 2020-05-12
-image: 
+image:
   src: /files/blog/2020/03/2020-05-12_Communitytechnologien.jpg
   title: Communitytechnologien
-  license:
-  license_url:
+  license: null
+  license_url: null
 tags:
 - Prototype Fund
 - Digitale Zivilgesellschaft
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Von Nutzer*innen für Nutzer*innen: Communitytechnologien als Alltagshelfer – nicht nur in der Krise"
+title: 'Von Nutzer*innen für Nutzer*innen: Communitytechnologien als Alltagshelfer – nicht nur in der Krise'
+publishedDate: 2020-05-12
 ---
-
 
 Wenn wir morgens aufwachen, dauert es meist nicht lang bis zum ersten Griff zum Smartphone oder Tablet: Wir checken E-Mails, verschicken Nachrichten oder scrollen durch Social-Media- und Newsfeeds. Im Job geht es für viele damit weiter: Sei es das gemeinsame Arbeiten an Dokumenten, Chats oder Videokonferenzen – zahlreiche Anwendungen gehören, nicht erst seit viele von uns im Home Office arbeiten, fest zu unserem Alltag. Dabei wird oft vergessen, dass die Anwendungen, die wir nutzen, nur die halbe Miete sind: Sie alle benötigen einen soliden Unterbau, also zum Beispiel Programmiersprachen, in denen ihre Basisfunktionen festgelegt sind, Datenbanken, Hosting oder Clouds. Wir benutzen unsere digitalen Tools vollkommen selbstverständlich und verlassen uns dabei blind auf die zugrundeliegende Infrastruktur. 
 

--- a/content/blog/2020/2020-06-04-CFG-Webinar-Resiliente-Kommunalverwaltungen.md
+++ b/content/blog/2020/2020-06-04-CFG-Webinar-Resiliente-Kommunalverwaltungen.md
@@ -1,20 +1,19 @@
 ---
 authors:
 - Claudia Jach
-date: 2020-06-04
-image: 
+image:
   src: /files/blog/2020/05/Town_Picture_by_john_moeses_bauan_unsplash.jpg
   title: Town_Picture_by_john_moeses_bauan_unsplash.jpg
-  license:
-  license_url:
+  license: null
+  license_url: null
 tags:
 - Code for Germany
 - Veranstaltungen
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Online-Seminar: Resiliente Kommunalverwaltungen - wie agieren wir krisenfest und flexibel?"
+title: 'Online-Seminar: Resiliente Kommunalverwaltungen - wie agieren wir krisenfest und flexibel?'
+publishedDate: 2020-06-04
 ---
 
 Krisenzeiten legen Mängel und Versäumnisse schonungslos offen. Krisenzeiten machen aber auch einen Raum auf für Kreativität, Kooperation und Partizipation. Eine Zeit, in der neue Lösungen entstehen können.

--- a/content/blog/2020/2020-06-08-Stellungnahme-Open-Data-Gesetz-NRW.md
+++ b/content/blog/2020/2020-06-08-Stellungnahme-Open-Data-Gesetz-NRW.md
@@ -1,20 +1,19 @@
 ---
 authors:
 - Henriette Litta
-date: 2020-06-08
-image: 
+image:
   src: /files/blog/2020/06/Open_picture_by_alex_holyoake_unsplash.jpg
   title: Open_picture_by_alex_holyoake_unsplash.jpg
-  license:
-  license_url:
+  license: null
+  license_url: null
 tags:
 - Open Data
 - Gesetzgebung
 type: post
 layout: post
-published: true
 featured: blue
-title: "Unsere Stellungnahme zum Open-Data-Gesetz in NRW"
+title: Unsere Stellungnahme zum Open-Data-Gesetz in NRW
+publishedDate: 2020-06-08
 ---
 
 Im März 2020 wurden wir gebeten, eine Stellungnahme zum Gesetzentwurf der Landesregierung zur Änderung des E-Government-Gesetzes Nordrhein-Westfalen und zur Änderung weiterer Vorschriften ([Drs. 17/8795](https://www.landtag.nrw.de/portal/WWW/dokumentenarchiv/Dokument/MMD17-8795.pdf) des Landtags Nordrhein-Westfalen) abzugeben. In Vorbereitung der Stellungnahme haben wir Inputs aus unserer Community eingesammelt, um Expertise aus verschiedenen Arbeitsbereichen der OKF einbringen zu können. Alle [eingegangenen Stellungnahmen](https://www.landtag.nrw.de/home/dokumente_und_recherche/aktuelle-dokumente.html?dokTyp=ST&wp=17&dokNum=Drs%2017/8795&_eventId_sendform=suchen) hat der Landtag NRW veröffentlicht. Der schriftlichen Stellungnahme folgte eine öffentliche Anhörung im Landtag NRW am 14.05.2020, an der unsere Geschäftsführerin Henriette Litta teilnahm. Im Folgenden haben wir unser Feedback an die Landesregierung NRW für euch zusammengefasst.

--- a/content/blog/2020/2020-07-15-Taetigkeitsbericht-2019.md
+++ b/content/blog/2020/2020-07-15-Taetigkeitsbericht-2019.md
@@ -1,18 +1,17 @@
 ---
-authors: 
+authors:
 - Dr. Henriette Litta
-date: 2020-07-15
 image:
   src: /files/blog/2020/06/OKF-logo_black.png
-  title: "OKF Logo"
-  license:
-  license_url:
+  title: OKF Logo
+  license: null
+  license_url: null
 type: post
 layout: post
 card: true
-published: true
 featured: yellow
-title: "Das war 2019: Unser Tätigkeitsbericht ist veröffentlicht" 
+title: 'Das war 2019: Unser Tätigkeitsbericht ist veröffentlicht'
+publishedDate: 2020-07-15
 ---
 
 Das letzte Jahr war wieder bunt und turbulent. Eine kurze Übersicht über das Jahr 2019 stellen wir euch hier zusammen. Ausführlichere und übersichtlich zusammengestellte Informationen findet ihr in unserem [aktuellen Tätigkeitsbericht](https://2019.okfn.de/), den wir wieder nach dem Social Reporting Standard erstellt haben.

--- a/content/blog/2020/2020-07-28-Neuer-Vorstand-OKF-gewaehlt.md
+++ b/content/blog/2020/2020-07-28-Neuer-Vorstand-OKF-gewaehlt.md
@@ -1,18 +1,17 @@
 ---
-authors: 
+authors:
 - Daniel Dietrich
-date: 2020-07-28
 image:
   src: /files/blog/2020/06/OKF-logo_black.png
-  title: "OKF Logo"
-  license:
-  license_url:
+  title: OKF Logo
+  license: null
+  license_url: null
 type: post
 layout: post
 card: true
-published: true
 featured: blue
-title: "Neuer Vorstand der Open Knowledge Foundation Deutschland gewählt" 
+title: Neuer Vorstand der Open Knowledge Foundation Deutschland gewählt
+publishedDate: 2020-07-28
 ---
 
 Auf der Mitgliederversammlung des Open Knowledge Foundation Deutschland e.V. (OKF) wurde am 28. Mai 2020 ein neuer Vorstand gewählt.

--- a/content/blog/2020/2020-08-15-kick-off-forum-open-education-2020.md
+++ b/content/blog/2020/2020-08-15-kick-off-forum-open-education-2020.md
@@ -1,13 +1,12 @@
 ---
-authors: 
+authors:
 - Maximilian Voigt
-date: 2020-08-03
 type: post
 layout: post
 card: true
-published: true
 featured: yellow
-title: "Kick-Off #FOE20: Offene Bildung politisch stärken" 
+title: 'Kick-Off #FOE20: Offene Bildung politisch stärken'
+publishedDate: 2020-08-03
 ---
 
 Mit dem dritten [Forum Open Education](https://education.forum-open.de/) intensivieren wir gemeinsam mit Wikimedia Deutschland und dem [Bündnis Freie Bildung](https://buendnis-freie-bildung.de/) den Austausch zwischen Zivilgesellschaft, Bildungspraxis und politischen Entscheidungsgremien, um zeitgemäßes Lehren und Lernen für eine digitale und offene Gesellschaft voranzubringen. Die folgenden Themen stehen 2020 im Fokus:

--- a/content/blog/2020/2020-09-11-open-education-strategie-unser-vorschlag.md
+++ b/content/blog/2020/2020-09-11-open-education-strategie-unser-vorschlag.md
@@ -1,10 +1,9 @@
 ---
-authors: 
+authors:
 - Maximilian Voigt
-date: 2020-09-11
 image:
   src: /files/blog/2020/09/foe19_dis.jpg
-  title: "FOE19"
+  title: FOE19
   license: CC-BY 4.0 Leonard Wolf
   license_url: https://creativecommons.org/licenses/by/4.0/
 type: post
@@ -13,9 +12,9 @@ tags:
 - Open Education
 - Bildungspolitik
 card: true
-published: true
 featured: yellow
-title: "Open Education: Unser Vorschlag für die OER-Strategie des Bundes" 
+title: 'Open Education: Unser Vorschlag für die OER-Strategie des Bundes'
+publishedDate: 2020-09-11
 ---
 
 Das Ende der 19. Legislaturperiode des Deutschen Bundestages ist abzusehen und noch immer warten wir mit Wikimedia und dem [Bündnis Freie Bildung](https://buendnis-freie-bildung.de/) auf die von der Bundesregierung versprochene [„umfassende Open Educational Resources-Strategie“](https://blog.wikimedia.de/2020/03/02/forderungen-fuer-eine-schnellere-umsetzung-der-oer-strategie/).
@@ -33,4 +32,4 @@ Wir sind der festen Überzeugung, dass die Digitalisierung ihr volles Potenzial 
 
 betrachten wir Open Education als eine Vielzahl an Ansätzen, die alle Bereiche der Bildung betreffen und diese reformieren und verbessern. 
 
-Wir möchten gemeinsam mit dem [Bundesministerium für Bildung und Forschung](https://www.bmbf.de/) an der Strategie arbeiten und **fordern einen offenen Beteiligungsprozess, der die Vielfalt an Akteuren und Akteurinnen der Bildungslandschaft mit einbezieht.** 
+Wir möchten gemeinsam mit dem [Bundesministerium für Bildung und Forschung](https://www.bmbf.de/) an der Strategie arbeiten und **fordern einen offenen Beteiligungsprozess, der die Vielfalt an Akteuren und Akteurinnen der Bildungslandschaft mit einbezieht.**

--- a/content/blog/2020/2020-09-15-digitalpakt-open-education-zivilgesellschaft-beteiligen.md
+++ b/content/blog/2020/2020-09-15-digitalpakt-open-education-zivilgesellschaft-beteiligen.md
@@ -1,18 +1,17 @@
 ---
-authors: 
+authors:
 - Maximilian Voigt
-date: 2020-09-15
 image:
   src: /files/blog/2020/09/foe19.jpg
-  title: "Forum Open Education 2019"
+  title: Forum Open Education 2019
   license: CC-BY 4.0 Leonard Wolf
   license_url: https://creativecommons.org/licenses/by/4.0/
 type: post
 layout: post
 card: true
-published: true
 featured: yellow
-title: "DigitalPakt Schule: mehr Open Education & Beteiligung der Zivilgesellschaft" 
+title: 'DigitalPakt Schule: mehr Open Education & Beteiligung der Zivilgesellschaft'
+publishedDate: 2020-09-15
 ---
 
 In [seiner 59. Sitzung](https://www.bundestag.de/presse/hib/791330-791330) hat der Ausschuss Digitale Agenda über aktuelle Entwicklungen in der digitalen Schulbildung in Zeiten der Corona-Pandemie diskutiert. "Fast sieben Milliarden Euro seien für die Digitalisierung im Bildungssektor von Seiten des Bundes zur Verfügung gestellt worden," so ein Sprecher des BMBF im Ausschuss. Am kommenden Mittwoch [tagt der Ausschuss erneut](https://www.bundestag.de/resource/blob/792032/3b5e8e330f437c83d5a0e8b87ccfc04b/19WP-60-data.pdf), um Vertretern und Vertreterinnen der Kultusministerkonferenz (KMK) die Teilnahme zu ermöglichen.
@@ -21,4 +20,4 @@ Neben dem Aufbau notwendiger Infrastrukturen ist die **Etablierung und Stärkung
 
 Mit dem Aufbau der Suchmaschine für offene Bildungsmaterialien - [WirLernenOnline.de](https://wirlernenonline.de/) - wurde bereits ein wichtiger Schritt in die richtige Richtung gegangen. Andererseits entstehen mit [mundo.schule](https://mundo.schule/) Parallel-Strukturen. Hier ist es wichtig, Plattformen zu verbinden und offene Schnittstellen zu schaffen! 
 
-**Wir möchten gemeinsam mit dem Bundesministerium für Bildung und Forschung an der im Koalitionsvertrag angekündigten Strategie arbeiten und fordern einen offenen Beteiligungsprozess, der die Vielfalt an Akteuren und Akteurinnen der Bildungslandschaft mit einbezieht.** 
+**Wir möchten gemeinsam mit dem Bundesministerium für Bildung und Forschung an der im Koalitionsvertrag angekündigten Strategie arbeiten und fordern einen offenen Beteiligungsprozess, der die Vielfalt an Akteuren und Akteurinnen der Bildungslandschaft mit einbezieht.**

--- a/content/blog/2020/2020-09-17-ogp-nap2-zwischenbericht-stellungnahme.md
+++ b/content/blog/2020/2020-09-17-ogp-nap2-zwischenbericht-stellungnahme.md
@@ -1,10 +1,9 @@
 ---
 authors:
 - Henriette Litta, Leonard Wolf
-date: 2020-09-17
 image:
   src: /files/blog/2020/09/bild_ogp_nap2_zwischenbericht_stellungnahme.png
-  title: 
+  title: null
   license: CC-BY 4.0 Leonard Wolf
   license_url: https://creativecommons.org/licenses/by/4.0/
 tags:
@@ -13,10 +12,11 @@ tags:
 - Jugendbeteiligung
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Open Government in Deutschland: Es gibt Fortschritte, aber große Ambitionen fehlen"
+title: 'Open Government in Deutschland: Es gibt Fortschritte, aber große Ambitionen fehlen'
+publishedDate: 2020-09-17
 ---
+
 **Es geht voran mit Open Government in Deutschland. Die Umsetzung der Ziele der Open Government Partnership ist auf dem Weg, aber es bleibt noch viel zu tun. Nur vorsichtige Schritte in der Jugendbeteiligung, ein Open Data Gesetz mit Reformbedarf, eine Beteiligungsplattform für Gesetze, deren Umsetzung nicht absehbar ist, und das Fehlen eines ambitionierten Leuchtturmprojektes: Diese und weitere Punkte kritisieren wir als OKF DE im Rahmen des Konsultationsverfahrens zum Zwischenbericht der Bundesregierung zur Umsetzung des Zweiten Nationalen OGP-Aktionsplans. Hier fassen wir unsere wichtigsten Punkte zusammen und veröffentlichen die gesamte Stellungnahme.**
 
 
@@ -57,9 +57,3 @@ Aktuell fehlt weiterhin ein Leuchtturmprojekt, das die Bemühungen der Bundesreg
 - die Ausschreibung von umfangreichen Förderprogrammen für digitale Open-Source-Infrastruktur
 
 Dies ist die Zusammenfassung unserer Stellungnahme. [Die gesamte Fassung gibt es hier im Volltext zum Download.](/files/blog/2020/09/2020-08-31_OKF_Stellungnahme_OGP.pdf)
-
-
-
- 
-
-

--- a/content/blog/2020/2020-10-07-open-education-community-und-bundespolitik-ergebnisse.md
+++ b/content/blog/2020/2020-10-07-open-education-community-und-bundespolitik-ergebnisse.md
@@ -1,20 +1,20 @@
 ---
 authors:
 - Maximilian Voigt
-date: 2020-10-06
 image:
   src: /files/blog/2020/10/foe20_fg.png
-  title: 
+  title: null
   license: CC-BY 4.0 Wikimedia DE
   license_url: https://creativecommons.org/licenses/by/4.0/
 tags:
 - Open Education
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Offene Bildung stärken: Lösungen und Forderungen"
+title: 'Offene Bildung stärken: Lösungen und Forderungen'
+publishedDate: 2020-10-06
 ---
+
 *Wie lässt sich Bildung inklusiv, gerecht und offen gestalten, lautet die Frage beim [Forum Open Education 2020](https://education.forum-open.de/timeline/) - [#FOE20](https://twitter.com/search?q=%23foe20&src=typed_query&f=live). Bereits das dritte Jahr in Folge laden das Bündnis Freie Bildung, die Open Knowledge Foundation Deutschland und Wikimedia Deutschland zum Austausch zwischen Zivilgesellschaft, Bildungspraxis und politischen Entscheidungsgremien.*
 
 Am [8. Oktober](https://education.forum-open.de/timeline/) werden die Ergebnisse des bisher einmaligen Arbeitsprozesses - in dem Bundespolitik und Zivilgesellschaft auf Augenhöhe korrespondieren - in einer digitalen Abschlussveranstaltung präsentiert und von den Bildungspolitiker\*innen Marja-Liisa Völlers, Margit Stumpp, Dr. Jens Brandenburg, Ronja Kemmer und Birke Bull-Bischoff diskutiert. 

--- a/content/blog/2020/2020-10-08-Energhack2020.md
+++ b/content/blog/2020/2020-10-08-Energhack2020.md
@@ -1,19 +1,18 @@
 ---
 authors:
-- Martin WP 
-date: 2020-10-08
+- Martin WP
 image:
   src: /files/blog/2020/10/EH20-praesentation.jpg
-  title: 
+  title: null
   license: CC-BY 4.0 Wikimedia DE
   license_url: https://creativecommons.org/licenses/by/4.0/
 tags:
 - Energyhack
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Rückblick Energyhack 2020 - ENERGY<->HACK³ STADT * ENERGIE * VERKEHRSWENDE!"
+title: Rückblick Energyhack 2020 - ENERGY<->HACK³ STADT * ENERGIE * VERKEHRSWENDE!
+publishedDate: 2020-10-08
 ---
 
 Energie für eine effiziente Stadt! Am 25. und 26. September fand der fünfte [Energyhack](https://energyhack.de/) von Stromnetz Berlin und der Open Knowledge Foundation statt.

--- a/content/blog/2020/2020-10-14-bundespolitik-einig-mehr-open-education.md
+++ b/content/blog/2020/2020-10-14-bundespolitik-einig-mehr-open-education.md
@@ -1,20 +1,20 @@
 ---
 authors:
 - Maximilian Voigt
-date: 2020-10-14
 image:
   src: /files/blog/2020/10/foe_2020.jpg
-  title: 
+  title: null
   license: CC-BY 4.0 Wikimedia DE
   license_url: https://creativecommons.org/licenses/by/4.0/
 tags:
 - Open Education
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Bundespolitik ist sich einig: Es braucht mehr Open Education!"
+title: 'Bundespolitik ist sich einig: Es braucht mehr Open Education!'
+publishedDate: 2020-10-14
 ---
+
 **Auch wenn eine Debatte vom Diskurs lebt, ist manchmal die Einstimmigkeit der Parteien das Bemerkenswerteste. Fraktionsübergreifend zeigte die [Abschlussdiskussion des dritten Forums Open Education](education.forum-open.de/stream/) eine große Einigkeit für mehr Open Education und freie Bildungsmaterialien.**
 
 {{< youtube whq56iPqBJ4 >}}
@@ -23,4 +23,4 @@ Bundestagsabgeordnete aus fünf verschiedenen Fraktionen diskutierten zum Abschl
 
 Vor der Paneldiskussion wurden diese der interessierten Öffentlichkeit in Fachgruppen virtuell vorgestellt und diskutiert. Die Teilnehmenden, aus Bundesministerien wie aus zivilgesellschaftlichen Organisationen, vertieften dabei die zukünftige Rolle von **Bibliotheken als dritte Lernorte**, das **Lernen in regionalen Netzwerken** – vernetzt mit Offenen Werkstätten oder anderen Kultureinrichtungen –, die Aspekte einer **zeitgemäßen Lehrkräfteausbildung** sowie die Potenziale und Risiken von **Künstlicher Intelligenz** für eine gerechtere, binnendifferenzierte Bildung. 
 
-Stimmen zu diesen Themen sowie zum Forum und der Entwicklung von Bildung allgemein sind im [Beitrag des Deutschlandfunks](https://ondemand-mp3.dradio.de/file/dradio/2020/10/09/unterrichten_mal_ganz_anders_das_forum_open_education_dlf_20201009_1448_6491a325.mp3) nachzuhören. Wir freuen uns über den intensiven und vielfältigen Austausch sowie die vielen guten Ideen für eine offene, gerechte und inklusive Bildung. Mit der OER-Strategie des Bündnis Freie Bildung liegen damit alle Elemente auf dem Tisch, um Bildung auch durch konkrete politische Handlungen voranzubringen. 
+Stimmen zu diesen Themen sowie zum Forum und der Entwicklung von Bildung allgemein sind im [Beitrag des Deutschlandfunks](https://ondemand-mp3.dradio.de/file/dradio/2020/10/09/unterrichten_mal_ganz_anders_das_forum_open_education_dlf_20201009_1448_6491a325.mp3) nachzuhören. Wir freuen uns über den intensiven und vielfältigen Austausch sowie die vielen guten Ideen für eine offene, gerechte und inklusive Bildung. Mit der OER-Strategie des Bündnis Freie Bildung liegen damit alle Elemente auf dem Tisch, um Bildung auch durch konkrete politische Handlungen voranzubringen.

--- a/content/blog/2020/2020-12-02-offener-brief-an-die-community.md
+++ b/content/blog/2020/2020-12-02-offener-brief-an-die-community.md
@@ -1,20 +1,20 @@
 ---
 authors:
 - AG Community
-date: 2020-12-02
 image:
   src: /files/blog/2020/06/OKF-logo_black.png
   title: OKF Logo
-  license:
-  license_url:
+  license: null
+  license_url: null
 tags:
 - Community
 type: post
 layout: post
-published: true
 featured: blue
-title: "Offener Brief an die Community"
+title: Offener Brief an die Community
+publishedDate: 2020-12-02
 ---
+
 **Dieser offene Brief richtet sich an die Community des Vereins, besonders an die vielen ehrenamtlich arbeitenden Menschen, die sich im Rahmen von Code for Germany engagieren. Wir nehmen damit Stellung zu den Konflikten und strukturellen Problemen, die es schon länger gibt, die jedoch in diesem Jahr besonders deutlich geworden sind.**
 
 Liebe Mitstreiter\*innen, liebe Engagierte und Unterstützer\*innen, liebe Community!

--- a/content/blog/2020/2020-12-10-publikation-digitale-zivilgesellschaft.md
+++ b/content/blog/2020/2020-12-10-publikation-digitale-zivilgesellschaft.md
@@ -1,21 +1,20 @@
 ---
 authors:
 - Patricia Leu
-date: 2020-12-10
 image:
-  src: /files/blog/2020/12/Publikation_Cover.png 
-  title: "Publikation des Prototype Fund"
-  license:
-  license_url:
+  src: /files/blog/2020/12/Publikation_Cover.png
+  title: Publikation des Prototype Fund
+  license: null
+  license_url: null
 tags:
 - Prototype Fund
 - Digitale Zivilgesellschaft
 - Public Interest Tech
 type: post
 layout: post
-published: true
 featured: blue
-title: "Publikation des Prototype Fund: Community-Technologien von Nutzer:innen für Nutzer:innen"
+title: 'Publikation des Prototype Fund: Community-Technologien von Nutzer:innen für Nutzer:innen'
+publishedDate: 2020-12-10
 ---
 
 Die digitale Zivilgesellschaft zeigt ständig ihr großes Engagement – und hat in der Corona-Krise vollends bewiesen, dass sie unser (digitales) Leben besser macht. Diese wichtige Arbeit hat der Prototype Fund über den Lauf des Jahres in einer [Reihe von Blogartikeln](https://prototypefund.de/was-ist-die-digitale-zivilgesellschaft/) dargestellt, welche nun in der Publikation [“Community-Technologien: Von Nutzer:innen für Nutzer:innen” zusammengefasst veröffentlicht werden](https://prototypefund.de/wp-content/uploads/2020/12/Die_digitale_Zivilgesellschaft_PTF-2.pdf).

--- a/content/blog/2020/2020-12-16-Was-fuer-ein-Jahr.md
+++ b/content/blog/2020/2020-12-16-Was-fuer-ein-Jahr.md
@@ -1,17 +1,16 @@
 ---
 authors:
 - Aus dem Off der OKF
-date: 2020-12-10
 image:
-  src: /files/blog/2020/12/Rueckblick_2020_photo_by_glen_carrie_unsplash.jpg 
-  title: "Rueckblick_2020_photo_by_glen_carrie_unsplash"
-  license:
-  license_url:
+  src: /files/blog/2020/12/Rueckblick_2020_photo_by_glen_carrie_unsplash.jpg
+  title: Rueckblick_2020_photo_by_glen_carrie_unsplash
+  license: null
+  license_url: null
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Zum Jahresende: Was für ein Jahr!"
+title: 'Zum Jahresende: Was für ein Jahr!'
+publishedDate: 2020-12-10
 ---
 
 Das Jahr kann jetzt wirklich einmal zu Ende gehen. Uns reicht es jetzt. 2020 hat uns alle heftig mitgenommen. Ein Wunder, wie entspannt wir alle auf der digitalen Weihnachtsfeier waren. Noch nie schleppte sich ein Jahr so zäh dahin oder ist es doch in Windeseile verflogen? 2020 geht in die Geschichte ein als ein Jahr, in dem alles ein wenig anders ist. Für viele von uns, ist es eine erstaunliche Erfahrung, unsere Gewohnheiten und unseren Alltag anzupassen, um unsere eigene Gesundheit zu schützen, sowie die Gesundheit von unseren Familien, Freunden und allen anderen.
@@ -30,4 +29,4 @@ Unterstütze uns gern mit deiner Spende. Spenden ermöglichen es uns, unabhängi
 
 Bleibt gesund und ein friedliches Weihnachtsfest uns allen.
 
-Wir sagen Tschüß 2020! 
+Wir sagen Tschüß 2020!

--- a/content/blog/2021/2021-01-11-zur-abschaltung-von-kleine-anfragen.md
+++ b/content/blog/2021/2021-01-11-zur-abschaltung-von-kleine-anfragen.md
@@ -1,7 +1,6 @@
 ---
 authors:
 - Maximilian Richt
-date: 2021-01-11
 image:
   src: /files/projects/KleineAnfragen_Header.png
   title: kleineAnfragen
@@ -12,9 +11,9 @@ tags:
 - Open Government
 type: post
 layout: post
-published: true
 featured: blue
-title: "Zur Abschaltung von kleineAnfragen.de"
+title: Zur Abschaltung von kleineAnfragen.de
+publishedDate: 2021-01-11
 ---
 
 Zum 31.12.2020 wurde [kleineAnfragen.de](https://kleineAnfragen.de) abgeschaltet. Das haben wir schon im Mai 2019 angekündigt. Denn nach mehr als 5 Jahren Betrieb ist die Datensituation der Parlamente kein Stück besser geworden. Was jetzt?

--- a/content/blog/2021/2021-01-14-jobs-jugend-hackt-finanzadministration.md
+++ b/content/blog/2021/2021-01-14-jobs-jugend-hackt-finanzadministration.md
@@ -1,19 +1,18 @@
 ---
 authors:
 - Sonja Fischbauer
-date: 2021-01-14
 image:
   src: /files/blog/2021/01/jugend-hackt-team-2020.jpg
-  title: "Jugend hackt Team"
-  license:
-  license_url:
+  title: Jugend hackt Team
+  license: null
+  license_url: null
 tags:
 - Jobs
 type: post
 layout: post
-published: true
 featured: blue
-title: "Job bei der OKF: Finanzadministration bei Jugend hackt (ab sofort)"
+title: 'Job bei der OKF: Finanzadministration bei Jugend hackt (ab sofort)'
+publishedDate: 2021-01-14
 ---
 
 ## Jugend hackt sucht eine\*n studentische\*n Mitarbeiter\*in (m/w/d) für Finanzadministration, 19h/Woche, ab sofort

--- a/content/blog/2021/2021-01-15-open-education-rueckschritte-fortschritte.md
+++ b/content/blog/2021/2021-01-15-open-education-rueckschritte-fortschritte.md
@@ -1,20 +1,19 @@
 ---
 authors:
 - Maximilian Voigt, Dominik Theis
-date: 2021-01-15
 image:
-  src: /files/blog/2021/01/jh.jpeg 
-  title: "Jugend hackt - by Leonard Wolf"
-  license:
-  license_url:
+  src: /files/blog/2021/01/jh.jpeg
+  title: Jugend hackt - by Leonard Wolf
+  license: null
+  license_url: null
 type: post
 tags:
 - Open Education
 - Bildungspolitik
 layout: post
-published: true
 featured: yellow
-title: "Open Education: Rückschritte und Fortschritte"
+title: 'Open Education: Rückschritte und Fortschritte'
+publishedDate: 2021-01-15
 ---
 
 Die im [März 2020 herbeigesehnten Entwicklungen](https://www.freitag.de/autoren/der-freitag/bildung-in-krisenzeiten) im Bildungsbereich haben sich nur bedingt bewahrheitet. Denn über Jahre hin aufgeschobene Defizite lassen sich nicht im Ausnahmezustand aufholen. 2021 blicken wir auf ein Jahr zurück, das durch Chaos und Frustration geprägt ist. In dieser Situation gehen Sensationen, wie der extrem gestiegene Einsatz von Cloud-Systemen in der Schule, beinahe unter: In der [JIM-Studie (Jugend Information Medien)](https://www.mpfs.de/fileadmin/files/Presse/2020/PM_JIM-2020-Homeschooling.pdf) berichteten im Juli 55 Prozent der befragten Lernenden, dass sie in der Schule in einer Cloud arbeiten. Als die Forschenden dieselbe Frage im April stellten, waren es nur 22 Prozent. In drei Monaten ist damit die Anbindung der Schulen an Clouds und Lernplattformen um 150 Prozent gestiegen - das schaffen aktuell kaum andere Softwarelösungen. 
@@ -33,4 +32,3 @@ Es geht also um die Integration von bereits etablierten Strukturen und mehr Vern
 Um die nötige Ausfallsicherheit und Weiterentwicklung sicherzustellen, braucht es darüber hinaus Förderstrukturen, die die Entwicklung freier Software und Infrastrukturen nachhaltig sichern. Dazu trägt eine vitale Open-Source und Open-Education-Gemeinschaft entscheidend bei. Daher muss der Bund und die Länder auf Kooperation, nicht auf Konkurrenz setzen. Das [agile Zusammenarbeiten](https://buendnis-freie-bildung.de/2020/09/18/wirlernenonline-mundo-bitte-gemeinsam/) und ein informeller Kooperationsstil sollten 2021 im Vordergrund stehen. Es bleibt abzuwarten, ob der Weg der Reformierung oder des “Weiter-so” gegangen wird. Fakt ist: Wir waren lange nicht so nah an grundlegenden Veränderungen dran. 
 
 [Dieser Artikel ist am 24.12. bereits auf Netzpolitik.org erschienen.](https://netzpolitik.org/2020/open-education-rueckschritte-und-fortschritte/)
-

--- a/content/blog/2021/2021-01-19-nachlese-wikipaka-rc3.md
+++ b/content/blog/2021/2021-01-19-nachlese-wikipaka-rc3.md
@@ -2,12 +2,11 @@
 authors:
 - Claudia Jach
 - Philip Steffan
-date: 2021-01-19
 image:
   src: /files/blog/2021/01/wikipaka_ident.jpg
   title: Wikipaka Television und Fernstreaming
-  license:
-  license_url:
+  license: null
+  license_url: null
 tags:
 - Konferenz
 - Event
@@ -16,9 +15,9 @@ tags:
 - Chaos Communication Congress
 type: post
 layout: post
-published: true
 featured: blue
-title: "Nachlese: Vorträge auf dem Congress (rc3)"
+title: 'Nachlese: Vorträge auf dem Congress (rc3)'
+publishedDate: 2021-01-19
 ---
 
 Einer unserer Standardtermine jedes Jahr ist der [Chaos Communication Congress](https://events.ccc.de/) zwischen Weihnachten und Neujahr. Viele Haupt- und Ehrenamtliche der OKF besuchen den weltweiten Kongress von Hacker:innen und gesellschaftspolitischen Aktivist:innen und gestalten auch das Programm mit.

--- a/content/blog/2021/2021-02-02-ptf-runde-zehn.md
+++ b/content/blog/2021/2021-02-02-ptf-runde-zehn.md
@@ -1,12 +1,11 @@
 ---
 authors:
 - Patricia Leu
-date: 2021-02-02
 image:
   src: /files/blog/2020/02/prototypefund.png
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - Prototype Fund
 - Civic Tech
@@ -14,9 +13,9 @@ tags:
 - Public Interest Tech
 type: post
 layout: post
-published: true
 featured: yellow
 title: Prototype Fund fördert eure Open-Source-Softwareideen – bewerbt euch jetzt!
+publishedDate: 2021-02-02
 ---
 
 Seit dem 1. Februar 2021 könnt ihr euch mit eurer Open-Source-Softwareidee für die kommende 10. Förderphase des Prototype Fund bewerben. Die Bewerbungsrunde ist themenoffen – auch wenn wir uns in der Trendforschung speziell an der Schnittstelle von Journalismus, Medien und Technologien umgesehen haben. Die Bereiche, in die eure Idee fallen sollte, heißen Civic Tech, Data Literacy, Datensicherheit und Softwareinfrastruktur. Darüber hinaus sind euch keine Grenzen gesetzt!

--- a/content/blog/2021/2021-02-03-okf-datenstrategie-nach-kabinettbeschluss.md
+++ b/content/blog/2021/2021-02-03-okf-datenstrategie-nach-kabinettbeschluss.md
@@ -1,21 +1,20 @@
 ---
 authors:
 - Henriette Litta
-date: 2021-02-03
 image:
   src: /files/blog/2021/01/data-joshua-sortino-unsplash.jpeg
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - Open Data
 - Datenstrategie
 - Zivilgesellschaft
 type: post
 layout: post
-published: true
 featured: blue
-title: "Datenstrategie der Bundesregierung: Gute Ansätze, aber zu sehr auf die Wirtschaft verengt"
+title: 'Datenstrategie der Bundesregierung: Gute Ansätze, aber zu sehr auf die Wirtschaft verengt'
+publishedDate: 2021-02-03
 ---
 
 **Die Bundesregierung hat am 27.01.2021 ihre erste Datenstrategie im Kabinett verabschiedet. Sie ist ein Schritt in die richtige Richtung und folgt aus unserer Sicht einer richtigen gesellschaftlichen Zielsetzung: Rahmenbedingungen zu schaffen für eine verantwortungsvolle und innovative Datennutzung, die sich an den Werten der informationellen Selbstbestimmung und des Schutzes persönlicher Daten orientiert und dem Gemeinwohl verpflichtet ist. Leider versäumt es die Bundesregierung, diesen Werten das nötige Gewicht zu verleihen. Die Datenstrategie verengt sich zu stark auf wirtschaftliche Aspekte und lässt dabei weitere, gemeinwohlorientierte Aspekte der Datennutzung unter den Tisch fallen. Die Zivilgesellschaft bleibt weiterhin Zaungast in der Diskussion: In der Datenstrategie finden sich die Vorschläge, die aus der Zivilgesellschaft kamen, nur teilweise berücksichtigt. Ungehört bleibt auch der Wunsch nach einem Regulativ: Die Gefahr des Datenmissbrauchs durch staatliche Behörden lässt die Datenstrategie gänzlich unbehandelt.**

--- a/content/blog/2021/2021-02-17-oer-strategie-konsultation-gestartet.md
+++ b/content/blog/2021/2021-02-17-oer-strategie-konsultation-gestartet.md
@@ -1,20 +1,19 @@
 ---
 authors:
 - Maximilian Voigt
-date: 2021-02-21
 image:
   src: https://edulabs.de/assets/img/blog/2018/Mai/squarelet/squarelet.jpg
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - Open Education
 - Bildungspolitik
 type: post
 layout: post
-published: true
 featured: yellow
 title: Konsultation zur bundesweiten OER-Strategie gestartet
+publishedDate: 2021-02-21
 ---
 
 Im vergangenen Jahr hat die OKF gemeinsam mit dem Bündnis Freie Bildung an einem [Entwurf für die lange überfällige OER-Strategie](https://okfn.de/blog/2020/09/open-education-strategie-unser-vorschlag/) des Bundes gearbeitet und den Prozess maßgeblich mitgestaltet. Nun ist es endlich soweit und die Strategie wird angegangen. Dazu hat das BMBF einen neuartigen Konsultationsprozess aufgelegt. Wir sind beteiligt und haben notwendige Entwicklungsbereiche im Bildungsbereich in [unserem Beitrag](https://raw.githubusercontent.com/okfde/okfn.de/master/static/files/blog/2021/01/Konsultation_OER-Strategie_Themenbereich_Gesellschaft_OKF_DE.pdf) benannt, damit Bildung partizipativer, gerechter und offener wird. 

--- a/content/blog/2021/2021-02-17-okf-10jahre-interview-dd.md
+++ b/content/blog/2021/2021-02-17-okf-10jahre-interview-dd.md
@@ -1,12 +1,11 @@
 ---
 authors:
 - Henriette Litta, Daniel Dietrich
-date: 2021-02-17
 image:
   src: /files/blog/2021/01/happybirthday1.jpg
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - OKFDE10
 - openknowledge
@@ -14,9 +13,9 @@ tags:
 - zivilgesellschaft
 type: post
 layout: post
-published: true
 featured: yellow
 title: Die OKF wird 10 Jahre alt
+publishedDate: 2021-02-17
 ---
 
 **Am 19. Februar 2011 wurde die “Open Knowledge Foundation Deutschland” in das Berliner Vereinsregister eingetragen. 10 Jahre ist das her. Unseren ersten runden Geburtstag wollen wir nutzen, um in diesem Jahr auf unsere Arbeit zurückzublicken, mit früheren und aktuellen Wegbegleiter:innen zu sprechen und auch nach vorne zu schauen, was zukünftig wichtig sein wird. Und feiern wollen wir auch. Ein bißchen. Im Sommer.**

--- a/content/blog/2021/2021-03-15-forum-open-education-2021.md
+++ b/content/blog/2021/2021-03-15-forum-open-education-2021.md
@@ -1,20 +1,19 @@
 ---
 authors:
 - Maximilian Voigt
-date: 2021-03-15
 image:
   src: /files/blog/2021/03/FOE-Posts-Social-Media-Landscape1-1024x532.jpg
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - Open Education
 - Bildungspolitik
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Forum Open Education: Bildungspolitik auf Augenhöhe"
+title: 'Forum Open Education: Bildungspolitik auf Augenhöhe'
+publishedDate: 2021-03-15
 ---
 
 Mit dem vierten [Forum Open Education](https://education.forum-open.de/) lädt das [Bündnis Freie Bildung](https://buendnis-freie-bildung.de/) auch 2021 wieder engagierte Bildungsenthusiast*innen und politischen Entscheidungstragende ein, zeitgemäßes Lehren und Lernen für eine digitale und offene Gesellschaft voranzubringen. Ziel ist es, die Zusammenarbeit und den Austausch zwischen Politik, Praxis und Zivilgesellschaft dauerhaft zu stärken. Gemeinsam werden Einschätzungen, Strategien und konkrete Handlungsempfehlungen für gerechte, offene und nachhaltige Bildung erarbeitet.

--- a/content/blog/2021/2021-03-16-okf-digitalpolitische-Forderungen.md
+++ b/content/blog/2021/2021-03-16-okf-digitalpolitische-Forderungen.md
@@ -1,20 +1,19 @@
 ---
 authors:
-- 
-date: 2021-03-16
+- null
 image:
   src: /files/blog/2021/03/vote_photo_by_glen_carrie_unsplash.jpg
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - open-government
 - policy
 type: post
 layout: post
-published: true
 featured: blue
-title: "Forderungen für eine gemeinwohlorientierte, demokratische Digitalpolitik"
+title: Forderungen für eine gemeinwohlorientierte, demokratische Digitalpolitik
+publishedDate: 2021-03-16
 ---
 
 Die sechs Landtags- bzw. Abgeordnetenhauswahlen sowie die Bundestagswahl am 26. September geben dieses Jahr viele Anlässe, die Themen der OKF zu diskutieren und - wie wir aktuell besonders erleben - viel Nachholbedarf bei Open Government und Co. auf Seiten von Staat und Verwaltungen.

--- a/content/blog/2021/2021-03-17-jugend-hackt-labs-2021-ausschreibung.md
+++ b/content/blog/2021/2021-03-17-jugend-hackt-labs-2021-ausschreibung.md
@@ -1,7 +1,6 @@
 ---
 authors:
 - Philip Steffan
-date: 2021-03-17
 image:
   src: /files/blog/2021/03/jugend_hackt_labs_2021_lab_ulm_cc_by_tomas_novy.jpg
   title: Tomas Novy/Jugend hackt
@@ -15,9 +14,9 @@ tags:
 - Jugendarbeit
 type: post
 layout: post
-published: true
 featured: blue
-title: "Jugend hackt sucht Partner*innen für neue Labs"
+title: Jugend hackt sucht Partner*innen für neue Labs
+publishedDate: 2021-03-17
 ---
 
 Jugend hackt wächst - und wir wollen, dass ihr dabei seid!

--- a/content/blog/2021/2021-03-29-okf-vorstandswechsel.md
+++ b/content/blog/2021/2021-03-29-okf-vorstandswechsel.md
@@ -1,20 +1,19 @@
 ---
 authors:
 - Vorstand
-date: 2021-03-29
 image:
   src: /files/blog/2021/03/Logo_okfde_black_centered.png
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - OKFDE
 - Vorstand
 type: post
 layout: post
-published: true
 featured: yellow
 title: Wechsel im Vorstandsvorsitz der OKF DE
+publishedDate: 2021-03-29
 ---
 
 **Nach sieben Jahren scheidet Andreas Pawelke zum Monatsende aus dem Vorstand der Open Knowledge Foundation Deutschland aus und übergibt den Vorsitz kommissarisch bis zur nächsten Mitgliederversammlung an Vorstandsmitglied Kristina Klein.**

--- a/content/blog/2021/2021-04-07-forum-open-education-2021-jetzt-anmelden.md
+++ b/content/blog/2021/2021-04-07-forum-open-education-2021-jetzt-anmelden.md
@@ -1,21 +1,21 @@
 ---
 authors:
 - Maximilian Voigt
-date: 2021-04-07
 image:
   src: /files/blog/2020/10/foe_2020.jpg
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - Open Education
 - Bildungspolitik
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Forum Open Education: jetzt anmelden & Bildungspolitik mitgestalten"
+title: 'Forum Open Education: jetzt anmelden & Bildungspolitik mitgestalten'
+publishedDate: 2021-04-07
 ---
+
 Es muss politischer Anspruch sein, Bildung offen, partizipativ und demokratisch zu gestalten. Bildungspolitische Strategien entstehen allerdings häufig hinter verschlossenen Türen. Die Perspektive der Praxis findet zu selten Beachtung im politischen Diskurs. Politik und Praxis können und wollen mehr voneinander profitieren.
 
 Das „Forum Open Education“ schafft eine Vertrauensbasis, indem es zu einem Arbeitsprozess auf Augenhöhe einlädt. Es zielt darauf ab, die Zusammenarbeit zwischen Politik, Praxis und Zivilgesellschaft dauerhaft zu stärken. Der Prozess ist darauf angelegt, dass politische Entscheidungstragende sowie politisch interessierte und engagierte Bildungsexpertinnen und -experten gemeinsam Einschätzungen, Strategien und konkrete Handlungsempfehlungen für zeitgemäße Bildung erarbeiten.

--- a/content/blog/2021/2021-04-15-digitales-ehrenamt-gemeinwohl.md
+++ b/content/blog/2021/2021-04-15-digitales-ehrenamt-gemeinwohl.md
@@ -2,12 +2,11 @@
 authors:
 - Claudia Jach
 - Henriette Litta
-date: 2021-04-15
 image:
   src: /files/blog/2021/04/digitales_ehrenamt_photo_by_sahand_babali_unsplash.jpg
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - Community
 - Zivilgesellschaft
@@ -15,10 +14,11 @@ tags:
 - Digitales Ehrenamt
 type: post
 layout: post
-published: true
 featured: blue
-title: "Das Digitale Ehrenamt ist ein wichtiger Baustein für eine gemeinwohlorientierte Digitalpolitik"
+title: Das Digitale Ehrenamt ist ein wichtiger Baustein für eine gemeinwohlorientierte Digitalpolitik
+publishedDate: 2021-04-15
 ---
+
 Das Superwahljahr 2021 hat bereits volle Fahrt aufgenommen. Digitale Themen standen noch nie so sehr im Fokus wie jetzt. Aus unserer Sicht kommt der Zivilgesellschaft und insbesondere den Digital Ehrenamtlichen bei der Gestaltung von Digitalisierung eine Schlüsselrolle zu. 
 
 ### Aktivitäten im Digitalen Ehrenamt
@@ -83,4 +83,4 @@ Es fehlt aber an einer sinnvollen Integration Offener Technologiebildung in das 
 
 Dies kann aber nicht rein ehrenamtlich geleistet werden. Speziell im Bereich Jugendbildung braucht es zusätzlich eine nachhaltige, verlässliche und langfristige Förderung von jugendlichem Engagement sowie pädagogischen und technisch geschultem Personal, das Jugendliche in physischen und digitalen Lernräumen begleitet. Die OKF fordert auch hier, dass entsprechende Förderprogramme bereits bestehende, erfolgreiche Projekte unterstützen sollten, statt immer neue Modelle zu fördern. Nur so können haupt- und ehrenamtliches Engagement der digitalen Zivilgesellschaft langfristig gut ineinandergreifen.
 
-**Dieser Beitrag wurde zuerst am 1. April 2021 im [Newsletter](https://www.b-b-e.de/bbe-newsletter/newsletter-nr-7-vom-142021/jach/litta-digitales-ehrenamt-in-der-digitalpolitik/) des Bundesnetzwerk Bürgerschaftliches Engagement (BBE) veröffentlicht.** 
+**Dieser Beitrag wurde zuerst am 1. April 2021 im [Newsletter](https://www.b-b-e.de/bbe-newsletter/newsletter-nr-7-vom-142021/jach/litta-digitales-ehrenamt-in-der-digitalpolitik/) des Bundesnetzwerk Bürgerschaftliches Engagement (BBE) veröffentlicht.**

--- a/content/blog/2021/2021-04-27-pm-forderungen-digitale-zivilgesellschaft.md
+++ b/content/blog/2021/2021-04-27-pm-forderungen-digitale-zivilgesellschaft.md
@@ -1,20 +1,20 @@
 ---
-authors:
-date: 2021-04-27
+authors: null
 image:
   src: /files/blog/2021/04/arrow_by_sigmund_unsplash.jpg
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - Digitale-Zivilgesellschaft
 - Policy
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Digitale Zivilgesellschaft: Vier Forderungen für eine digital souveräne Gesellschaft"
+title: 'Digitale Zivilgesellschaft: Vier Forderungen für eine digital souveräne Gesellschaft'
+publishedDate: 2021-04-27
 ---
+
 **Die OKF ist Mitglied eines Bündnisses aus 30 Organisationen der digitalen Zivilgesellschaft. Gemeinsam stellen wir für die Bundestagswahl 2021 vier Forderungen für eine digital souveräne Gesellschaft an die Politik.**
 
 Am 1. April 2020 forderten wir mit vielen weiteren zivilgesellschaftlichen Organisationen die Politik auf: Aus der Krise lernen - Digitale Zivilgesellschaft stärken! Dafür lieferten wir gemeinsam konkrete Handlungsempfehlungen. Geschehen ist seitdem jedoch viel zu wenig. Das vergangene Jahr hat deutlich gemacht, dass Politik und öffentliche Verwaltung mit ihrer eigenen digitalen Transformation überfordert sind und in der Digitalpolitik Schwerpunkte setzen, die nicht den Bedürfnissen der Gesellschaft entsprechen. Dies haben wir auch in den [umfassenden Forderungen der OKF](https://okfn.de/blog/2021/03/okf-digitalpolitische-forderungen/) zum diesjährigen Wahljahr deutlich gemacht: Gemeinwohlorientierung und digitale Selbstbestimmung der Bürger:innen werden bei Technologieentwicklung und -anwendung kaum berücksichtigt. Von einer digital souveränen Gesellschaft sind wir weit entfernt. 

--- a/content/blog/2021/2021-04-29-veranstaltungsreihe-okf10.md
+++ b/content/blog/2021/2021-04-29-veranstaltungsreihe-okf10.md
@@ -1,12 +1,11 @@
 ---
 authors:
 - Claudia Jach
-date: 2021-04-29
 image:
   src: /files/blog/2021/04/confetti_Photo_by_jason-leung_unsplash.jpg
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - OKFDE10
 - Community
@@ -15,10 +14,11 @@ tags:
 - Transparenz
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Wir laden ein zu unserer Veranstaltungsreihe. Ein Jahrzehnt OKF – Kritik, Politik und Aktivismus"
+title: Wir laden ein zu unserer Veranstaltungsreihe. Ein Jahrzehnt OKF – Kritik, Politik und Aktivismus
+publishedDate: 2021-04-29
 ---
+
 [10 Jahre OKF](https://okfn.de/anniversary/), das heißt auch, zehn Jahre Kontakte knüpfen, Expertise herausbilden, Konzepte entwickeln und Austausch befördern. All das möchten wir in diesem Sommer in einer Veranstaltungsreihe mit euch zusammen bringen. 
 
 ### Digitale Zivilgesellschaft – dem Schlagwort zum Durchbruch verhelfen

--- a/content/blog/2021/2021-05-03-veranstaltung-digitale-zivilgesellschaft.md
+++ b/content/blog/2021/2021-05-03-veranstaltung-digitale-zivilgesellschaft.md
@@ -2,22 +2,22 @@
 authors:
 - Claudia Jach
 - Patricia Leu
-date: 2021-05-03
 image:
   src: /files/blog/2021/05/demo_by_alex-radelich_unsplash.jpg
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - OKFDE10
 - Community
 - Zivilgesellschaft
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Eine Bestandsaufnahme der digitalen Zivilgesellschaft. Bildschirmgespräch zum 10. Geburtstag der OKF"
+title: Eine Bestandsaufnahme der digitalen Zivilgesellschaft. Bildschirmgespräch zum 10. Geburtstag der OKF
+publishedDate: 2021-05-03
 ---
+
 ### Wir laden ein!
 
 **18. Mai 2021, 17.30 - 19 Uhr**

--- a/content/blog/2021/2021-05-05-digitale-nachhaltigkeit-gerechtigkeit.md
+++ b/content/blog/2021/2021-05-05-digitale-nachhaltigkeit-gerechtigkeit.md
@@ -1,21 +1,21 @@
 ---
 authors:
 - Claudia Jach
-date: 2021-05-05
 image:
   src: /files/blog/2021/04/climate_justice_by_markus_spiske_unsplash.jpg
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - Open-knowledge
 - Policy
 type: post
 layout: post
-published: true
 featured: blue
-title: "Digitale Nachhaltigkeit nur mit digitaler Gerechtigkeit!"
+title: Digitale Nachhaltigkeit nur mit digitaler Gerechtigkeit!
+publishedDate: 2021-05-05
 ---
+
 Das Buzzword Nachhaltigkeit begleitet uns überall. Doch was bedeutet Nachhaltigkeit im Kontext der Arbeit der OKF? Ermöglicht durch eine Projektförderung der [Postcode Lotterie](https://codefor.de/blog/code-for-climate-open-data-day/) konnten wir uns intensiver mit dem Thema auseinandersetzen und mögliche Handlungsfelder für unsere Arbeit herausarbeiten. Im Folgenden stellen wir einige der Ideen kurz vor. [Die vollständige Publikation kann hier heruntergeladen werden.](https://raw.githubusercontent.com/okfde/okfn.de/master/static/files/blog/2021/05/Digitale%20Nachhaltigkeit%20nur%20mit%20digitaler%20Gerechtigkeit.pdf)
 
 ### Zugänge zu digitaler Nachhaltigkeit

--- a/content/blog/2021/2021-05-07-kickoff-foe21-bildungspolitik-gestalten.md
+++ b/content/blog/2021/2021-05-07-kickoff-foe21-bildungspolitik-gestalten.md
@@ -1,21 +1,21 @@
 ---
 authors:
 - Maximilian Voigt
-date: 2021-05-07
 image:
   src: /files/blog/2021/05/FOE-Posts-Social-Media-Landscape2-1024x532.jpg
-  title:
+  title: null
   license: CC-BY 4.0 Wikimedia
-  license_url:
+  license_url: null
 tags:
 - Bildungspolitik
 - Open Education
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Bundespolitik und offene Bildungspraxis gehen in den Austausch"
+title: Bundespolitik und offene Bildungspraxis gehen in den Austausch
+publishedDate: 2021-05-07
 ---
+
 Ab dem 12. Mai kommen zum vierten Mal engagierte Bildungsenthusiast:innen und Bundespolitiker:innen zusammen, um gemeinsam an zukunftsgerichteten Lösungen für die Bildungslandschaft zu arbeiten. Im Zentrum stehen Einschätzungen, Strategien und konkrete Handlungsempfehlungen für eine gerechte, offene und nachhaltige Bildung.
 
 Das vergangene Jahr hat gezeigt, wie wichtig der Austausch mit der Bildungspraxis ist und welche wirkmächtigen Strukturen zivilgesellschaftliche Netzwerke und Projekte schaffen können. Aber auch die Politik zeigte, dass schnelles Handeln möglich ist und ebnete mit zahlreichen Maßnahmen den Weg für längst überfällige Veränderungen. Wohin sich diese in der kommenden Legislatur entwickeln und wie die zahlreichen Fäden zu einer zeitgemäßen und offenen Bildung verwoben werden können, ist Thema des diesjährigen [Forum Open Education](https://education.forum-open.de).

--- a/content/blog/2021/2021-05-17-ptf-solutionismus-innovationsentwicklung.md
+++ b/content/blog/2021/2021-05-17-ptf-solutionismus-innovationsentwicklung.md
@@ -1,22 +1,22 @@
 ---
 authors:
-- 
-date: 2021-05-17
+- null
 image:
   src: /files/blog/2021/05/Copy of PrototypeFund_twitter-headerNEU.png
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - Prototype Fund
 - Policy
 - Positionen
 type: post
 layout: post
-published: true
 featured: blue
-title: "Vielleicht hilft eine App? – Prototype Fund kritisiert Solutionismus in der Innovationsentwicklung"
+title: Vielleicht hilft eine App? – Prototype Fund kritisiert Solutionismus in der Innovationsentwicklung
+publishedDate: 2021-05-17
 ---
+
 **Pressemitteilung**
 
 **Berlin, 17.05.2021**
@@ -38,4 +38,3 @@ Diese Bedeutung von Technologien sollte bereits vor ihrer Entstehung analysiert 
 **+++**
 
 **Für weitere Informationen steht Patricia Leu vom Prototype Fund zur Verfügung: presse@prototypefund.de**
-

--- a/content/blog/2021/2021-05-21-fairer-wahlkampf-campaign-watch.md
+++ b/content/blog/2021/2021-05-21-fairer-wahlkampf-campaign-watch.md
@@ -1,20 +1,20 @@
 ---
 authors:
-- 
-date: 2021-05-21
+- null
 image:
   src: /files/blog/2021/05/campaign-watch.png
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - Policy
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Leitfaden für digitale Demokratie"
+title: Leitfaden für digitale Demokratie
+publishedDate: 2021-05-21
 ---
+
 ### Zivilgesellschaft fordert Parteien zu mehr Einsatz gegen Hetze und Desinformation auf
 
 Ein breites zivilgesellschaftliches Bündnis mit der Open Knowledge Foundation fordert im Wahlkampf 2021 die Parteien zur Einhaltung eines “Leitfaden für Digitale Demokratie” auf. Die Unterzeichner:innen des Appells richten sich an Wahlkämpfende aller Parteien.

--- a/content/blog/2021/2021-05-26-bestandsaufnahme-digitale-zivilgesellschaft.md
+++ b/content/blog/2021/2021-05-26-bestandsaufnahme-digitale-zivilgesellschaft.md
@@ -1,22 +1,22 @@
 ---
 authors:
 - Patricia Leu
-date: 2021-05-26
 image:
   src: /files/blog/2021/05/DZ_Event.png
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - OKFDE10
 - Community
 - Zivilgesellschaft
 type: post
 layout: post
-published: true
 featured: blue
-title: "Von Militärgeschichte zu Datenspaziergängen - eine Bestandsaufnahme der digitalen Zivilgesellschaft"
+title: Von Militärgeschichte zu Datenspaziergängen - eine Bestandsaufnahme der digitalen Zivilgesellschaft
+publishedDate: 2021-05-26
 ---
+
 Am 18. Mai 2021 fand das erste Bildschirmgespräch anlässlich des [10. Geburtstags der OKF](https://okfn.de/anniversary/) in diesem Jahr statt. In einer [“Bestandsaufnahme der digitalen Zivilgesellschaft”](https://okfn.de/blog/2021/05/veranstaltung-digitale-zivilgesellschaft/) diskutierten die Gäste Elisa Lindinger (Initiative Digitale Zivilgesellschaft), Victoria Boeck (Technologiestiftung Berlin) und Maximilian Voigt (Verbund Offener Werkstätten), wer zu dieser zählt, wie sie sich politisch positioniert und - vor allem - wie sie sich politisch mehr Gehör verschaffen kann. [Die Aufzeichnung der Veranstaltung kann hier angesehen werden.](https://www.youtube.com/watch?v=EV4MmjaKerU)
 
 Wir freuen uns sehr, diese drei Expert\*innen für die Veranstaltung gewonnen zu haben, die spannende Ein- und inspirierende Ausblicke geben konnten. Einige davon fassen wir hier zusammen.

--- a/content/blog/2021/2021-06-01-okf-zukunft-teil-eins.md
+++ b/content/blog/2021/2021-06-01-okf-zukunft-teil-eins.md
@@ -1,20 +1,20 @@
 ---
 authors:
 - Andreas Pawelke
-date: 2021-06-01
 image:
   src: /files/blog/2021/06/jugend hackt zukunft.jpg
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - Positionen
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Die OKF der Zukunft – Teil I"
+title: Die OKF der Zukunft – Teil I
+publishedDate: 2021-06-01
 ---
+
 Als langjähriges (und [vor kurzem ausgeschiedenes](https://okfn.de/blog/2021/03/okf-vorstandswechsel/)) Vorstandsmitglied nehme ich zum Abschied das Privileg in Anspruch, nicht nur laut über die vergangene und gegenwärtige Arbeit der OKF nachzudenken, sondern auch Überlegungen zur zukünftigen Ausrichtung der Organisation anzustellen.
 
 ### Die großen Fragen der OKF
@@ -41,4 +41,4 @@ Bei all dem ging es immer [um weit mehr als nur das Erlernen von Programmieren](
 
 Bildung in Pandemiezeiten läuft in Deutschland mehr schlecht als recht. Doch auch wenn es gelingen sollte, die Schulen mit funktionierenden Teststrategien, Wechselunterricht und Co. wieder zu öffnen, so bleiben die großen Fragen nach einer zeitgemäßen Bildung bestehen. Denn die Kluft zwischen dem, was wir jungen Menschen vermitteln, und dem, [was im digitalen Zeitalter tatsächlich notwendig wäre](https://www.linkedin.com/pulse/bildungskrise-dejan-mihajlovi%C4%87/), besteht weiter und wird zunehmend größer. Es ist durchaus zu erwarten (und zu hoffen), dass wir in den nächsten fünf Jahren mehr über [notwendige Veränderungen im Bildungssystem](https://twitter.com/david_perell/status/1381422784996237312) sprechen werden als in den letzten 50 Jahren zusammen.
 
-Die OKF sollte in diesen Diskursen eine prominentere Rolle spielen und den Anspruch haben, die Zukunft der Bildung mitzugestalten. Weil Bildung Ländersache ist, müsste sie dazu vor allem auf Länderebene noch aktiver werden. Die Erfahrungen in der Entwicklung und Umsetzung innovativer Formate, die Netzwerke zur Förderung einer offenen Bildung und insbesondere das Wissen darum, wie man jene Themen, die so wichtig sind in der heutigen Welt aber in den allermeisten Schulen immer noch nicht ganz angekommen sind, verleihen der OKF dabei eine besondere Verantwortung. 
+Die OKF sollte in diesen Diskursen eine prominentere Rolle spielen und den Anspruch haben, die Zukunft der Bildung mitzugestalten. Weil Bildung Ländersache ist, müsste sie dazu vor allem auf Länderebene noch aktiver werden. Die Erfahrungen in der Entwicklung und Umsetzung innovativer Formate, die Netzwerke zur Förderung einer offenen Bildung und insbesondere das Wissen darum, wie man jene Themen, die so wichtig sind in der heutigen Welt aber in den allermeisten Schulen immer noch nicht ganz angekommen sind, verleihen der OKF dabei eine besondere Verantwortung.

--- a/content/blog/2021/2021-06-02-okf-zukunft-teil-zwei.md
+++ b/content/blog/2021/2021-06-02-okf-zukunft-teil-zwei.md
@@ -1,20 +1,20 @@
 ---
 authors:
 - Andreas Pawelke
-date: 2021-06-02
 image:
   src: /files/blog/2021/06/daten zukunft.jpg
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - Positionen
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Die OKF der Zukunft – Teil II"
+title: Die OKF der Zukunft – Teil II
+publishedDate: 2021-06-02
 ---
+
 Als langjähriges (und [vor kurzem ausgeschiedenes](https://okfn.de/blog/2021/03/okf-vorstandswechsel/)) Vorstandsmitglied nehme ich zum Abschied das Privileg in Anspruch, nicht nur laut über die vergangene und gegenwärtige Arbeit der OKF nachzudenken, sondern auch Überlegungen zur zukünftigen Ausrichtung der Organisation anzustellen.
 
 ### Teil II

--- a/content/blog/2021/2021-06-03-okf-zukunft-teil-drei.md
+++ b/content/blog/2021/2021-06-03-okf-zukunft-teil-drei.md
@@ -1,20 +1,20 @@
 ---
 authors:
 - Andreas Pawelke
-date: 2021-06-03
 image:
   src: /files/blog/2021/06/Model novelties Loreto et al 2017.png
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - Positionen
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Die OKF der Zukunft – Teil III"
+title: Die OKF der Zukunft – Teil III
+publishedDate: 2021-06-03
 ---
+
 Als langjähriges (und [vor kurzem ausgeschiedenes](https://okfn.de/blog/2021/03/okf-vorstandswechsel/)) Vorstandsmitglied nehme ich zum Abschied das Privileg in Anspruch, nicht nur laut über die vergangene und gegenwärtige Arbeit der OKF nachzudenken, sondern auch Überlegungen zur zukünftigen Ausrichtung der Organisation anzustellen.
 
 ### Teil III

--- a/content/blog/2021/2021-06-21-digitale-kolonialisierung-stoppen.md
+++ b/content/blog/2021/2021-06-21-digitale-kolonialisierung-stoppen.md
@@ -1,22 +1,22 @@
 ---
 authors:
 - Maximilian Voigt, Patricia Leu
-date: 2021-06-21
 image:
   src: /files/blog/2021/06/ws_Pixel_World_1920x1200.jpg
   title: Quelle "https://hintergrundbilder.wallpaperstock.net/pixel-world-wallpapers_w22479.html"
-  license:
-  license_url:
+  license: null
+  license_url: null
 tags:
-- Public Interest Tech 
+- Public Interest Tech
 - WTO
 - Positionen
 type: post
 layout: post
-published: true
 featured: yellow
-title: "WTO eCommerce: digitale Kolonialisierung stoppen"
+title: 'WTO eCommerce: digitale Kolonialisierung stoppen'
+publishedDate: 2021-06-21
 ---
+
 In 10 Jahren OKF hat sich der digitale Datenaustausch explosionsartig entwickelt. Die Ausbreitung und damit auch Macht international agierender Unternehmen ist weit fortgeschritten. Die Welthandelsorganisation (WTO) entwickelt im Rahmen einer „Joint Statement Initiative“ (JSI) seit dem Frühjahr 2019 gemeinsame Regeln ([WTO Electronic Commerce Negotiations](https://www.bilaterals.org/IMG/pdf/wto_plurilateral_ecommerce_draft_consolidated_text.pdf)) für den Handel in der Digitalökonomie. Wir fordern mit Aktivist:innen wie der Anwältin [Renata Ávila Pinto](https://de.wikipedia.org/wiki/Renata_Ávila_Pinto) den digitalen Kolonialismus zu stoppen und globale Regeln am Gemeinwohl auszurichten.
 
 In den letzten fast fünfzig Jahren hat sich die Architektur des Internets von einem weitgehend demokratischen Netzwerk autonomer Knoten zu einer verteilten feudalen Struktur verändert, die Daten in wenigen Händen zentralisiert. Wohlhabende Länder dominieren diese Struktur. Das Ziel der großen Technologieunternehmen ist offensichtlich: Es gibt einen Wettlauf um den Anschluss der nächsten Milliarde Menschen an eine Version des Internets, die nicht mehr auf Offenheit oder das öffentliche Interesse ausgerichtet ist. Sie wollen die kritische Infrastruktur weltweit kontrollieren, um die fehlenden Datensätze der globalen Bevölkerung, insbesondere benachteiligter Menschen des Globalen Südens, in die Hände zu bekommen. Diese und weitere Erkenntnisse formuliert [Renata Ávila Pinto](https://de.wikipedia.org/wiki/Renata_Ávila_Pinto) in ihrem Papier [“Against Digital Colonialism”](https://autonomy.work/wp-content/uploads/2020/09/Avila.pdf). Darin untersucht sie, wie dominante Länder innerhalb eines globalen Systems von der Digitalisierung einkommensschwacher Länder profitieren, was sie als eine neue Form des Kolonialismus bezeichnet.

--- a/content/blog/2021/2021-07-08-freiheit-fuer-wissen-freiheit-fuer-uns.md
+++ b/content/blog/2021/2021-07-08-freiheit-fuer-wissen-freiheit-fuer-uns.md
@@ -1,12 +1,11 @@
 ---
 authors:
 - Judith Doleschal
-date: 2021-07-08
 image:
   src: /files/blog/2021/07/freiheit-fuer-wissen.jpg
   title: Fragezeichen in Leuchtschrift
-  license:
-  license_url:
+  license: null
+  license_url: null
 tags:
 - OKFDE10
 - Community
@@ -14,9 +13,9 @@ tags:
 - Informationsfreiheit
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Freiheit für Wissen! Freiheit für uns?"
+title: Freiheit für Wissen! Freiheit für uns?
+publishedDate: 2021-07-08
 ---
 
 ### Wir laden ein!
@@ -40,4 +39,3 @@ Informationsfreiheit ist dank FragDenStaat kein Fremdwort mehr. Dennoch sind sic
 Gleichermaßen wollen wir einen kritischen Blick wagen und diskutieren, was noch zu tun ist. Was hat sich seit der Gründung von FragDenStaat.de – ebenfalls vor zehn Jahren – tatsächlich getan? Ist Transparenz alleine der Heilsbringer, nach dem sich viele sehnen, oder was braucht es darüber hinaus? Die Liste der Forderungen vor der Bundestagswahl ist lang –  besonders zu erwähnen ist hierbei die Tromsö-Konvention, die Deutschland immer noch nicht unterzeichnet hat. Abschreckende Gebühren und vorgeschobene vermeintliche Urheberrechte werden gern genommen, um Antragsteller:innen am Informationszugang zu hindern. Wie wir als Community hier Druck auf die Politik ausüben und kämpfen können, wird ebenfall Teil des Gesprächs sein.
 
 Auf YouTube wird es die Möglichkeit geben, Fragen im Chat zu stellen. Außerdem könnt ihr auf Twitter unter [#OKFde10](https://twitter.com/hashtag/OKFde10) und [@okfde](https://twitter.com/okfde) mitdiskutieren.
-

--- a/content/blog/2021/2021-07-15-jahresbericht-2020.md
+++ b/content/blog/2021/2021-07-15-jahresbericht-2020.md
@@ -2,22 +2,22 @@
 authors:
 - Vorstand
 - Henriette Litta
-date: 2021-07-15
 image:
   src: /files/blog/2021/07/titelbild_fuer_blog.png
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - OKFDE
 - openknowledge
 - jahresbericht
 type: post
 layout: post
-published: true
 featured: blue
-title: "Das war 2020: Unser Jahresbericht ist jetzt veröffentlicht"
+title: 'Das war 2020: Unser Jahresbericht ist jetzt veröffentlicht'
+publishedDate: 2021-07-15
 ---
+
 ### Das letzte Jahr war mal wieder besonders aufregend. Eine kurze Übersicht über 2020 stellen wir euch hier zusammen. Ausführlichere und übersichtlich zusammengestellte Informationen findet ihr in unserem [Jahresbericht 2020](https://2020.okfn.de/).
 
  *   In diesem Jahr eröffnete [Jugend hackt](https://jugendhackt.org/) drei neue Labs in Cottbus, Heilbronn und Heidelberg. Zusammen mit den 2019 gestarteten Pilot-Labs in Fürstenberg und Ulm gibt es damit in fünf deutschen Städten ein regelmäßiges Angebot von Jugend hackt mit Workshops, Vorträgen und offenen Nachmittagen.

--- a/content/blog/2021/2021-07-20-transparenzranking-2021.md
+++ b/content/blog/2021/2021-07-20-transparenzranking-2021.md
@@ -1,21 +1,21 @@
 ---
 authors:
 - Arne Semsrott
-date: 2021-07-20
 image:
   src: /files/blog/2021/07/transparenzranking-2021.jpg
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - Transparenzranking
 - FragDenStaat
 type: post
 layout: post
-published: true
 featured: blue
-title: "Neues Transparenz-Ranking 2021: Bundesländer meilenweit auseinander"
+title: 'Neues Transparenz-Ranking 2021: Bundesländer meilenweit auseinander'
+publishedDate: 2021-07-20
 ---
+
 Das neue Transparenz-Ranking zeigt große Unterschiede zwischen den Bundesländern in Sachen Informationsfreiheit: Verträge der öffentlichen Hand, Gutachten oder für die Allgemeinheit wichtigen Informationen, zum Beispiel über staatlich kontrollierte Unternehmen, Hochschulen oder Strafverfolgungsbehörden, sind noch immer nicht in allen Bundesländern einsehbar. In Hamburg (Platz 1) macht die Verwaltung solche amtlichen Dokumente und Aufzeichnungen von sich aus kostenlos zugänglich, seitdem 2012 eine Volksinitiative für ein Transparenzgesetz erfolgreich war. Bayern, Sachsen und Niedersachsen (gemeinsam auf dem letzten Platz) dagegen ermöglichen der Bevölkerung bisher nicht einmal auf Nachfrage, an Informationen zu gelangen.
 
 "Informationsfreiheit ist Teil eines demokratischen Staatswesens“, sagt Arne Semsrott, Projektleiter von FragDenStaat bei der Open Knowledge Foundation. „Trotzdem haben Bayern, Sachsen und Niedersachsen noch immer kein Informationsfreiheitsgesetz. Die dortigen Landesregierungen schließen ihre Bürgerinnen und Bürger noch komplett von der Einsicht in Verwaltungsakten aus. Das muss sich ändern!" Die nächste Bundesregierung müsse Informationsfreiheit endlich zum Standard in ganz Deutschland machen und die Tromsö-Konvention des Europarates über den Zugang zu amtlichen Dokumenten unterzeichnen.

--- a/content/blog/2021/2021-08-01-10-jahre-fragdenstaat.md
+++ b/content/blog/2021/2021-08-01-10-jahre-fragdenstaat.md
@@ -1,20 +1,19 @@
 ---
 authors:
 - Arne Semsrott
-date: 2021-08-01
 image:
   src: /files/blog/2021/08/fds.png
   title: Ausschnitt aus dem Aufghanistan-Lagebericht des Auswärtigen Amts
-  license: 
-  license_url: 
+  license: null
+  license_url: null
 tags:
 - FragDenStaat
 - Informationsfreiheit
 type: post
 layout: post
-published: true
 featured: blue
-title: "10 Jahre FragDenStaat: Fortschritte sind durchaus erkennbar"
+title: '10 Jahre FragDenStaat: Fortschritte sind durchaus erkennbar'
+publishedDate: 2021-08-01
 ---
 
 FragDenStaat wird heute zehn Jahre alt. Darüber freuen wir uns sehr!

--- a/content/blog/2021/2021-08-05-freiheit-fuer-wissen.md
+++ b/content/blog/2021/2021-08-05-freiheit-fuer-wissen.md
@@ -1,12 +1,11 @@
 ---
 authors:
 - Judith Doleschal
-date: 2021-08-05
 image:
   src: /files/blog/2021/08/online-talkrunde-2-julia-stefan-freiheit.jpg
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - OKFDE10
 - Community
@@ -14,10 +13,11 @@ tags:
 - Informationsfreiheit
 type: post
 layout: post
-published: true
 featured: blue
-title: "Von der ersten Anfrage bis zur großen Enthüllung - zwei Perspektiven auf 10 Jahre Informationsfreiheit"
+title: Von der ersten Anfrage bis zur großen Enthüllung - zwei Perspektiven auf 10 Jahre Informationsfreiheit
+publishedDate: 2021-08-05
 ---
+
 Unser Veranstaltungsreihe im Rahmen des [10. Geburtstags der OKF](https://okfn.de/anniversary/) ist am 20. Juli 2021 in die nächste Runde gegangen. Dieses Mal haben sich Felix Reda und Stefan Wehrmeyer über Informationsfreiheit ausgetauscht.
 
 Informationsfreiheit spielt schon seit Gründung in der OKF eine wichtige Rolle, denn [FragDenStaat.de](https://fragdenstaat.de) – die Plattform für Informationsfreiheit – wird dieses Jahr ebenfalls 10 Jahre alt und war somit von Anfang an mit dabei. Stefan erzählt, wie er 2011 als Softwareentwickler nach guten Civic Tech-Anwendungsfällen gesucht und bei befreundeten internationalen Organisationen das Thema entdeckt hat. Behörden zur Herausgabe öffentlicher Informationen zwingen, gibt es dafür auch eine rechtliche Grundlage in Deutschland? Schnell hat sich gezeigt, dass ein komplexes Bundes-Informationsfreiheitsgesetz (IFG) und viele zusätzliche Spezial- und Ländergesetze eine neue eigene Plattform erforderlich machen.

--- a/content/blog/2021/2021-08-18-kickoff-open-hardware-foerdern.md
+++ b/content/blog/2021/2021-08-18-kickoff-open-hardware-foerdern.md
@@ -1,20 +1,19 @@
 ---
 authors:
 - Maximilian Voigt
-date: 2021-08-18
 image:
   src: https://preciousplastic.com/images/basic-extruder.jpg
   title: Precious Plastic Extrusion
-  license: CC-BY-SA 4.0 
+  license: CC-BY-SA 4.0
   license_url: https://creativecommons.org/licenses/by-sa/4.0/
 tags:
 - Open Hardware
 - Civic Tech
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Kickoff MoFab: zivilgesellschaftlich orientierte, offene Hardware fördern"
+title: 'Kickoff MoFab: zivilgesellschaftlich orientierte, offene Hardware fördern'
+publishedDate: 2021-08-18
 ---
 
 Mit dem [Prototype Fund](https://prototypefund.de) besteht bereits ein starkes Programm zur Förderung von Open Source Software, das stetig weiterentwickelt wird. Durch das BMBF geförderte Forschungsprojekt [MoFab](https://okfn.de/projekte/mofab/) - Mobile Fablabs - kann erstmals ein Open Hardware Fund aufgebaut werden. Gefördert werden bis zu sechs Vorhaben, die Ausschreibung wird voraussichtlich im Frühjahr 2022 starten.
@@ -25,4 +24,4 @@ Unter dem Themenbereich der Reparaturkultur ruft das Projektbündnis aus [Netzwe
 
 Das Projekt wird vom BMBF gefördert und hat eine Projektlaufzeit von zwei Jahren.
 
-Du hast jetzt schon Interesse, Rückfragen oder möchtest auf dem Laufenden bleiben? Dann meldet euch gerne mit einer Mail oder schreibt euch auf die [Open-Hardware-Mailingliste](https://mailman.offene-werkstaetten.org/mailman/listinfo/hardware-offene-werkstaetten.org). 
+Du hast jetzt schon Interesse, Rückfragen oder möchtest auf dem Laufenden bleiben? Dann meldet euch gerne mit einer Mail oder schreibt euch auf die [Open-Hardware-Mailingliste](https://mailman.offene-werkstaetten.org/mailman/listinfo/hardware-offene-werkstaetten.org).

--- a/content/blog/2021/2021-08-27-stf-infrastructure.md
+++ b/content/blog/2021/2021-08-27-stf-infrastructure.md
@@ -2,10 +2,9 @@
 authors:
 - Katharina Meyer
 - Adriana Groh
-date: 2021-08-27
 image:
   src: /files/blog/2021/08/dependency.png
-  title: 
+  title: null
   license: CC BY-NC 2.5
   license_url: https://creativecommons.org/licenses/by-nc/2.5/
 tags:
@@ -13,9 +12,9 @@ tags:
 - zivilgesellschaft
 type: post
 layout: post
-published: true
 featured: blue
 title: Infrastructure first, Innovation second!
+publishedDate: 2021-08-27
 ---
 
 Verschiedene Arten von Infrastrukturen verbindet, dass sie in der Regel beinahe unsichtbar sind - und deshalb gerne in Vergessenheit geraten. Ob Internet-Kabel auf dem Meeresgrund, die Straßen unter unseren Füßen und Reifen, oder die untersten Schichten eines Technologiestacks - Infrastrukturen wirken im Verborgenen.

--- a/content/blog/2021/2021-09-01-abschluss-foe.md
+++ b/content/blog/2021/2021-09-01-abschluss-foe.md
@@ -1,21 +1,21 @@
 ---
 authors:
 - Maximilian Voigt
-date: 2021-09-01
 image:
   src: /files/blog/2021/09/foe-abschluss.jpeg
   title: Carla Cargo Drawing
   license: CC-BY 4.0 FOE21
-  license_url: 
+  license_url: null
 tags:
 - Open Education
 - Bildungspolitik
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Mach mit: für transparente und offene Politikgestaltung"
+title: 'Mach mit: für transparente und offene Politikgestaltung'
+publishedDate: 2021-09-01
 ---
+
 Mit dem vierten [Forum Open Education](https://education.forum-open.de) geht die über vier Jahre gewachsene Veranstaltung zu Ende. Begonnen als Paneldiskussion ist daraus ein über fünf Monate verlaufendes Beteiligungsprogramm entstanden, durch das Abgeordnete und Aktivist\*en intensiv zusammenarbeiten. Die Teilnehmenden diskutieren Positionen, Ideen und entwickeln gemeinsame Konzepte. In diesem Jahr waren es folgende Themen:
 
 * **[Bildungsbenachteiligungen erfassen und strukturiert angehen](https://education.forum-open.de/2021/groups/fg1.html)** \

--- a/content/blog/2021/2021-09-15-gruendung-f5.md
+++ b/content/blog/2021/2021-09-15-gruendung-f5.md
@@ -1,21 +1,21 @@
 ---
 authors:
 - Henriette Litta
-date: 2021-09-15
 image:
   src: /files/blog/2021/01/data-joshua-sortino-unsplash.jpeg
-  title:
-  license: 
-  license_url: 
+  title: null
+  license: null
+  license_url: null
 tags:
 - Open Government
 - Zivilgesellschaft
 type: post
 layout: post
-published: true
 featured: blue
 title: OKF gründet gemeinsam mit Partnerorganisationen Bündnis F5 für eine gemeinwohlorientierte Digitalisierung
+publishedDate: 2021-09-15
 ---
+
 **Die Open Knowledge Foundation Deutschland (OKF), AlgorithmWatch, die Gesellschaft für Freiheitsrechte, Reporter ohne Grenzen und Wikimedia Deutschland schließen sich zum Bündnis F5 zusammen. Ziel der Kooperation ist es, für einen Neustart in der Digitalpolitik (F5) zu werben, um die Digitalisierung an den Interessen der Menschen in Deutschland und Europa auszurichten. Der Fokus sollte in Zukunft auf dem Gemeinwohl liegen, anstatt Interessen von Behörden und die Einnahmen von Tech-Konzerne zum Gradmesser zu machen.**
  
 Erstmals vorgestellt haben wir uns als Bündnis F5 auf dem [Internet Governance Forum](https://www.igf-d.de/igf-d-2021/) gestern am 14. September 2021. „Mit aktiven Gesprächsangeboten an Abgeordnete wollen wir uns dafür einsetzen, dass Prinzipien der offenen und transparenten Regierungsführung auch durch den Einsatz von digitalen Instrumenten besser umgesetzt werden“, sagt Henriette Litta, Geschäftsführerin der OKF. Ausgehend von einem demokratischen Verständnis der Digitalisierung wendet sich das Bündnis der Kernfrage der kommenden Jahre und Jahrzehnte zu: Wie können Offenheit und Transparenz, Teilhabe und Zugang konkret in politische Formen gegossen werden, um bessere Spielregeln für die digitale Welt zu schaffen? Am Freitag ist zudem ein Artikel im [Tagesspiegel Background](https://background.tagesspiegel.de/digitalisierung/dis-kurswechsel-in-der-digitalpolitik) zum Bündnis erschienen. 

--- a/content/blog/2021/2021-09-16-fuer-eine-euopaeische-infrastruktur-zum-datenschutz.md
+++ b/content/blog/2021/2021-09-16-fuer-eine-euopaeische-infrastruktur-zum-datenschutz.md
@@ -1,19 +1,18 @@
 ---
 authors:
 - Beata Hubrig
-date: 2021-09-16
 image:
   src: /files/blog/2021/09/2021-09-15_datenschutz.jpg
-  title:
-  license: 
-  license_url: 
+  title: null
+  license: null
+  license_url: null
 tags:
 - Datenschutz
 type: post
 layout: post
-published: true
 featured: yellow
 title: Für eine europäische Infrastruktur zum Datenschutz
+publishedDate: 2021-09-16
 ---
 
 **In diesem Blogartikel meldet sich die OKF-Datenschutzexpertin Beata Hubrig zu Wort. 

--- a/content/blog/2021/2021-11-16-stf-publikation-machbarkeitsstudie.md
+++ b/content/blog/2021/2021-11-16-stf-publikation-machbarkeitsstudie.md
@@ -1,20 +1,19 @@
 ---
 authors:
 - Adriana Groh
-date: 2021-11-16
 image:
   src: /files/blog/2021/09/STF_Titelfolie.png
   title: STF-Studie_Titel
   license: CC-BY OKFDE
-  license_url: 
+  license_url: null
 tags:
 - infrastructure
 - Basistechnologien
 type: post
 layout: post
-published: true
 featured: yellow
 title: Wir brauchen ein Förderprogramm für Offene Digitale Basistechnologien
+publishedDate: 2021-11-16
 ---
 
 **Berlin, 16.11.2021**

--- a/content/blog/2021/2021-11-25-okf-kommentar-koalitionsvertrag.md
+++ b/content/blog/2021/2021-11-25-okf-kommentar-koalitionsvertrag.md
@@ -1,20 +1,19 @@
 ---
 authors:
 - Henriette Litta
-date: 2021-11-25
 image:
   src: /files/blog/2021/09/Screenshot_KoaVertrag2021.png
   title: Screenshot vom Titel des Koalitionsvertrags
   license: Screenshot vom Titel des Koalitionsvertrags
-  license_url: 
+  license_url: null
 tags:
 - politik
 - zivilgesellschaft
 type: post
 layout: post
-published: true
 featured: blue
 title: Der Koalitionsvertrag liegt vor. In der Digitalpolitik soll vieles anders werden. Gut so. Aber bitte auch liefern.
+publishedDate: 2021-11-25
 ---
 
 **Gestern hat die Ampel ihren [Koalitionsvertrag](https://fragdenstaat.de/dokumente/142083-koalitionsvertrag-2021-2025/#page-1) vorgestellt. Für die Digitalpolitik nimmt sie sich viel vor. Sehr erfreulich ist der vorgenommene Perspektivwechsel: Im Zentrum der Vorschläge stehen die Bürger:innen mit ihren Rechten, ihrem Bedürfnis nach Sicherheit und dem Wunsch nach mehr Partizipation. Darüber hinaus ist es den Verhandelnden gelungen, die Digitalpolitik in ihrer gesamten Bandbreite quer über alle Themen zu verankern: Von der Infrastruktur, den Digitalkompetenzen, den Verbraucher:innenrechten bis zur IT-Sicherheit und der Außenpolitik. Aus der Zivilgesellschaft bekommt die Ampel daher viel Lob zum Start. Ob sie die ambitionierten Pläne wirklich umsetzt, werden wir ab jetzt kritisch begleiten.**
@@ -55,4 +54,4 @@ Wir begrüßen es sehr, dass die Ampel “zivilgesellschaftliches Bildungsengage
 
 **Institutioneller Rahmen: same same but different?**
 
-Die neue Regierung gibt uns im Koalitionsvertrag nur wenig Aufschluss darüber, in welcher institutionellen Konstellation die ambitionierten Pläne der Digitalpolitik umgesetzt werden sollen. Es wird wohl kein Digitalministerium geben, sondern ein neues zentrales Digitalbudget, das wahrscheinlich im Bundeskanzleramt angesiedelt wird. Gesetzentwürfe sollen sich zudem einem Digitalisierungscheck unterziehen. Ob diese “kleine Lösung” die passende Form für eine umfassend neue Digitalpolitik ist, bleibt abzuwarten. Wir sind gespannt, wie die Ausgestaltung aussehen wird. 
+Die neue Regierung gibt uns im Koalitionsvertrag nur wenig Aufschluss darüber, in welcher institutionellen Konstellation die ambitionierten Pläne der Digitalpolitik umgesetzt werden sollen. Es wird wohl kein Digitalministerium geben, sondern ein neues zentrales Digitalbudget, das wahrscheinlich im Bundeskanzleramt angesiedelt wird. Gesetzentwürfe sollen sich zudem einem Digitalisierungscheck unterziehen. Ob diese “kleine Lösung” die passende Form für eine umfassend neue Digitalpolitik ist, bleibt abzuwarten. Wir sind gespannt, wie die Ausgestaltung aussehen wird.

--- a/content/blog/2021/2021-12-22-okf-beim-rc3.md
+++ b/content/blog/2021/2021-12-22-okf-beim-rc3.md
@@ -1,11 +1,10 @@
 ---
 authors:
 - Maximilian Voigt
-date: 2021-12-22
 image:
   src: /files/blog/2021/12/Fairydust.png
   title: Fairydust
-  license: CC0 
+  license: CC0
   license_url: https://creativecommons.org/publicdomain/zero/1.0/deed.de
 tags:
 - Open Hardware
@@ -14,9 +13,9 @@ tags:
 - Community
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Die OKF beim rC3"
+title: Die OKF beim rC3
+publishedDate: 2021-12-22
 ---
 
 Auch in diesem Jahr wird der jährliche Congress des Chaos Computer Clubs wieder online stattfinden. Dazu bieten verschiedene Hackspaces Bühnen für Veranstaltungen ([eine Übersicht gibt es hier](https://pretalx.c3voc.de/)). Außerdem könnt ihr euch in der Remote Chaos Experience treffen - dazu müsst ihr euch nur ein [Ticket klicken](https://tickets.events.ccc.de/RC3-21/). Auch die OKF ist mit ein paar Talks, Workshops und Community-Treffen dabei, die wir hier auflisten:

--- a/content/blog/2022/2022-01-11-fuer-den-schutz-des-pseudonyms.md
+++ b/content/blog/2022/2022-01-11-fuer-den-schutz-des-pseudonyms.md
@@ -1,19 +1,18 @@
 ---
 authors:
 - Beata Hubrig
-date: 2022-01-11
 image:
   src: /files/blog/2022/01/220111-schutz-des-pseudonyms.jpg
   title: Fuer den Schutz des Psyeudonyms
-  license:
-  license_url:
+  license: null
+  license_url: null
 tags:
 - Datenschutz
 type: post
 layout: post
-published: true
 featured: blue
 title: Für den Schutz des Pseudonyms
+publishedDate: 2022-01-11
 ---
 
 *In diesem Blogartikel meldet sich die OKF-Datenschutzexpertin Beata Hubrig zu Wort. Die Rechtsanwältin tritt dafür ein, dass Nutzer\*innen Profile auf Facebook etc. weiterhin unter Pseudonymen verwenden können. Das Oberlandesgericht München hatte zuletzt anders geurteilt. Update vom 27.01.2022: Der Bundesgerichtshof entschied zugunsten der pseudonymisierten Nutzung.*
@@ -54,4 +53,4 @@ Die bundesrichterliche Entscheidung über die Revision gegen die Entscheidung de
 
 _Nach den für diesen Fall maßgeblichen Nutzungsbedingungen vom 19. April 2018 hat der Kontoinhaber bei der Nutzung des Netzwerks den Namen zu verwenden, den er auch im täglichen Leben verwendet. Diese Bestimmung ist unwirksam, weil sie den Kläger zum Zeitpunkt ihrer Einbeziehung in den Nutzungsvertrag der Parteien am 30. April 2018 entgegen den Geboten von Treu und Glauben unangemessen benachteiligte. Sie ist mit dem in § 13 Abs. 6 Satz 1 TMG in der bis zum 30. November 2021 geltenden Fassung zum Ausdruck kommenden Grundgedanken, dass der Diensteanbieter die Nutzung der Telemedien anonym oder unter Pseudonym zu ermöglichen hat, soweit dies technisch möglich und zumutbar ist, nicht zu vereinbaren. Eine umfassende Würdigung und Abwägung der wechselseitigen Interessen unter Einbeziehung von Art. 6 Abs. 1 Buchst. c der Richtlinie 95/46/EG des Europäischen Parlaments und des Rates vom 24. Oktober 1995 zum Schutz natürlicher Personen bei der Verarbeitung personenbezogener Daten und zum freien Datenverkehr (Datenschutz-Richtlinie) ergibt, dass es der Beklagten zwar nicht zumutbar gewesen ist, die Nutzung des Netzwerks zu ermöglichen, ohne dass der jeweilige Nutzer ihr zuvor – etwa bei der Registrierung – im Innenverhältnis seinen Klarnamen mitgeteilt hatte. Für die anschließende Nutzung der von ihr angebotenen Dienste unter Pseudonym ist die Zumutbarkeit jedoch zu bejahen._
 
-https://www.bundesgerichtshof.de/SharedDocs/Pressemitteilungen/DE/2022/2022013.html 
+https://www.bundesgerichtshof.de/SharedDocs/Pressemitteilungen/DE/2022/2022013.html

--- a/content/blog/2022/2022-01-19-prototype-fund-hardware-gestartet.md
+++ b/content/blog/2022/2022-01-19-prototype-fund-hardware-gestartet.md
@@ -1,10 +1,9 @@
 ---
 authors:
 - Maximilian Voigt
-date: 2022-01-19
 image:
   src: https://hardware.prototypefund.de/wp-content/uploads/2021/12/unbo_blackbox.png
-  title: "Unbox / Blackbox"
+  title: Unbox / Blackbox
   license: CC-BY 4.0
   license_url: https://creativecommons.org/licenses/by/4.0/
 tags:
@@ -12,9 +11,9 @@ tags:
 - Open Hardware
 type: post
 layout: post
-published: true
 featured: yellow
 title: Prototype Fund Hardware gestartet
+publishedDate: 2022-01-19
 ---
 
 Mit dem Prototype Fund besteht bereits ein Programm zur Förderung von zivilgesellschaftlich orientierter Open-Source-Software. Insgesamt wurden bereits 248 Projekte unterstützt, die [großartige Ergebnisse](https://prototypefund.de/projects/) hervorgebracht haben. Immer wieder kamen auch Bewerbungen aus dem Bereich der Hardware, die allerdings aus formalen Gründen nicht gefördert werden können. Das versuchen wir - Daniel Wessolek und Maximilian Voigt - nun mit unserem [Partnerprogramm](https://hardware.prototypefund.de/) zu ändern und damit eine Lücke zu schließen. 
@@ -23,4 +22,4 @@ Denn ein Förderprogramm für offene Hardware ist ein Anliegen, an dem einige sc
 
 Mit dem BMBF geförderte Forschungsprojekt [MoFab](https://okfn.de/projekte/mofab/) - Mobile Fablabs - besteht nun die Chance, ein solches Förderprogramm aufzubauen. Mit dem [Prototype Fund Hardware](https://hardware.prototypefund.de/) können zunächst bis zu sechs Vorhaben gefördert werden, die Ausschreibung startet am 15. April 2022. Im Fokus der Forschung steht die Frage, was Public Interest Tech und Civic Tech für Hardware bedeuten. Denn Open Source und die damit verbundenen Technologien sind kein Selbstzweck. Eine erste Orientierung, insbesondere auch für mögliche Bewerbende, soll unsere [digitale Ausstellung](https://hardware.prototypefund.de/hardware-gallery/) geben. Außerdem sammeln wir unsere Erkenntnisse in diesem [Artikel zu Public Interest Hardware](https://hardware.prototypefund.de/about/public-interest-hardware/).
 
-Wir freuen uns sehr über die Möglichkeit und möchten euch einladen, mit uns zu zeigen, welches Potenzial in Open Hardware steckt. Kramt schon mal in euren Schubladen und bewerbt euch ab dem 15. April mit euren Ideen. 
+Wir freuen uns sehr über die Möglichkeit und möchten euch einladen, mit uns zu zeigen, welches Potenzial in Open Hardware steckt. Kramt schon mal in euren Schubladen und bewerbt euch ab dem 15. April mit euren Ideen.

--- a/content/blog/2022/2022-02-10-okf-lobbyregister.md
+++ b/content/blog/2022/2022-02-10-okf-lobbyregister.md
@@ -1,10 +1,9 @@
 ---
 authors:
 - Henriette Litta
-date: 2022-02-10
 image:
   src: /files/blog/2019/11/reichstag-juergen-matern.jpg
-  title: "Reichstag"
+  title: Reichstag
   license: CC BY-SA 3.0
   license_url: https://creativecommons.org/licenses/by-sa/3.0
 tags:
@@ -13,9 +12,9 @@ tags:
 - Advocacy
 type: post
 layout: post
-published: true
 featured: blue
 title: Das neue Lobbyregister braucht schon jetzt ein Update (und wir sind auch drin)
+publishedDate: 2022-02-10
 ---
 
 **Berlin, 10.02.2022**

--- a/content/blog/2022/2022-02-16-okf-unterstuetzt-recht-auf-reparatur.md
+++ b/content/blog/2022/2022-02-16-okf-unterstuetzt-recht-auf-reparatur.md
@@ -1,10 +1,9 @@
 ---
 authors:
 - Maximilian Voigt
-date: 2022-02-16
 image:
   src: /files/blog/2022/02/repair.JPG
-  title: "Repair Café"
+  title: Repair Café
   license: CC BY 4.0 FabLab Cottbus
   license_url: https://creativecommons.org/licenses/by/4.0
 tags:
@@ -12,10 +11,11 @@ tags:
 - Open Hardware
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Recht auf Reparatur: ein erster Schritt zu offenen Technologien"
+title: 'Recht auf Reparatur: ein erster Schritt zu offenen Technologien'
+publishedDate: 2022-02-16
 ---
+
 Die Open Knowledge Foundation unterstützt mit zahlreichen anderen Initiativen den Appell des [Runden Tisch Für Reparatur](https://runder-tisch-reparatur.de/) an die Bundesregierung, das [Recht auf Reparatur wirksam umzusetzen](https://netzpolitik.org/2022/recht-auf-reparatur-die-ampel-wartet-auf-bruessel/). Die bessere Reparierbarkeit, der Zugang zu Ersatzteilen und Reparaturanleitungen sowie verpflichtende Update-Zeiträume sind wichtige Maßnahmen, um die Lebensdauer unserer Alltagstechnologien zu verlängern und dadurch Ressourcen zu schonen. Es sind aber auch maßgebliche Aspekte der Beteiligung an Technologie. **Seit Jahren erleben wir, dass Hardware immer verschlossener designt wird. Diese Entwicklung muss ein Ende haben.**
 
 Das Recht auf Reparatur setzt hier einen wichtigen Startpunkt, um ein Mindestmaß an Autonomie zurückzugewinnen. Perspektivisch muss es aber darauf hinauslaufen, den Umgang mit technischem Wissen grundlegend neu zu denken und auf offene Technologien zu setzen. Mit der [2021 erschienenen Studie](https://digital-strategy.ec.europa.eu/en/library/study-about-impact-open-source-software-and-hardware-technological-independence-competitiveness-and) *"The impact of open source software and hardware on technological independence, competitiveness and innovation in the EU economy"* hat sich die EU-Kommission bereits mit den Potenzialen von offenen Technologien auseinandergesetzt. Jetzt müssen Rahmenbedingungen geschaffen werden, um aus den Potenzialen konkrete Entwicklungsmöglichkeiten ableiten zu können. Dazu gehören:

--- a/content/blog/2022/2022-02-28-open-data-berlin.md
+++ b/content/blog/2022/2022-02-28-open-data-berlin.md
@@ -1,10 +1,9 @@
 ---
 authors:
 - Stefan Kaufmann und Walter Palmetshofer
-date: 2022-02-28
 image:
   src: /files/blog/2022/02/Bebelplatz_berlin_1998.jpg
-  title: "Reichstag"
+  title: Reichstag
   license: CC BY-SA 3.0
   license_url: https://creativecommons.org/licenses/by-sa/3.0
 tags:
@@ -13,11 +12,10 @@ tags:
 - Advocacy
 type: post
 layout: post
-published: true
 featured: blue
 title: Eine neue Open Data Strategie für Berlin
+publishedDate: 2022-02-28
 ---
-
 
 Als das Land Berlin letztes Jahr 10 Jahre Open Data feierte, war das Anlass für einige Diskussionen unter denjenigen, die den Prozess schon länger aus Sicht der Zivilgesellschaft begleiteten: Auch 10 Jahre später scheinen wir noch weit entfernt von einer automatisierten Open-by-Default-Strategie. Umso mehr freut uns, dass Berlin sich genau diesen kritischen Blick als Unterstützung bei der Ausarbeitung einer neuen Open-Data-Strategie gewünscht hat. Die Open Knowledge Foundation darf das Land bei der Entwicklung dieser Strategie unterstützen, und wir wünschen uns ganz ausdrücklich viel Beteiligung von all denjenigen in unserem weiten und erfahrenen Ehrenamtsnetzwerk, die die üblichen Fallstricke und Probleme kennen!
 

--- a/content/blog/2022/2022-03-18-koalitionstracker.md
+++ b/content/blog/2022/2022-03-18-koalitionstracker.md
@@ -1,16 +1,15 @@
 ---
 authors:
 - Leonie Gehrke
-date: 2022-03-18
 image:
   src: /files/blog/2022/03/koatracker.jpg
 tags:
 - Transparenz
 type: post
 layout: post
-published: true
 featured: blue
-title: "Neu: Wir starten Koalitionstracker, um Regierungsarbeit zu kontrollieren"
+title: 'Neu: Wir starten Koalitionstracker, um Regierungsarbeit zu kontrollieren'
+publishedDate: 2022-03-18
 ---
 
 Auf fragdenstaat.de/koalitionstracker können Bürger:innen, Journalist:innen und weitere Interessierte verfolgen, welche Vorhaben aus dem verabschiedeten Koalitionsvertrag aktuell bearbeitet werden, welche umgesetzt sind oder auf Eis liegen. Ergänzt wird der Koalitionstracker durch weiterführende Informationen und qualitative Einschätzungen von Expert:innen aus der Zivilgesellschaft. 

--- a/content/blog/2022/2022-03-28-stf-offener-brief.md
+++ b/content/blog/2022/2022-03-28-stf-offener-brief.md
@@ -1,7 +1,6 @@
 ---
 authors:
 - Felix Reda
-date: 2022-03-28
 image:
   src: /files/blog/2020/03/2020-03-23-Prototyp-und-dann.jpg
   title: Photo by Charles Deluvio on Unsplash
@@ -11,9 +10,9 @@ tags:
 - Infrastruktur
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Sovereign Tech Fund: Bundestag muss Open Source im Haushalt verankern"
+title: 'Sovereign Tech Fund: Bundestag muss Open Source im Haushalt verankern'
+publishedDate: 2022-03-28
 ---
 
 **Berlin, 28.03.2022**

--- a/content/blog/2022/2022-03-31-open-source-investigation.md
+++ b/content/blog/2022/2022-03-31-open-source-investigation.md
@@ -1,20 +1,19 @@
 ---
 authors:
 - Patricia Leu
-date: 2022-03-31
 image:
   src: /files/blog/2022/03/open-source-investigation.jpg
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 tags:
 - tag1
 - tag2
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Mit Open Source Investigation gegen Menschenrechtsverletzungen"
+title: Mit Open Source Investigation gegen Menschenrechtsverletzungen
+publishedDate: 2022-03-31
 ---
 
 **Hadi al-Khatib** ist Geschäftsführer der gemeinnützigen Organisation Mnemonic und Gründer des Syrian Archive. Beide Projekte konzentrieren sich auf Open Source Investigation - eine Methodik, die sich immer weiter verbreitet und über die im Kontext des Krieges in der Ukraine immer wieder auch in den Medien berichtet wird. Das Syrian Archive wurde im Jahr 2017 im Rahmen des Prototype Fund gefördert. Wir haben mit Hadi über seine Arbeit, die Vorteile von Open Source Investigation und deren Entwicklung über die letzten Jahre gesprochen. Hier gibt es das Interview auch auf [Englisch](https://prototypefund.de/open-source-investigation/).
@@ -101,4 +100,4 @@ Hier erfahrt ihr mehr über
 
 - das Yemeni Archive: https://yemeniarchive.org/, 
 
-- und das Sudanese Archive: https://sudanesearchive.org/. 
+- und das Sudanese Archive: https://sudanesearchive.org/.

--- a/content/blog/2022/2022-04-14-prototype-fund-hardware-jetzt-bewerben.md
+++ b/content/blog/2022/2022-04-14-prototype-fund-hardware-jetzt-bewerben.md
@@ -1,10 +1,9 @@
 ---
 authors:
 - Maximilian Voigt
-date: 2022-04-14
 image:
   src: https://hardware.prototypefund.de/wp-content/uploads/2021/12/unbo_blackbox.png
-  title: "Unbox / Blackbox"
+  title: Unbox / Blackbox
   license: CC-BY 4.0
   license_url: https://creativecommons.org/licenses/by/4.0/
 tags:
@@ -12,9 +11,9 @@ tags:
 - Open Hardware
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Prototype Fund Hardware: ab dem 15. April bewerben"
+title: 'Prototype Fund Hardware: ab dem 15. April bewerben'
+publishedDate: 2022-04-14
 ---
 
 *Für eine Welt, in der die Reparatur normal ist, muss Technik neu erfunden werden. Denn unsere Alltagstechnik wurde über Jahre hinweg immer mehr zur Blackbox. Ab dem 15. April startet die Bewerbungsphase des Prototype Fund Hardware - dem Förderprogramm für offene, transparente Technologien.*

--- a/content/blog/2022/2022-04-21-auftakt-bits-und-baeume.md
+++ b/content/blog/2022/2022-04-21-auftakt-bits-und-baeume.md
@@ -1,7 +1,6 @@
 ---
 authors:
 - Claudia Jach
-date: 2022-04-21
 image:
   src: /files/blog/2022/03/Save the Date Banner.jpg
 tags:
@@ -9,9 +8,9 @@ tags:
 - Nachhaltigkeit
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Bits & Bäume 2022 und die OKF"
+title: Bits & Bäume 2022 und die OKF
+publishedDate: 2022-04-21
 ---
 
 [Vom 30.9. bis 2.10.2022 findet die zweite große Bits & Bäume Konferenz statt - mit der OKF im Trägerkreis.](https://bits-und-baeume.org/konferenz/de) Bits & Bäume ist eine Konferenz, aber auch eine Bewegung von allen Menschen, die Digitalisierung nachhaltiger gestalten wollen, also u. a. gerechter, transparenter, zugänglicher, umweltfreundlicher und ressourcenschonender.

--- a/content/blog/2022/2022-06-07-auftakt-pm-bits-baeume.md
+++ b/content/blog/2022/2022-06-07-auftakt-pm-bits-baeume.md
@@ -1,17 +1,16 @@
 ---
 authors:
 - Claudia Jach
-date: 2022-06-07
-image: 
+image:
   src: /files/blog/2022/03/B&B Logo mit Schrift.jpg
 tags:
 - Community
 - Nachhaltigkeit
 type: post
 layout: post
-published: true
 featured: blue
-title: "Gemeinsame Pressemitteilung von 13 Organisationen aus Umwelt- und Digitalpolitik, Entwicklungszusammenarbeit und Wissenschaft 7. Juni 2022"
+title: Gemeinsame Pressemitteilung von 13 Organisationen aus Umwelt- und Digitalpolitik, Entwicklungszusammenarbeit und Wissenschaft 7. Juni 2022
+publishedDate: 2022-06-07
 ---
 
 **++ Digitalisierung und Nachhaltigkeit zusammendenken – Zweite bundesweite Bits & Bäume Konferenz vom 30. September bis 2. Oktober – Aufruf für Konferenzbeiträge ++**

--- a/content/blog/2022/2022-06-22-jahresbericht-2021.md
+++ b/content/blog/2022/2022-06-22-jahresbericht-2021.md
@@ -1,8 +1,7 @@
 ---
 authors:
 - Sonja Fischbauer
-date: 2022-06-22
-image: 
+image:
   src: /files/blog/2022/jahresbericht21-blog.jpg
 tags:
 - OKFDE
@@ -10,11 +9,10 @@ tags:
 - jahresbericht
 type: post
 layout: post
-published: true
 featured: blue
-title: "Das war 2021: Unser Jahresbericht ist jetzt veröffentlicht"
+title: 'Das war 2021: Unser Jahresbericht ist jetzt veröffentlicht'
+publishedDate: 2022-06-22
 ---
-
 
 Wer erinnert sich noch an 2021? Es ist doch überraschend viel passiert, wenn man so zurückschaut! 
 Nach erfolgreich abgeschlossener Wirtschaftsprüfung findet ihr auf [2021.okfn.de](https://2021.okfn.de/) unseren Jahresbericht online. 
@@ -44,4 +42,4 @@ Im September 2021 trafen sich Team- und Boardmitglieder endlich wieder in große
 Der Prototype Fund hat auch im Jahr 2021 gezeigt, wie Technologieentwicklung mit sozialpolitischem Profil erfolgreich von der Zivilgesellschaft umgesetzt und dabei staatlich gefördert  werden kann. inter den Kulissen hat das Team vor allem kräftig an der Zukunftsgestaltung des Förderprogramms geschraubt. Wenn auch wenig davon nach außen sichtbar war, konnten wir 2021 viele Schritte anstoßen, die die Wirkung des Funds in der Zukunft maßgeblich beeinflussen werden.
 
 ### Förderung unserer digital Ehrenamtlichen 
-Durch eine kurzfristige Förderung von der Deutschen Stiftung für Ehrenamt und Engagement konnten wir 2021 dem Einsatz von zahlreichen Freiwilligen Rechnung tragen, die sich in ihrer Freizeit für eine gemeinwohlorientierte Digitalisierung einsetzen. Rund 1.000 Stunden an ehrenamtlichem Engagement mit Tätigkeiten von Event- und Communityorganisation über Vortrags- und Bildungsarbeit bis hin zu technischen Aufgaben konnten wir in diesem Projekt honorieren.  
+Durch eine kurzfristige Förderung von der Deutschen Stiftung für Ehrenamt und Engagement konnten wir 2021 dem Einsatz von zahlreichen Freiwilligen Rechnung tragen, die sich in ihrer Freizeit für eine gemeinwohlorientierte Digitalisierung einsetzen. Rund 1.000 Stunden an ehrenamtlichem Engagement mit Tätigkeiten von Event- und Communityorganisation über Vortrags- und Bildungsarbeit bis hin zu technischen Aufgaben konnten wir in diesem Projekt honorieren.

--- a/content/blog/2022/2022-08-01-ptf-runde-13.md
+++ b/content/blog/2022/2022-08-01-ptf-runde-13.md
@@ -1,18 +1,16 @@
 ---
 authors:
 - Patricia Leu
-date: 2022-08-01
-image: 
+image:
   src: /files/blog/2022/08/now-never.png.png
 tags:
 - Prototype Fund
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Prototype Fund: Jetzt bewerben für Runde 13"
+title: 'Prototype Fund: Jetzt bewerben für Runde 13'
+publishedDate: 2022-08-01
 ---
-
 
 Seit dem 1. August 2022 ist es wieder soweit: Ihr könnt eure Public-Interest-Tech-Ideen für die kommende Förderphase des Prototype Fund einreichen. Wenn eure Bewerbung den Zuschlag erhält, startet ihr mit den anderen Prototypler*innen am 1. März 2023 in die Förderung.
 

--- a/content/blog/2022/2022-09-05-forderungen-bits-und-baeume.md
+++ b/content/blog/2022/2022-09-05-forderungen-bits-und-baeume.md
@@ -1,8 +1,7 @@
 ---
 authors:
 - Bits & Bäume
-date: 2022-09-05
-image: 
+image:
   src: /files/blog/2022/03/B&B Logo mit Schrift.jpg
 tags:
 - Bits & Bäume
@@ -10,9 +9,9 @@ tags:
 - Policy
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Bündnis fordert von Politik: Digitalisierung muss sozial-ökologischem Wandel dienen"
+title: 'Bündnis fordert von Politik: Digitalisierung muss sozial-ökologischem Wandel dienen'
+publishedDate: 2022-09-05
 ---
 
 **Pressemitteilung**
@@ -51,4 +50,4 @@ Die Veranstaltung wird gefördert durch die Deutsche Bundesstiftung Umwelt (DBU)
 
 **Ticketverkauf:** https://events.fairetickets.de/gedlv/
 
-**E-Mail*:** presse@bits-und-baeume.org 
+**E-Mail*:** presse@bits-und-baeume.org

--- a/content/blog/2022/2022-09-13-B&B-digitales-gemeingut.md
+++ b/content/blog/2022/2022-09-13-B&B-digitales-gemeingut.md
@@ -1,8 +1,7 @@
 ---
 authors:
 - Ben Burmeister
-date: 2022-09-13
-image: 
+image:
   src: /files/blog/2022/03/B&B Logo mit Schrift.jpg
 tags:
 - Bits & Bäume
@@ -10,9 +9,9 @@ tags:
 - Policy
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Bits & Bäume 2022: Nachhaltigkeit braucht digitales Gemeingut!"
+title: 'Bits & Bäume 2022: Nachhaltigkeit braucht digitales Gemeingut!'
+publishedDate: 2022-09-13
 ---
 
 **Die Digitalisierung schafft neue Möglichkeiten für eine offene und gerechtere Gesellschaft. Dafür muss sie allerdings auch mit den Herausforderungen des Klimawandels vereinbar sein.  Im Rahmen der Bits & Bäume 2022 fordern wir eine digitale Transformation, die aktiv zu einer gerechten, nachhaltigen und demokratischen Zukunft beiträgt. Um diese Zukunft zu ermöglichen, muss der Fokus auf das Gemeingut rücken – das Natürliche wie das Digitale!**

--- a/content/blog/2022/2022-09-22-konferenz-beyond-code.md
+++ b/content/blog/2022/2022-09-22-konferenz-beyond-code.md
@@ -1,7 +1,6 @@
 ---
 authors:
 - Philip Steffan
-date: 2022-09-22
 image:
   src: /files/blog/2022/09/jugend-hackt-beyond-code.jpeg
 tags:
@@ -10,9 +9,9 @@ tags:
 - KI
 type: post
 layout: post
-published: true
 featured: blue
-title: "Einladung zur Jugendkonferenz „Beyond Code“"
+title: Einladung zur Jugendkonferenz „Beyond Code“
+publishedDate: 2022-09-22
 ---
 
 **Jugend hackt lädt ein zur ersten Jugendkonferenz zu digital literacy, KI und digitaler Verantwortung; vom 17. bis 18. November 2022, in den Technischen Sammlungen Dresden.**

--- a/content/blog/2022/2022-10-04-open-hardware-und-circular-economy.md
+++ b/content/blog/2022/2022-10-04-open-hardware-und-circular-economy.md
@@ -1,7 +1,6 @@
 ---
 authors:
 - Maximilian Voigt
-date: 2022-10-04
 image:
   src: /files/blog/2022/10/open_closed_cm.png
   title: By Ferdinand Paul Revellio, in Böckel et al. "Mythen der Circular Economy"
@@ -13,10 +12,11 @@ tags:
 - Circular Society
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Den Krisen zum Trotz: eine digital-nachhaltige Zukunftspolitik"
+title: 'Den Krisen zum Trotz: eine digital-nachhaltige Zukunftspolitik'
+publishedDate: 2022-10-04
 ---
+
 Trotz der multiplen Krisen darf die Gestaltung der Zukunft nicht aus den Augen geraten. Das betonten auch die zweite Bürgermeisterin der Stadt Hamburg, Katharina Fegebank und Kai Gehring, Vorsitzender des Ausschusses für Bildung, Forschung und Technikfolgenabschätzung bei der[ Abschlussveranstaltung "Zukunft erfinden"](https://www.gruene-bundestag.de/termine/abschlussveranstaltung-zukunft-erfinden#m-tab-0-programm) der Bündnis 90/Die Grünen Bundestagsfraktion, am 21. September. Doch wie soll diese Zukunft aussehen? Und wie wollen wir in ihr wirtschaften?
 
 Mit Blick auf die EU-Kommission sind es Kreisläufe, in denen wir in Zukunft Produkte entwickeln, nutzen und verwerten. Der "[Circular economy action plan](https://environment.ec.europa.eu/strategy/circular-economy-action-plan_en)" vereint sämtliche Maßnahmen, die zur Erreichung dieses Zieles verfolgt werden. Eine ist die "[Sustainable Products Initiative](https://ec.europa.eu/info/law/better-regulation/have-your-say/initiatives/12567-Initiative-fur-nachhaltige-Produkte_de)". Mit ihr soll ein EU-weiter Produktpass eingeführt werden, der Informationen über die Nachhaltigkeit von Produkten zur Verfügung stellt. Allerdings setzt dieser stark auf Markmechanismen. Konkrete Designvorgaben oder Informationen, die über allgemeine Parameter hinausgehen,[ sind bisher nicht vorgesehen](https://netzpolitik.org/2022/nachhaltige-produkte-wir-muessen-ueber-geistiges-eigentum-reden/).

--- a/content/blog/2022/2022-10-06-bits-und-baeume-alternative-digitalstrategie.md
+++ b/content/blog/2022/2022-10-06-bits-und-baeume-alternative-digitalstrategie.md
@@ -1,8 +1,7 @@
 ---
 authors:
 - Bits & Bäume
-date: 2022-10-06
-image: 
+image:
   src: /files/blog/2022/03/B&B Logo mit Schrift.jpg
 tags:
 - Bits & Bäume
@@ -10,9 +9,9 @@ tags:
 - Policy
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Für eine nachhaltige Digitalisierung: 2.500 Teilnehmende auf der Konferenz Bits & Bäume"
+title: 'Für eine nachhaltige Digitalisierung: 2.500 Teilnehmende auf der Konferenz Bits & Bäume'
+publishedDate: 2022-10-06
 ---
 
 **Pressemitteilung**

--- a/content/blog/2022/2022-11-18-f5-stellungnahme-zukunftsstrategie.md
+++ b/content/blog/2022/2022-11-18-f5-stellungnahme-zukunftsstrategie.md
@@ -2,8 +2,7 @@
 authors:
 - Christina Willems
 - Henriette Litta
-date: 2022-11-18
-image: 
+image:
   src: /files/blog/2022/10/klein_kadir-celep-I3N-kVCYvA4-unsplash.jpg
 tags:
 - Innovation
@@ -11,9 +10,9 @@ tags:
 - OpenScience
 type: post
 layout: post
-published: true
 featured: blue
-title: "Innovation geht nicht ohne Offenheit & Partizipation"
+title: Innovation geht nicht ohne Offenheit & Partizipation
+publishedDate: 2022-11-18
 ---
 
 **Wir sind davon überzeugt, dass die Bewältigung der gesellschaftlichen und globalen Herausforderungen nur gelingen wird, wenn das Innovationssystem auf den Prinzipien der Offenheit und Partizipation beruht. Die derzeit von der Bundesregierung ressortübergreifend entwickelte [Zukunftsstrategie Forschung und Innovation](https://www.bmbf.de/bmbf/de/forschung/zukunftsstrategie/zukunftsstrategie_node.html) ist jedoch zu stark auf wirtschaftlichen Erfolg fokussiert. Hier muss nachgebessert werden.**
@@ -49,4 +48,4 @@ Damit sich alle Menschen selbstbestimmt und kritisch mit der Nutzung digitaler M
 
 
 
-Die ganze Stellungnahme ist [hier](https://raw.githubusercontent.com/okfde/okfn.de/master/static/files/blog/2022/10/2022-11-17_Lang_F5_Stellungnahme_Zukunftsstrategie_finfin.pdf) zu finden. 
+Die ganze Stellungnahme ist [hier](https://raw.githubusercontent.com/okfde/okfn.de/master/static/files/blog/2022/10/2022-11-17_Lang_F5_Stellungnahme_Zukunftsstrategie_finfin.pdf) zu finden.

--- a/content/blog/2022/2022-12-05-digitales-ehrenamt-bei-der-OKF.md
+++ b/content/blog/2022/2022-12-05-digitales-ehrenamt-bei-der-OKF.md
@@ -1,17 +1,16 @@
 ---
 authors:
 - Nora Titz
-date: 2022-12-05
-image: 
+image:
   src: /files/blog/2022/10/digitales ehrenamt.jpg
 tags:
 - Ehrenamt
 - Digitales-Ehrenamt
 type: post
 layout: post
-published: true
 featured: blue
-title: "Digitales Ehrenamt bei der OKF"
+title: Digitales Ehrenamt bei der OKF
+publishedDate: 2022-12-05
 ---
 
 ## Digitales Ehrenamt bei der OKF
@@ -64,4 +63,4 @@ Du hast eine Idee, wie Software oder Hardware für die Allgemeinheit genutzt wer
 
 Wenn du dich bereits im Open Source und digital zivilgesellschaftlichen Kosmos bewegst und gerne mitentscheiden würdest, was die Gesellschaft gerade an digitalen Tools benötigt, kannst du dich auch auf einen Platz in der [Jury](https://prototypefund.de/bewerbung/jury/) bewerben. 
 
-### Wir freuen uns auf dich! Wenn du kannst und möchtest, hilft uns auch eine [Spende](https://okfn.de/spenden/#:~:text=F%C3%BCr%20Spenden%20bis%20zu%20300,Kampagnenarbeit%20im%20Interesse%20der%20Zivilgesellschaft)! 
+### Wir freuen uns auf dich! Wenn du kannst und möchtest, hilft uns auch eine [Spende](https://okfn.de/spenden/#:~:text=F%C3%BCr%20Spenden%20bis%20zu%20300,Kampagnenarbeit%20im%20Interesse%20der%20Zivilgesellschaft)!

--- a/content/blog/2022/2022-12-09-f5-digitalgipfel.md
+++ b/content/blog/2022/2022-12-09-f5-digitalgipfel.md
@@ -2,8 +2,7 @@
 authors:
 - Christina Willems
 - Henriette Litta
-date: 2022-12-09
-image: 
+image:
   src: /files/blog/2022/10/kleiner_mikrofon.jpg
 tags:
 - Zivilgesellschaft
@@ -11,9 +10,9 @@ tags:
 - BündnisF5
 type: post
 layout: post
-published: true
 featured: blue
-title: "Digital-Gipfel der Bundesregierung – ein staatlich organisiertes Lobbyfest"
+title: Digital-Gipfel der Bundesregierung – ein staatlich organisiertes Lobbyfest
+publishedDate: 2022-12-09
 ---
 
 **Heute endet der Digital-Gipfel der Bundesregierung. Titel: „Digitalisierung betrifft uns alle – Unternehmen wie Bürgerinnen und Bürger, Wissenschaft wie Gesellschaft.“ Doch „die Gesellschaft“ spricht gar nicht mit. Schon bei der Digitalstrategie war es ein Problem, dass die Zivilgesellschaft nicht eingebunden war. Die Ampel gelobte, alles besser zu machen. Der Digital-Gipfel zeigt, dass das ein Lippenbekenntnis war. Die Regierung behandelt die digitalpolitische Zivilgesellschaft wie es die GroKo tat: Gerne mal reden – aber strukturelle Einbindung, gleichberechtigte Teilnahme, Mitgestaltung? Fehlanzeige...**
@@ -37,7 +36,4 @@ Wir fordern, dass dieses Versprechen endlich eingelöst wird: Für jedes Treffen
 
 Die Bundesregierung täte gut daran, einen echten Neustart in der Zusammenarbeit mit der Zivilgesellschaft zu wagen. Das vordergründige Werben um die Zivilgesellschaft bei gleichzeitiger wirtschaftspolitischer „Realpolitik“ ist unaufrichtig und schädlich: Die Zukunft der Digitalpolitik ist zu wichtig, um sie nur aus gewinnorientierter Unternehmenssicht zu diskutieren. 
 
-Die Stellungnahme ist [hier](https://raw.githubusercontent.com/okfde/okfn.de/master/static/files/blog/2022/10/F5_Digitalgipfel.pdf) zu finden. 
-
-
-
+Die Stellungnahme ist [hier](https://raw.githubusercontent.com/okfde/okfn.de/master/static/files/blog/2022/10/F5_Digitalgipfel.pdf) zu finden.

--- a/content/blog/2023/2023-01-26-Selbstgebaute-Sensoren-ein-mächtiges-Tool.md
+++ b/content/blog/2023/2023-01-26-Selbstgebaute-Sensoren-ein-mächtiges-Tool.md
@@ -1,17 +1,17 @@
 ---
 authors:
 - Nora Titz
-date: 2023-01-26
-image: 
-  src: 
+image:
+  src: null
 tags:
 - codeforgermany
 - open-data
 type: post
 layout: post
-published: false
 featured: yellow
-title: "Selbstgebaute Sensoren - ein mächtiges Tool"
+title: Selbstgebaute Sensoren - ein mächtiges Tool
+draft: 'true'
+publishedDate: 2023-01-26
 ---
 
 ## Selbstgebaute Sensoren - ein mächtiges Tool
@@ -58,4 +58,4 @@ Damit internationale Institutionen Ableitung aus den Daten treffen können, biet
 
 Eine direkte Zusammenarbeit mit Forschungsinstituten ermöglicht es, spezifischer auf deren Bedarfe einzugehen. So gibt es z.B. eine Community Kampagne DIY Sensoren im Umkreis von 250 Meter um eine offizielle Station zu installieren, da es ein Forschungsprojekt gibt, welches nach diesem Parameter Datenvergleiche erhebt. “Leute schreiben uns E-Mails, wenn sie nicht mehr wissen, wo sie ihren dritten oder fünften Sensor anbringen sollen und Fragen, ob es strategisch sinnvolle Orte für Sensoren gibt. Die Kampagne war eine der Reaktionen darauf.”, erzählt Lukas.  
 
-Das Fazit ist und bleibt wohl: Bringt man viele Menschen, möglichst unkompliziert zusammen, lässt sich auch viel erreichen. Dabei ermöglichen digitale Werkzeuge und gemeinsame Interessen sogar eine Zusammenarbeit über Kontinente hinweg. 
+Das Fazit ist und bleibt wohl: Bringt man viele Menschen, möglichst unkompliziert zusammen, lässt sich auch viel erreichen. Dabei ermöglichen digitale Werkzeuge und gemeinsame Interessen sogar eine Zusammenarbeit über Kontinente hinweg.

--- a/content/blog/2023/2023-01-31-Save-the-Date-Forum-Open-Hardware-23.md
+++ b/content/blog/2023/2023-01-31-Save-the-Date-Forum-Open-Hardware-23.md
@@ -1,16 +1,15 @@
 ---
 authors:
 - Maximilian Voigt
-date: 2023-01-31
 image:
   src: /files/blog/2023/02/foh23.png
 tags:
 - Open Hardware
 type: post
 layout: post
-published: true
 featured: blue
-title: "Save the Date: Forum Open Hardware"
+title: 'Save the Date: Forum Open Hardware'
+publishedDate: 2023-01-31
 ---
 
 Die Kreislaufwirtschaft oder auch „Circular Society“ sowie das Recht auf Reparatur werden als Wege in eine nachhaltige Zukunft gesehen. Doch wie gelangen wir dorthin? Welche Rolle spielen die Zivilgesellschaft und die offene Technologiegestaltung dabei? Diesen Fragen möchten wir mit euch und dem Forum Open Hardware am 13. März 2023 nachgehen.

--- a/content/blog/2023/2023-02-01-ptf-bewerbungsphase-runde-14.md
+++ b/content/blog/2023/2023-02-01-ptf-bewerbungsphase-runde-14.md
@@ -1,17 +1,17 @@
 ---
 authors:
 - Joram Schwartzmann
-date: 2023-02-01
-image: 
+image:
   src: /files/blog/2023/02/Read-Write-1.png
 tags:
 - prototype-fund
 - ausschreibung
 type: post
 layout: post
-published: true
-title: "Prototype Fund: Jetzt bewerben für Runde 14"
+title: 'Prototype Fund: Jetzt bewerben für Runde 14'
+publishedDate: 2023-02-01
 ---
+
 Seit dem 1. Februar 2023 könnt ihr eure Public-Interest-Tech-Ideen für die 14. Förderphase des Prototype Fund einreichen. Wenn eure Projektidee überzeugt, könnt ihr ab dem 1. September 2023 mit den anderen Prototyp-Entwickler\*innen in die Förderung starten.
 
 Der Prototype Fund sucht nach innovativen Open-Source-Softwareprojekten mit gesellschaftlichem Mehrwert, die bottom-up und in engem Austausch mit der Zielgruppe entwickelt werden. Das Bundesministerium für Bildung und Forschung entscheidet über die Förderung der von unserer Jury vorgeschlagenen Projekte. Ausgewählte Projekte werden über sechs Monate mit bis zu 47.500 € gefördert und von uns mit Coachings und regelmäßiger Beratung unterstützt.

--- a/content/blog/2023/2023-02-09-wahlberlin-forderungen.md
+++ b/content/blog/2023/2023-02-09-wahlberlin-forderungen.md
@@ -2,8 +2,7 @@
 authors:
 - Dénes Jäger
 - Henriette Litta
-date: 2023-02-09
-image: 
+image:
   src: /files/blog/2023/02/openfax.png
   license: c4ddownload
   license_url: https://c4ddownload.com/download/office-fax-3d-model/
@@ -14,9 +13,9 @@ tags:
 - Transparenzgesetz
 type: post
 layout: post
-published: true
 featured: blue
-title: "Digitaler Aufbruch in Berlin nach der Wiederholungswahl - oder weiter so?"
+title: Digitaler Aufbruch in Berlin nach der Wiederholungswahl - oder weiter so?
+publishedDate: 2023-02-09
 ---
 
 **Im ersten Jahr ihrer Regierungstätigkeit hat die Koalition im Berliner Abgeordnetenhaus im Digitalbereich vor allem an der Theorie gearbeitet – aber in der Praxis Forderungen der Zivilgesellschaft weiter ignoriert. Eine fortbestehende oder umgebildete Regierung muss in der restlichen Legislaturperiode zum Handeln übergehen.**  

--- a/content/blog/2023/2023-03-23-das-war-das-Forum-Open-Hardware-23.md
+++ b/content/blog/2023/2023-03-23-das-war-das-Forum-Open-Hardware-23.md
@@ -1,16 +1,15 @@
 ---
 authors:
 - Maximilian Voigt
-date: 2023-03-23
 image:
   src: /files/blog/2023/03/FOH23.JPG
 tags:
 - Open Hardware
 type: post
 layout: post
-published: true
 featured: blue
-title: "Seit dem FOH23 online: die Publikation Unboxing Blackboxes"
+title: 'Seit dem FOH23 online: die Publikation Unboxing Blackboxes'
+publishedDate: 2023-03-23
 ---
 
 Die Herausforderungen unser Zeit sind bekannt, die auf sozialer, ökologischer und wirtschaftlicher Ebene vor uns liegen. Offene Hardware kann ein Teil der Lösung werden. Beim [Forum Open Hardware 2023](https://hardware.forum-open.de/) (#FOH23) befassten sich 100 Expertinnen und Experten mit der Frage, wie das gelingen kann. Dabei stand das zivilgesellschaftliche Engagement im Forderung. Denn es sind zivilgesellschaftliche Akteure, die daran arbeiten, Technologie und alle damit verbundenen Aspekte offen zu denken. Damit gehören sie zu den innovativsten Köpfen unserer Zeit, wenn Innovation bedeutet, Hardware reparierbar, veränderbar und partizipativ zu gestalten.

--- a/content/blog/2023/2023-04-06-Klimawatch-Bürgerliche-Kontrolle-braucht-Daten.md
+++ b/content/blog/2023/2023-04-06-Klimawatch-Bürgerliche-Kontrolle-braucht-Daten.md
@@ -1,7 +1,6 @@
 ---
 authors:
 - Nora Titz
-date: 2023-04-06
 image:
   src: /files/blog/2023/04/KW23.jpg
 tags:
@@ -9,10 +8,11 @@ tags:
 - community
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Klimawatch - Bürgerliche Kontrolle braucht Daten"
+title: Klimawatch - Bürgerliche Kontrolle braucht Daten
+publishedDate: 2023-04-06
 ---
+
 Klimawandel und CO2 reduzieren ist in aller Munde: das Pariser Klimaabkommen - 2030. Auf welchem Weg in Deutschland aber konkret, und vor allem lokal, dazu beigetragen wird, ist oft wenig ersichtlich. Welche Maßnahmen werden getroffen? Welche Ziele gesetzt? Bin ich davon betroffen?  Kann ich etwas tun? Sollte ich vielleicht von meiner Kommune fordern, sich höhere Ziele zu setzen? 
 
 Wie an vielen anderen Stellen demokratischer Willensbildung und gemeinschaftlichen Handelns ist hier Transparenz wichtig und kann durch Digitale Tools unterstützt und vereinfacht werden. Wie genau das aussehen kann zeigt z.B. [Klimawatch.de](https://klimawatch.de/). Dort kann man sich aktuell über die Lage der Klimaziele in Münster, Köln, Leipzig, Hamburg, Karlsruhe, Landau, Moers, Chemnitz, Berlin, München, Düsseldorf, Paderborn, Dortmund, Ulm, Bielefeld und Bonn informieren. 
@@ -42,5 +42,3 @@ Die Gruppe um Klimawatch und alle Interessierten finden sich in einem Slack Chan
 Klimawatch ist ein Beispiel dafür, wie Offene Daten und zivilgesellschaftliches Engagement abstrakte Aufgaben und Zusammenhänge greifbarer machen kann, aber auch dafür, dass der Weg hin zu Offenem Regierungshandeln noch ein weiter ist. Andreas Kugel, Ehrenamtlicher der Code for Germany Community fasst es so: „wenn die Daten zu Klimaschutz und Treibhausgasen in einheitlichen Kategorien und nachnutzbaren Formaten veröffentlicht würden, könnten zivilgesellschaftliche Initiativen auf diesem Gebiet gesellschaftlichen Nutzen erzeugen. Darauf müssen wir hinarbeiten.“
 
 Wenn du Fragen zu Klimawatch hast, mitmachen oder Daten bereitstellen möchtest, kannst du dich gerne hier bei Andreas und dem Rest des ehrenamtlichen Teams melden: info@klimawatch.de
-
-

--- a/content/blog/2023/2023-04-13-KoaVertrag-Berlin.md
+++ b/content/blog/2023/2023-04-13-KoaVertrag-Berlin.md
@@ -1,8 +1,7 @@
 ---
 authors:
 - Dénes Jäger
-date: 2023-04-13
-image: 
+image:
   src: /files/blog/2023/04/blog-koavertrag-2.jpg
 tags:
 - Digitalpolitik
@@ -11,9 +10,9 @@ tags:
 - Transparenzgesetz
 type: post
 layout: post
-published: true
 featured: blue
-title: "Digitalpolitik im Berliner Koalitionsvertrag: Wenig Zeit für Veränderung"
+title: 'Digitalpolitik im Berliner Koalitionsvertrag: Wenig Zeit für Veränderung'
+publishedDate: 2023-04-13
 ---
 
 **Sollten die jeweiligen Parteigremien Ende April zustimmen, bleibt einer neuen Regierungskoalition aus CDU und SPD nur wenig Zeit, um in der restlichen Legislaturperiode digitalpolitische Vorhaben umzusetzen. Welche Projekte priorisiert werden sollen, bleibt im Koalitionsvertrag vage. Viel wird von dem neuen Personal abhängen.**
@@ -48,4 +47,4 @@ Ansonsten beruft sich der Koalitionsvertrag vor allem auf die Basics. Dazu gehö
 
 **Ohne Mut zur Reform und Investitionen in Infrastruktur wird es nicht gehen**
 
-Insgesamt zeigt sich der Koalitionsvertrag digitalpolitisch wenig aufschlussreich und  unambitioniert, was angesichts der kurzen Zeit, die noch für vorzeigbare Ergebnisse bleibt, nicht verwunderlich ist. Zumindest mit der E-Akte und den Änderungen im Rechtsrahmen können aber die Weichen für einen Aufbruch gestellt werden. In vielen Bereichen ist zudem schon Vorarbeit geleistet worden, die jetzt endlich auch in die Praxis kommen muss – die Verabschiedung des Transparenzgesetzes bleibt alternativlos. Vieles wird von der Neubesetzung des CDO abhängen, beispielsweise ob die aktuell gültigen Open-Source-Regelungen weiter verfolgt werden und die Dachstrategie „Gemeinsam:Digital Berlin“ Früchte trägt. Externe Anbieter:innen spielen in den Überlegungen der Koalitionsparteien eine größere Rolle als zuvor, allerdings richtet sich der Fokus nahezu ausschließlich auf wirtschaftliche Akteur:innen. Dabei darf auch eine neue Regierung nicht vergessen: Investitionen in Infrastruktur und der Mut, Reformen intern voranzubringen, mögen nicht so öffentlichkeitswirksam sein, ohne wird es aber nicht gehen.  
+Insgesamt zeigt sich der Koalitionsvertrag digitalpolitisch wenig aufschlussreich und  unambitioniert, was angesichts der kurzen Zeit, die noch für vorzeigbare Ergebnisse bleibt, nicht verwunderlich ist. Zumindest mit der E-Akte und den Änderungen im Rechtsrahmen können aber die Weichen für einen Aufbruch gestellt werden. In vielen Bereichen ist zudem schon Vorarbeit geleistet worden, die jetzt endlich auch in die Praxis kommen muss – die Verabschiedung des Transparenzgesetzes bleibt alternativlos. Vieles wird von der Neubesetzung des CDO abhängen, beispielsweise ob die aktuell gültigen Open-Source-Regelungen weiter verfolgt werden und die Dachstrategie „Gemeinsam:Digital Berlin“ Früchte trägt. Externe Anbieter:innen spielen in den Überlegungen der Koalitionsparteien eine größere Rolle als zuvor, allerdings richtet sich der Fokus nahezu ausschließlich auf wirtschaftliche Akteur:innen. Dabei darf auch eine neue Regierung nicht vergessen: Investitionen in Infrastruktur und der Mut, Reformen intern voranzubringen, mögen nicht so öffentlichkeitswirksam sein, ohne wird es aber nicht gehen.

--- a/content/blog/2023/2023-05-22-triffdieokfaufderrepublica23.md
+++ b/content/blog/2023/2023-05-22-triffdieokfaufderrepublica23.md
@@ -1,17 +1,16 @@
 ---
 authors:
 - OKFDE
-date: 2023-05-22
-image: 
+image:
   src: /files/blog/2023/Blogpost_Foto_republica_kombrimiert2.jpg
 tags:
 - re-publica
 - digitaleZivilgesellschaft
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Triff die OKFDE auf der re:publica!"
+title: Triff die OKFDE auf der re:publica!
+publishedDate: 2023-05-22
 ---
 
 **Die [re:publica](https://re-publica.com/de), das Festival für die digitale Gesellschaft, findet vom 05.-07. Juni 2023 in der Arena Berlin und dem Festsaal Kreuzberg statt. Die OKFDE wird mit verschiedenen Themen und Formaten dabei sein.**
@@ -94,4 +93,3 @@ Das vollständige Programm zur re:publica findet [ihr hier](https://re-publica.c
 
 
 See you soon!
-

--- a/content/blog/2023/2023-06-21-f5-engagementstrategie-bund.md
+++ b/content/blog/2023/2023-06-21-f5-engagementstrategie-bund.md
@@ -2,8 +2,7 @@
 authors:
 - Christina Willems
 - Henriette Litta
-date: 2023-06-21
-image: 
+image:
   src: /files/blog/2023/Blogpost_Engangementstrategie.png
 tags:
 - Stellungnahme
@@ -11,9 +10,9 @@ tags:
 - DigitalesEhrenamt
 type: post
 layout: post
-published: true
 featured: blue
-title: "Engagementstrategie des Bundes: Unsere Forderungen für ein starkes digitales Ehrenamt"
+title: 'Engagementstrategie des Bundes: Unsere Forderungen für ein starkes digitales Ehrenamt'
+publishedDate: 2023-06-21
 ---
 
 **Noch in dieser Legislaturperiode soll unter Beteiligung der Zivilgesellschaft eine neue [Engagementstrategie des Bundes](https://www.bmfsfj.de/bmfsfj/themen/engagement-und-gesellschaft/engagement-staerken/engagementstrategie-des-bundes-222072) erarbeitet werden. Die letzte Engagementstrategie stammt noch aus dem Jahr 2010. Es wird also Zeit – denn es hat sich viel getan! Das digitale Ehrenamt ist stark gewachsen und neue Technologien durchdringen mehr und mehr unser Leben. Im Rahmen der Verbändebeteiligung haben wir gemeinsam im [Bündnis F5](https://buendnis-f5.de/) eine Stellungnahme eingereicht. Hier sind unsere zentralen Forderungen:**
@@ -43,4 +42,4 @@ Menschen aller Altersgruppen müssen befähigt werden, sich selbstbestimmt und k
 Die ganze Stellungnahme ist [hier](https://github.com/okfde/okfn.de/blob/5da0a7a476b038ea084ca3d60fc931569cc0e04b/static/files/blog/2023/Stellungnahme_Engagementstrategie_Bu%CC%88ndnisF5.pdf) zu finden. 
 
 
-Auf der Website www.zukunft-des-engagements.de haben Engagierte und zivilgesellschaftliche Akteur:innen die Möglichkeit, durch verschiedene Formate ihre Vorschläge und Ideen einzubringen. Der Beteiligungsprozess wird bis Ende des Jahres 2023 andauern. 
+Auf der Website www.zukunft-des-engagements.de haben Engagierte und zivilgesellschaftliche Akteur:innen die Möglichkeit, durch verschiedene Formate ihre Vorschläge und Ideen einzubringen. Der Beteiligungsprozess wird bis Ende des Jahres 2023 andauern.

--- a/content/blog/2023/2023-06-22-Open-Data-Knowledge-Hub-Launch.md
+++ b/content/blog/2023/2023-06-22-Open-Data-Knowledge-Hub-Launch.md
@@ -1,8 +1,7 @@
 ---
 authors:
 - Dénes Jäger
-date: 2023-06-22
-image: 
+image:
   src: /files/blog/2023/06/knowledgehub-new.png
 tags:
 - Open Data
@@ -11,9 +10,9 @@ tags:
 - Knowledge Hub
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Der Open Data Knowledge Hub ist gelauncht! "
+title: 'Der Open Data Knowledge Hub ist gelauncht! '
+publishedDate: 2023-06-22
 ---
 
 **Braucht es im Jahr 2023 noch einen weiteren Knowledge Hub? Wir glauben ja! Mit dem Projekt [Open Data in der Verwaltung](https://okfn.de/projekte/opendata/) bringen wir uns wieder verstärkt in den Diskurs um eines unserer Kernthemen ein. Das heißt: Expertise zu Open Data aus der Zivilgesellschaft in die Behörden transportieren und öffentlich dokumentieren sowie den Mehrwert von offenen Daten zeigen.**

--- a/content/blog/2023/2023-06-28-jahresbericht-2022.md
+++ b/content/blog/2023/2023-06-28-jahresbericht-2022.md
@@ -1,8 +1,7 @@
 ---
 authors:
 - Henriette Litta
-date: 2023-06-28
-image: 
+image:
   src: /files/blog/2023/jahresbericht22-blog.jpg
 tags:
 - OKFDE
@@ -10,11 +9,10 @@ tags:
 - jahresbericht
 type: post
 layout: post
-published: true
 featured: blue
-title: "Das war 2022: Unser Jahresbericht ist jetzt veröffentlicht"
+title: 'Das war 2022: Unser Jahresbericht ist jetzt veröffentlicht'
+publishedDate: 2023-06-28
 ---
-
 
 Wer erinnert sich noch an 2022? Es ist viel passiert, wenn man so zurückschaut! 
 Nach erfolgreich abgeschlossener Wirtschaftsprüfung findet ihr auf [2022.okfn.de](https://2022.okfn.de/) unseren Jahresbericht online. 

--- a/content/blog/2023/2023-07-06-pm-dsc.md
+++ b/content/blog/2023/2023-07-06-pm-dsc.md
@@ -1,7 +1,6 @@
 ---
 authors:
 - Henriette Litta
-date: 2023-07-06
 image:
   src: /files/blog/2023/warnleuchten_dsc_post.jpg
   title: Fünf Warnleuchten
@@ -13,9 +12,9 @@ tags:
 - DSC
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Digital Services Act: Deutschland braucht eine Plattformaufsicht, keine Poststelle"
+title: 'Digital Services Act: Deutschland braucht eine Plattformaufsicht, keine Poststelle'
+publishedDate: 2023-07-06
 ---
 
 **Berlin, 06.07.2023**

--- a/content/blog/2023/2023-07-12-whistleblowingpolicy.md
+++ b/content/blog/2023/2023-07-12-whistleblowingpolicy.md
@@ -1,7 +1,6 @@
 ---
 authors:
 - Henriette Litta
-date: 2023-07-12
 image:
   src: /files/blog/2023/grafik_erhobenerZeigefinger.png
   title: erhobener Zeigefinger
@@ -11,9 +10,9 @@ tags:
 - Zivilgesellschaft
 type: post
 layout: post
-published: true
 featured: blue
-title: "Die OKF hat eine Whistleblowing Policy eingeführt, um Hinweisgebende besser zu schützen"
+title: Die OKF hat eine Whistleblowing Policy eingeführt, um Hinweisgebende besser zu schützen
+publishedDate: 2023-07-12
 ---
 
 **Wir haben uns einem zivilgesellschaftlichen Bündnis zur Einführung einer Whistleblowing Policy angeschlossen. Mit der Whistleblowing Policy verpflichten wir uns, Menschen zu schützen, die erhebliches Fehlverhalten in unserer Organisation melden.**

--- a/content/blog/2023/2023-08-29-halbzeitkritik-ampel.md
+++ b/content/blog/2023/2023-08-29-halbzeitkritik-ampel.md
@@ -2,18 +2,17 @@
 authors:
 - Christina Willems
 - Henriette Litta
-date: 2023-08-29
 image:
   src: /files/blog/2023/Sanduhr_PM_Halbzeitkritik.jpg
-  title: Halb abgelaufene Sanduhr 
+  title: Halb abgelaufene Sanduhr
 tags:
 - Pressemitteilung
 - Zivilgesellschaft
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Halbzeit für die Ampel: Danke für die schönen Worte, lasst endlich Taten sprechen!"
+title: 'Halbzeit für die Ampel: Danke für die schönen Worte, lasst endlich Taten sprechen!'
+publishedDate: 2023-08-29
 ---
 
 **Pressemitteilung**
@@ -65,6 +64,4 @@ Eine Übersicht aller beteiligten Organisationen findet sich auf der Webseite de
 
 +++
 
-Pressekontakt: presse@okfn.de 
-
-
+Pressekontakt: presse@okfn.de

--- a/content/blog/2023/2023-09-12-stn-datenstrategie.md
+++ b/content/blog/2023/2023-09-12-stn-datenstrategie.md
@@ -2,7 +2,6 @@
 authors:
 - Christina Willems
 - Henriette Litta
-date: 2023-09-12
 image:
   src: /files/blog/2020/03/data-joshua-sortino-unsplash.jpg
   title: Photo by Joshua Sortino on Unsplash
@@ -12,9 +11,9 @@ tags:
 - Zivilgesellschaft
 type: post
 layout: post
-published: true
 featured: blue
-title: "Stellungnahme des Bündnis F5 zur Datenstrategie der Bundesregierung"
+title: Stellungnahme des Bündnis F5 zur Datenstrategie der Bundesregierung
+publishedDate: 2023-09-12
 ---
 
 **„Fortschritt durch Datennutzung“ – so lautet die Weiterentwicklung der Datenstrategie von 2021, die zur Mitte der Legislatur veröffentlicht wurde. Es ist deutlich erkennbar, dass die Bedeutung der Datenpolitik nun stärker als gesamtgesellschaftliches Thema begriffen wird. Dennoch verharrt das Dokument im üblichen Modus der zusammengeschusterten Strategiepapiere als Sammelsurium verschiedener bekannter Ansätze und Einzelmaßnahmen; ein Gesamtrahmen mit klaren Governance-Strukturen, Rollen und Prozessen sowie einer soliden Dateninfrastruktur für eine planvolle und effektive Umsetzung der bereits beschlossenen Maßnahmen fehlt weiterhin.**
@@ -45,5 +44,4 @@ Um den Mehrwert von Daten aufzuzeigen, sollen laut Datenstrategie Anwendungsbeis
 
 ### Klare Governance-Strukturen müssen endlich entwickelt werden ###
 
-Um die vielen Einzelmaßnahmen effektiv umsetzen zu können, muss die Regierung klare Governance-Strukturen mit eindeutigen Rollen und Prozessen schaffen, die bisher zu unkoordiniert sind. So soll laut Datenstrategie nun jedes Ministerium Datenatlasse und Datenpools in den einzelnen Datenlaboren entwickeln. Dabei stellen sich zentrale Fragen: Wie werden zivilgesellschaftliche Organisationen in den Strukturen eingebunden und wie wird ihre langjährige Expertise nachhaltig berücksichtigt? Wie wird Wissen zwischen den Laboren ausgetauscht? Wie sollen die notwendigen Infrastrukturen entstehen, um nach der Kartierung auch den Zugang zu schaffen? Es braucht eine übergeordnete Koordination für eine solide Dateninfrastruktur der öffentlichen Verwaltung. Experimentierräume der Verwaltung dürfen dabei unter keinen Umständen demokratische Prinzipien der Transparenz, Beteiligung und Rechenschaftspflicht außer Acht lassen. Zudem ist unklar, welche Rolle das sich im Aufbau befindende Dateninstitut innerhalb des Datenökosystems einnehmen soll und wie zivilgesellschaftliche Expertise eingebunden wird. Auch wie die nationale Datenpolitik andere föderale Ebenen unterstützt und mitdenkt, findet keine Erwähnung. Die Datenstrategie hätte das Potenzial gehabt, einen Gesamtrahmen mit einer klaren Zielrichtung der Datenpolitik zu definieren. Diese Chance wurde leider vertan. 
-
+Um die vielen Einzelmaßnahmen effektiv umsetzen zu können, muss die Regierung klare Governance-Strukturen mit eindeutigen Rollen und Prozessen schaffen, die bisher zu unkoordiniert sind. So soll laut Datenstrategie nun jedes Ministerium Datenatlasse und Datenpools in den einzelnen Datenlaboren entwickeln. Dabei stellen sich zentrale Fragen: Wie werden zivilgesellschaftliche Organisationen in den Strukturen eingebunden und wie wird ihre langjährige Expertise nachhaltig berücksichtigt? Wie wird Wissen zwischen den Laboren ausgetauscht? Wie sollen die notwendigen Infrastrukturen entstehen, um nach der Kartierung auch den Zugang zu schaffen? Es braucht eine übergeordnete Koordination für eine solide Dateninfrastruktur der öffentlichen Verwaltung. Experimentierräume der Verwaltung dürfen dabei unter keinen Umständen demokratische Prinzipien der Transparenz, Beteiligung und Rechenschaftspflicht außer Acht lassen. Zudem ist unklar, welche Rolle das sich im Aufbau befindende Dateninstitut innerhalb des Datenökosystems einnehmen soll und wie zivilgesellschaftliche Expertise eingebunden wird. Auch wie die nationale Datenpolitik andere föderale Ebenen unterstützt und mitdenkt, findet keine Erwähnung. Die Datenstrategie hätte das Potenzial gehabt, einen Gesamtrahmen mit einer klaren Zielrichtung der Datenpolitik zu definieren. Diese Chance wurde leider vertan.

--- a/content/blog/2023/2023-09-18-globaldigitalcompact.md
+++ b/content/blog/2023/2023-09-18-globaldigitalcompact.md
@@ -1,20 +1,18 @@
 ---
 authors:
 - Henriette Litta
-date: 2023-09-18
 image:
   src: /files/blog/2023/humphrey-muleba-L4jb3ubqsmM-unsplash.png
   title: Foto von Humphrey Muleba auf Unsplash
-  
 tags:
 - Global Digital Compact
 - UN
 - Zivilgesellschaft
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Beim Global Digital Compact braucht es eine stärkere Stimme der Zivilgesellschaft"
+title: Beim Global Digital Compact braucht es eine stärkere Stimme der Zivilgesellschaft
+publishedDate: 2023-09-18
 ---
 
 **Die Vereinten Nationen befassen sich im Rahmen des [Global Digital Compact](https://www.un.org/techenvoy/global-digital-compact) (GDC) mit der Gestaltung der digitalen Zukunft im globalen Rahmen. Hierzu hatte der UN-Generalsekretär im Mai 2023 einen [Policy Brief](https://indonesia.un.org/sites/default/files/2023-07/our-common-agenda-policy-brief-gobal-digi-compact-en.pdf) vorgelegt. Die Regierungen verorten derzeit ihre Positionen dazu und sollten dabei insbesondere auch die Stimmen aus der Zivilgesellschaft hören. Über die letzten Wochen hatte sich die Open Knowledge Foundation im Rahmen eines Bündnisses aus zivilgesellschaftlichen Organisationen (auf Initiative von Wikimedia Deutschland) den Policy Brief genauer angeschaut und Vorschläge für wünschenswerte Anpassungen gemacht. Beim [Internet Governance Forum Deutschland](https://www.igf-d.de/igf-d-2023/) in der letzten Woche bot sich nun die Gelegenheit für einen neuen Austausch.**

--- a/content/blog/2023/2023-09-21-nkws.md
+++ b/content/blog/2023/2023-09-21-nkws.md
@@ -1,7 +1,6 @@
 ---
 authors:
 - Maximilian Voigt
-date: 2023-09-21
 image:
   src: /files/blog/2023/nkws.png
   title: Grafik by Mikhail Seleznev/iStock
@@ -14,10 +13,11 @@ tags:
 - Circular Society
 type: post
 layout: post
-published: true
 featured: blue
-title: "Mehr Gestaltungswillen für die Kreislaufwirtschaftsstrategie"
+title: Mehr Gestaltungswillen für die Kreislaufwirtschaftsstrategie
+publishedDate: 2023-09-21
 ---
+
 *Statt eine Müllverwertungsstrategie zu entwickeln sollte sich die Kreislaufwirtschaftsstrategie (NKWS) der Bundesregierung auf offene Kreisläufe konzentrieren, in denen die Zivilgesellschaft nicht reiner Konsument ist, sondern mitgestalten kann.*
 
 Das Bundesministerium für Umwelt, Naturschutz, nukleare Sicherheit und Verbraucherschutz arbeitet an einer Nationalen Kreislaufwirtschaftsstrategie („NKWS“). Es ist gut, dass Bewegung in das Thema kommt. Allerdings konzentriert sich der aktuelle Stand auf die Abfallwirtschaft, auf die letzte Phase im Produktkreislauf. Rahmenbedingungen, die den Müllberg klein und Produkte von Beginn an modular, veränderbar und reparierbar halten, werden kaum diskutiert. Das muss sich ändern.

--- a/content/blog/2023/2023-09-28-stn-EGovGBB.md
+++ b/content/blog/2023/2023-09-28-stn-EGovGBB.md
@@ -2,8 +2,7 @@
 authors:
 - Dénes Jäger
 - Henriette Litta
-date: 2023-09-28
-image: 
+image:
   src: /files/blog/2023/StadtschlossPotsdam-blogBBEGOVG.jpg
   license: Stadtschloss Potsdam - adapted from original picture by Andraszy CC BY-SA 4.0
   license_url: https://commons.wikimedia.org/wiki/File:Stadtschloss_Potsdam_von_der_Havelseite.jpg
@@ -14,9 +13,9 @@ tags:
 - E-Government-Gesetz
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Initiativstellungnahme zur Änderung des Brandenburgischen E-Government-Gesetzes"
+title: Initiativstellungnahme zur Änderung des Brandenburgischen E-Government-Gesetzes
+publishedDate: 2023-09-28
 ---
 
 **Mit einer Gesetzesänderung möchte die Brandenburger Landesregierung das Thema Open Data endlich auch in den Rechtsrahmen aufnehmen. Doch die geplanten Änderungen gehen aus Sicht der OKF nicht weit genug. In einer kurzen Initiativstellungnahme haben wir einige Kritikpunkte zusammengefasst.**
@@ -31,4 +30,4 @@ Die geplanten Änderungen gehen aus unserer Sicht aber nicht weit genug, bzw. or
 
 Nach Veröffentlichung der Brandenburgischen [Offene-Daten-Strategie](https://mik.brandenburg.de/sixcms/media.php/9/20230607_Open%20Data%20Strategie_web_ba.pdf), die aktuelle Problemfelder diagnostiziert und mögliche Arbeitsschritte aufgezeigt hat, hätten mit der Änderung der Gesetzesgrundlage die richtigen Schlüsse daraus gezogen werden können, um das Land Brandenburg zu einem Vorreiter in Sachen Open Data zu machen. Der vorliegende Entwurf greift leider in vielen Bereichen zu kurz und wird keinen Paradigmenwechsel in den Verwaltungen befeuern. Positiv hervorzuheben ist die geplante Schaffung einer Informations- und Beratungsstelle für das Thema Open Data, die, wenn sie mit entsprechenden Mitteln und politischem Rückhalt ausgestattet wird, tatsächlich Dinge anstoßen könnte. So bleibt zu hoffen, dass schnellstmöglich das in der Open-Data-Strategie genannte eigenständige Open-Data-Gesetz Realität wird – und im Beratungsverfahren dann gerne auch die Zivilgesellschaft direkt Berücksichtigung findet.
 
-Die komplette Stellungnahme können Sie [hier](https://github.com/okfde/okfn.de/blob/e806fe0aef4e7c51bba040812ca974fdcf9443a6/static/files/blog/2023/2023-09-28_OKF_Stellungnahme_BBEGovG.pdf?raw=true) als PDF herunterladen. 
+Die komplette Stellungnahme können Sie [hier](https://github.com/okfde/okfn.de/blob/e806fe0aef4e7c51bba040812ca974fdcf9443a6/static/files/blog/2023/2023-09-28_OKF_Stellungnahme_BBEGovG.pdf?raw=true) als PDF herunterladen.

--- a/content/blog/2024/2024-02-01-In Support of Gubad Ibadoghlu.md
+++ b/content/blog/2024/2024-02-01-In Support of Gubad Ibadoghlu.md
@@ -1,17 +1,16 @@
 ---
 authors:
 - Walter Palmetshofer
-date: 2024-02-01
-image: 
+image:
   src: /files/blog/2024/02/FreeGubad-update.png
 tags:
 - DEITI
-- Transparency 
+- Transparency
 type: post
 layout: post
-published: true
 featured: blue
-title: "In Support of Gubad Ibadoghlu"
+title: In Support of Gubad Ibadoghlu
+publishedDate: 2024-02-01
 ---
 
 **Statement from the Civil Society Members of the EITI Germany (DEITI) in Support of Gubad Ibadoghlu**

--- a/content/blog/2024/2024-02-02-Aufruf gegen Rechts.md
+++ b/content/blog/2024/2024-02-02-Aufruf gegen Rechts.md
@@ -1,8 +1,7 @@
 ---
 authors:
 - OKFDE
-date: 2024-02-02
-image: 
+image:
   src: /files/blog/2024-02-Demo Aufurf_Hand in Hand.jpg
 tags:
 - Engangement
@@ -10,9 +9,9 @@ tags:
 - Digitalpolitik
 type: post
 layout: post
-published: true
 featured: blue
-title: "OKF und Bündnis F5 unterstützen Aktionstag gegen Rechtsextremismus und Rassismus"
+title: OKF und Bündnis F5 unterstützen Aktionstag gegen Rechtsextremismus und Rassismus
+publishedDate: 2024-02-02
 ---
 
 **Digitalpolitik für eine starke Demokratie.**
@@ -33,5 +32,3 @@ Wir stehen gemeinsam für eine offene, demokratische, vielfältige und solidaris
 Zum Aufruf des [Bündnis F5](https://buendnis-f5.de/publikationen/2024-02-01-resilientedemokratie)
 
 Weitere Infos findet ihr unter www.gemeinsam-hand-in-hand.org
-
-

--- a/content/blog/2024/2024-02-03-right-to-repair-entschieden.md
+++ b/content/blog/2024/2024-02-03-right-to-repair-entschieden.md
@@ -1,8 +1,7 @@
 ---
 authors:
 - Maximilian Voigt
-date: 2024-02-03
-image: 
+image:
   src: /files/blog/2024/rc2.JPG
   license: cc by Maximilian Voigt
   license_url: https://creativecommons.org/licenses/by/4.0/
@@ -12,10 +11,11 @@ tags:
 - Produkttransparenz
 type: post
 layout: post
-published: true
 featured: blue
-title: "Nach EU-Einigung: Beim Reparaturgesetz sollte DE sich an Frankreich orientieren"
+title: 'Nach EU-Einigung: Beim Reparaturgesetz sollte DE sich an Frankreich orientieren'
+publishedDate: 2024-02-03
 ---
+
 Im März 2023 hat die EU-Kommission neue Regeln zur Förderung von Reparaturen vorgelegt. Seitdem ist die Diskussion um ein Recht auf Reparatur europaweit im vollen Gange.
 
 Im Oktober haben Rat und Parlament sich mit dem Entwurf befasst und ihre eigene Position entwickelt. Nun ist es im Rahmen der Trilog-Verhandlungen gelungen, die unterschiedlichen Perspektiven zusammenzubringen. Die neue Verordnung könnte den Preis für Reparaturen deutlich senken und Praktiken unterbinden, die Reparaturen erschweren oder gar verbieten.
@@ -26,6 +26,4 @@ Das Recht auf Reparatur setzt einen wichtigen Startpunkt, dass Bürger*innen ein
 
 Daher sollte sich die Bundesregierung bei der Schaffung des aktuell geplanten Reparaturgesetztes an Frankreich orientieren, [das die Möglichkeiten von Open Hardware erkannt hat](https://netzpolitik.org/2022/frankreich-selbstgemachte-ersatzteile-aus-dem-3d-drucker/).
 
-In Zusammenarbeit mit der Open Hardware Allianz ist ein [Diskussionspapier](https://open-hardware-allianz.de/assets/files/OHA_Open-Hardware_Circularity.pdf) entstanden, das die Rollen von Hardware in einer auf Kreisläufe ausgereichteten Gesellschaft neu denkt. Die Reparatur ist in dieser nur eine Praktik, die intensiv auf Informationen angewiesen ist. Der auf EU-Ebene erreichte Kompromiss kann nur ein Anfang sein, eine in die Sackgasse geratene Industrie transparenter und nachhaltiger zu gestalten. Open Hardware muss dabei eine wichtige Rolle spielen. 
-
-
+In Zusammenarbeit mit der Open Hardware Allianz ist ein [Diskussionspapier](https://open-hardware-allianz.de/assets/files/OHA_Open-Hardware_Circularity.pdf) entstanden, das die Rollen von Hardware in einer auf Kreisläufe ausgereichteten Gesellschaft neu denkt. Die Reparatur ist in dieser nur eine Praktik, die intensiv auf Informationen angewiesen ist. Der auf EU-Ebene erreichte Kompromiss kann nur ein Anfang sein, eine in die Sackgasse geratene Industrie transparenter und nachhaltiger zu gestalten. Open Hardware muss dabei eine wichtige Rolle spielen.

--- a/content/blog/2024/2024-03-01-Start-der-Umweltdatenwerkstatt-fuer-den-Umweltschutz.md
+++ b/content/blog/2024/2024-03-01-Start-der-Umweltdatenwerkstatt-fuer-den-Umweltschutz.md
@@ -1,8 +1,7 @@
 ---
 authors:
 - Maximilian Voigt
-date: 2024-03-01
-image: 
+image:
   src: /files/blog/2024/03/UDE_Leipzig_2024.jpg
   license: Umweltdatenwerkstatt Leipzig, cc by Maximilian Voigt
   license_url: https://creativecommons.org/licenses/by/4.0/
@@ -12,15 +11,15 @@ tags:
 - Sogenannte KI
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Helfen KI-Modelle und offene Daten dem Umweltschutz?"
+title: Helfen KI-Modelle und offene Daten dem Umweltschutz?
+publishedDate: 2024-03-01
 ---
+
 Neben den zahlreichen Krisen und dem Erstarken der Rechten schreitet die Klimakrise voran. Laut eines aktuellen Berichts der Europäischen Umweltagentur (EEA) ist Europa "[der sich am schnellsten erwärmende Kontinent.](https://www.rnd.de/politik/ueberschwemmungen-hitze-und-braende-europa-bereitet-sich-laut-bericht-zu-wenig-auf-klimakrise-vor-3YNVG2N7CJLPLB7YDDVWV5PVVA.html)" Neben zahlreichen anderen Gründen hat das großen Einfluss auf die Beschaffenheit der Umwelt. Ein [Rückgang der Insekten und Vögel](https://www.nabu.de/tiere-und-pflanzen/voegel/gefaehrdungen/24661.html) ist nur ein Effekt. Technologien, wie sogenannte "künstliche Intelligenz", werden als [Lösungen postuliert](https://www.boell.de/de/kuenstliche-intelligenz-und-klimawandel). Ist das so? Hilft uns die Technik, die Umwelt zu schützen? Und: Wissen wir zu wenig, um zu handeln?
 
 Mit diesen Fragen befassen sich Expertinnen und Experten aus den Bereichen Umweltschutz, Open Data und KI-basierter Datenauswertung im Projekt "[Umweltdatenwerkstatt](https://datenschule.de/projekte/umweltdatenwerkstatt/)". Oft wird einseitig über technische Lösungen nachgedacht. Das technisch Machbare wird über das Nützliche gestellt. Bei der Umweltdatenwerkstatt geht es darum, gemeinsam abzuwägen und zu zielführenden Lösungen zu kommen. Die lokale Vernetzung, das voneinander Lernen und Testen konkreter Lösungsansätze steht im Vordergrund.
 
 An zwei Tagen arbeiten die Teilnehmenden an Umweltschutzprojekten. Die Veranstaltungen finden bundesweit statt. Durchgeführt wird die Umweldatenwerkstatt vom OKF-Programm Datenschule, im Auftrag der [KI-Ideenwerkstatt der ZUG](https://www.ki-ideenwerkstatt.de/), gefördert durch das Bundesministerium für Umwelt, Naturschutz, nukleare Sicherheit und Verbraucherschutz im Rahmen von [Civic Coding](https://www.civic-coding.de/). Die Veranstaltungen finden in Zusammenarbeit mit der [Code for Germany-Community](https://codefor.de/) statt. 
 
-Du hast Interesse, dabei zu sein? Die Anmeldung zu den nächsten Terminen findest du auf der [Projektseite](https://datenschule.de/workshops/umweltdatenwerkstatt/). 
-
+Du hast Interesse, dabei zu sein? Die Anmeldung zu den nächsten Terminen findest du auf der [Projektseite](https://datenschule.de/workshops/umweltdatenwerkstatt/).

--- a/content/blog/2024/2024-04-18-F5-Forderungen-DMK.md
+++ b/content/blog/2024/2024-04-18-F5-Forderungen-DMK.md
@@ -2,8 +2,7 @@
 authors:
 - Christina Willems
 - Henriette Litta
-date: 2024-04-18
-image: 
+image:
   src: /files/blog/2024/Blog_DMK.jpg
   license: Bündnis F5 Forderungen zur Digitalministerkonferenz
   license_url: https://creativecommons.org/licenses/by/4.0/
@@ -13,9 +12,9 @@ tags:
 - Pressemitteilung
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Erste Digitalministerkonferenz: Bündnis F5 stellt Forderungen vor"
+title: 'Erste Digitalministerkonferenz: Bündnis F5 stellt Forderungen vor'
+publishedDate: 2024-04-18
 ---
 
 ## Erste Digitalministerkonferenz: Bündnis F5 stellt Forderungen vor ##

--- a/content/blog/2024/2024-04-24-right-to-repair-entschieden-final.md
+++ b/content/blog/2024/2024-04-24-right-to-repair-entschieden-final.md
@@ -1,8 +1,7 @@
 ---
 authors:
 - Maximilian Voigt
-date: 2024-02-03
-image: 
+image:
   src: /files/blog/2024/rc2.JPG
   license: cc by Maximilian Voigt
   license_url: https://creativecommons.org/licenses/by/4.0/
@@ -12,10 +11,11 @@ tags:
 - Produkttransparenz
 type: post
 layout: post
-published: true
 featured: blue
-title: "EU-Parlament schafft ein Rechtchen auf Reparatur"
+title: EU-Parlament schafft ein Rechtchen auf Reparatur
+publishedDate: 2024-02-03
 ---
+
 *Wir haben das Recht, ein paar Geräte reparieren zu lassen, aber nicht auf technische Informationen oder Ersatzteile, um es selbst zu tun.*
 
 Am vergangenen Dienstag hat das EU-Parlament nach langem Prozess das sogenannte "Recht auf Reparatur" verabschiedet. Anfang 2024 wurde im Rahmen der Trilogverhandlungen ein [Kompromiss ausgehandelt](https://netzpolitik.org/2024/verbraucherschutz-eu-ebnet-weg-fuer-guenstige-reparaturen/). Im Kern gibt es uns als Kaufende das Recht, auch außerhalb der Gewährleistung die Reparatur des Gegenstandes einzufordern, sofern die Reparatur nicht "unmöglich" ist. Das Recht zu reparieren haben hingegen in der Regel "fachlich kompetente Reparateure" oder "gewerbliche Reparateure", wie es in den Ecodesignverordnungen zu verschiedenen Produktgruppen heißt. Die reparieren nur das, was sich lohnt. Inwiefern zivilgesellschaftliche Akteure am Ende an Ersatzteile oder reparaturrelevante Informationen kommen, ist offen. Bisher haben sie nur bei Smartphones einen umfänglichen Zugriff. Für den Rest gibt's Dichtungen. Denn ohnehin gilt das sogenannte "Recht auf Reparatur" nur für wenige Produktgruppen, für die bereits Verordnungen erlassen wurden. Das ist die sogenannte "weiße Ware", wie Kühlschränke und Waschmaschinen, sowie Schweißgeräte, Smartphones, Displays und Server.

--- a/content/blog/2024/2024-05-06_Open Data_Verwaltungsmodernisierung.md
+++ b/content/blog/2024/2024-05-06_Open Data_Verwaltungsmodernisierung.md
@@ -2,8 +2,7 @@
 authors:
 - Christina Willems
 - Henriette Litta
-date: 2024-05-06
-image: 
+image:
   src: /files/blog/2024/Bündnis_F5_-_Parlamentarisches_Frühstück_Nr._8_Verwaltungsdigitalisierung_2.jpg
   license: CC BY 4.0 by Lilli Iliev
   license_url: https://creativecommons.org/licenses/by/4.0/
@@ -13,10 +12,11 @@ tags:
 - Verwaltungsdigitalisierung
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Verwaltungsmodernisierung durch Open Data"
+title: Verwaltungsmodernisierung durch Open Data
+publishedDate: 2024-05-06
 ---
+
 ### Parlamentarisches Frühstück des Bündnis F5 zur Verwaltungsmodernisierung ### 
 
 Unter der Schirmherrschaft von Nadine Schön, stellvertretende Vorsitzende der CDU/CSU Bundestagsfraktion und Mitglied im Ausschuss für Digitales, veranstaltete das [Bündnis F5](www.bündnis-f5.de) am 09.04.2024 ein parlamentarisches Frühstück, um sich darüber auszutauschen, welchen politischen Rahmen es für den Einsatz von KI braucht und wie das Potenzial von Daten für die Verwaltungsmodernisierung besser genutzt werden kann.

--- a/content/blog/2024/2024-05-21-triffdieokfaufderrepublica24.md
+++ b/content/blog/2024/2024-05-21-triffdieokfaufderrepublica24.md
@@ -1,8 +1,7 @@
 ---
 authors:
 - OKF DE
-date: 2024-05-21
-image: 
+image:
   src: /files/blog/2024/Blogpost_Foto_republica_2024.jpg
   license: cc by Jaime Lopes
   license_url: https://creativecommons.org/licenses/by/4.0/
@@ -11,9 +10,9 @@ tags:
 - digitaleZivilgesellschaft
 type: post
 layout: post
-published: true
 featured: blue
-title: "Triff die OKF auf der re:publica!"
+title: Triff die OKF auf der re:publica!
+publishedDate: 2024-05-21
 ---
 
 **Die [re:publica](https://re-publica.com/de) steht wieder an: das Festival für die digitale Gesellschaft findet vom 27.-29. Mai 2024 in der [STATION Berlin](https://www.station-berlin.de/de/lage-anfahrt/lage.html) statt. Die OKFDE wird mit vielen verschiedenen Themen und Formaten dabei sein.

--- a/content/blog/2024/2024-05-22-F5ForderungenzurEUWahl.md
+++ b/content/blog/2024/2024-05-22-F5ForderungenzurEUWahl.md
@@ -1,8 +1,7 @@
 ---
 authors:
 - Christina Willems
-date: 2024-05-22
-image: 
+image:
   src: /files/blog/2024/240522_Bogpost_F5EUWahl.png
   license: Bündnis F5 Forderungen zur Europawahl, cc by Bündnis F5
   license_url: https://creativecommons.org/licenses/by/4.0/
@@ -12,9 +11,9 @@ tags:
 - Europa
 type: post
 layout: post
-published: true
 featured: blue
-title: "Positionen des Bündnis F5 zur Europawahl 2024"
+title: Positionen des Bündnis F5 zur Europawahl 2024
+publishedDate: 2024-05-22
 ---
 
 **Die Europäische Union hat sich als wegweisende Akteurin in der Digitalpolitik etabliert. In den letzten fünf Jahren wurden bedeutende Gesetze auf den Weg gebracht, um die Macht von Big-Tech Unternehmen einzudämmen und die Einhaltung von Grund- und Menschenrechten im Digitalen zu stärken. Gleichzeitig ist die europäische Digitalpolitik zu oft von technischen Trends und gewinnorientierten Interessen getrieben. Der Fokus auf das Gemeinwohl geht dabei verloren.**

--- a/content/blog/2024/2024-05-29-opendataranking.md
+++ b/content/blog/2024/2024-05-29-opendataranking.md
@@ -1,9 +1,8 @@
 ---
-authors: 
+authors:
 - Dénes Jäger
 - OKF DE
-date: 2024-05-29
-image: 
+image:
   src: /files/blog/2024/OpenDataRanking.png
   license: cc Karte by  David Liuzzo, DeStatis
   license_url: https://OpenDataRanking.de
@@ -11,9 +10,9 @@ tags:
 - OpenDataRanking
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Das erste Open Data Ranking ist erschienen"
+title: Das erste Open Data Ranking ist erschienen
+publishedDate: 2024-05-29
 ---
 
 *Wir veröffentlichen das erste [Open Data Ranking](https://opendataranking.de)! In Anlehnung an das [Transparenzranking](https://transparenzranking.de) blicken wir auf die Open-Data-Landschaft in Deutschland und gehen über das reine Datensätzezählen hinaus. Die Analyse der rechtlichen Rahmenbedingungen, Datenqualität und personellen Ausstattung zeigen, dass es innerhalb Deutschlands erhebliche Unterschiede in Bezug auf Open Data gibt. Während sich einzelne Bundesländer auch schon um Linked Data kümmern, fehlen bei anderen noch jegliche Grundlagen für die Datenbereitstellung.*
@@ -39,6 +38,3 @@ Am anderen Ende des [Rankings](https://opendataranking.de) stehen allerdings etl
 Weder in einem Bundesland noch im Bund gibt es aktuell ein subjektiv-öffentliches Recht auf Bereitstellung von Daten. Auf Bundesebene steht ein Rechtsanspruch zumindest im Koalitionsvertrag. Mit 25% nimmt diese Kategorie einen großen Anteil des Rankings ein, denn ein solcher Rechtsanspruch könnte als Umsetzungsmotor dienen, um die notwendige IT- und  Dateninfrastruktur für eine automatisierte Bereitstellung von Open Data zu schaffen. Die Hoffnung, dass der Rechtsanspruch in dieser Legislaturperiode noch kommt, wollen wir uns nach wie vor erhalten und setzen uns weiterhin dafür ein. Die positive Wirkung eines solchen wird im Übrigen auch vom [Max-Planck-Institut](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4492439), von [Wikimedia](https://www.wikimedia.de/wp-content/uploads/2023/04/Wikimedia_Deutschland_-_Positionspapier_Recht_auf_Open_Data_2022.pdf) und von der [Böll-Stiftung](https://www.boell.de/de/2022/09/15/daten-als-oeffentliche-infrastruktur) untermauert.
 
 ## [www.OpenDataRanking.de](https://www.opendataranking.de) ##
-
-
-

--- a/content/blog/2024/2024-06-06-civic-tech-taiwan.en.md
+++ b/content/blog/2024/2024-06-06-civic-tech-taiwan.en.md
@@ -1,8 +1,7 @@
 ---
-authors: 
+authors:
 - Sonja Fischbauer
-date: 2024-06-06
-image: 
+image:
   src: /files/blog/2024/2024-06-taipei-skyline.jpg
   license: CC-BY SA 4.0
   license_url: https://creativecommons.org/licenses/by-sa/4.0/deed.de
@@ -12,10 +11,11 @@ tags:
 - Community
 type: post
 layout: post
-published: true
 featured: blue
-title: "From Taipei to Berlin: How Civic Tech in Taiwan Inspires Digital Democracy"
+title: 'From Taipei to Berlin: How Civic Tech in Taiwan Inspires Digital Democracy'
+publishedDate: 2024-06-06
 ---
+
 Last month, we had the chance to learn more about the civic tech and open source scene in Taiwan and to exchange ideas with Taiwanese activists. The country is a model in the field of digital democracy with some success stories in the collaboration between government and civil society. Seven years ago, we reported on our first [visit to Taiwan](https://codefor.de/blog/open-communities/) as part of an exchange program by Code for All.
 
 In the international civic tech network, g0v is the Taiwanese counterpart to Code for Germany. The organization g0v is the Taiwanese counterpart to Code for Germany in Taiwan, g0v (pronounced “gov-zero”). Following the hands-on principle, the community develops open source technologies and civic tech projects for democratic participation. A well-known early project is the vTaiwan platform, which allows people to actively participate in legislation. The g0v hackathons take place every two months and each have 100 participants to this day.

--- a/content/blog/2024/2024-06-06-civic-tech-taiwan.md
+++ b/content/blog/2024/2024-06-06-civic-tech-taiwan.md
@@ -1,8 +1,7 @@
 ---
-authors: 
+authors:
 - Sonja Fischbauer
-date: 2024-06-06
-image: 
+image:
   src: /files/blog/2024/2024-06-taipei-skyline.jpg
   license: CC-BY SA 4.0
   license_url: https://creativecommons.org/licenses/by-sa/4.0/deed.de
@@ -10,10 +9,11 @@ tags:
 - Taiwan
 type: post
 layout: post
-published: true
 featured: blue
-title: "Von Taipei nach Berlin: Wie Civic Tech in Taiwan zur digitalen Demokratie inspiriert"
+title: 'Von Taipei nach Berlin: Wie Civic Tech in Taiwan zur digitalen Demokratie inspiriert'
+publishedDate: 2024-06-06
 ---
+
 Im letzten Monat hatten wir die Chance, mehr über die Civic-Tech- und Open-Source-Szene in Taiwan zu erfahren und uns mit taiwanischen Aktivist:innen auszutauschen. Das Land ist ein Vorbild im Bereich Digital Democracy mit einigen Erfolgsgeschichten in der Zusammenarbeit zwischen Verwaltung und Zivilgesellschaft. Vor sieben Jahren berichteten wir über unseren ersten [Besuch in Taiwan](https://codefor.de/blog/open-communities/) im Rahmen eines Austauschprogramms von Code for All.
 
 Im internationalen Civic-Tech-Netzwerk ist g0v (ausgesprochen “gov-zero”) das taiwanesische Pendant zu Code for Germany. Nach dem Hands-on-Prinzip entwickelt die Community Open-Source-Technologien und Civic-Tech-Projekte zur demokratischen Teilhabe. Ein bekanntes frühes Projekt ist die Plattform [vTaiwan](https://info.vtaiwan.tw/), mit der Menschen aktiv an der Gesetzgebung teilnehmen können. Alle zwei Monate finden g0v-Hackathons statt, die jeweils bis zu 100 Teilnehmende zählen. 
@@ -52,4 +52,4 @@ Isabel Hou, ehemalige Vorständin von g0v und Tiff Lin, Projektmanagerin der g0v
 ![Isabel Hou beim g0v workshop in Berlin.](/files/blog/2024/2024-06-g0v-in-berlin.jpg)
 Photo: Sonja Fischbauer; Isabel Hou beim g0v workshop in Berlin; Lizenz CC-BY SA 4.0
 
-Wir freuen uns über die zahlreichen Kontakte nach Taiwan, die neu gewonnenen Perspektive und die gestärkte Motivation, auch hierzulande mehr Civic-Tech-Projekte umzusetzen. 
+Wir freuen uns über die zahlreichen Kontakte nach Taiwan, die neu gewonnenen Perspektive und die gestärkte Motivation, auch hierzulande mehr Civic-Tech-Projekte umzusetzen.

--- a/content/blog/2024/2024-06-17-Fragen-fuer-die-oeff-KI-Foerderung.md
+++ b/content/blog/2024/2024-06-17-Fragen-fuer-die-oeff-KI-Foerderung.md
@@ -1,8 +1,7 @@
 ---
-authors: 
+authors:
 - Sophia Schulze Schleithoff
-date: 2024-06-17
-image: 
+image:
   src: /files/blog/2024/2024-06-17-Blog-Fragen-fuer-die-oeff-KI-Foerderung.jpeg
   license: CC0 1.0 Universal
   license_url: https://commons.wikimedia.org/wiki/File:Cameron_Kirby_2016-10-01_(Unsplash).jpg
@@ -12,9 +11,9 @@ tags:
 - Open Source
 type: post
 layout: post
-published: true
 featured: blue
-title: "Fragen für die öffentliche KI-Förderung"
+title: Fragen für die öffentliche KI-Förderung
+publishedDate: 2024-06-17
 ---
 
 In den vergangenen zwei Jahren haben den [Prototype Fund](https://prototypefund.de/) zunehmend mehr Bewerbungen für Softwareprojekte erreicht, die Methoden der Künstlichen Intelligenz (KI) wie Large Language Models (LLM) nutzen oder kritisch beleuchten. Mit der Verbreitung dieser Ansätze müssen sich öffentlich finanzierte Technologieförderprogramme wie der Prototype Fund damit auseinandersetzen, welche Auswahl- und Unterstützungsmechanismen es für KI-Projekte braucht, die offen, anpassbar und nachhaltig sind.

--- a/content/blog/2024/2024-06-geradejetztfueralle.md
+++ b/content/blog/2024/2024-06-geradejetztfueralle.md
@@ -1,8 +1,7 @@
 ---
-authors: 
+authors:
 - OKF DE
-date: 2024-06-12
-image: 
+image:
   src: /files/blog/2024/2024-06-GeradeJetzt.png
   license: HateAid
   license_url: https://gerade-jetzt-fuer-alle.de
@@ -11,9 +10,9 @@ tags:
 - Zivilgesellschaft
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Gerade jetzt. Für alle."
+title: Gerade jetzt. Für alle.
+publishedDate: 2024-06-12
 ---
 
 *Die OKF unterstützt die Kampagne **"Gerade jetzt. Für alle."**: Im Bundeshaushalt 2025 drohen nach Sparvorgaben des Finanzministeriums massive Streichungen. Bei den derzeitigen Verhandlungen zeichnet sich ab, dass das vor allem die Programmhaushalte der Ministerien treffen wird. Damit sind zivilgesellschaftliche Projekte und Initiativen bundesweit in ihrer Existenz bedroht. Ein breites Bündnis aus mehr als 50 gemeinnützigen Organisationen warnt nun vor den dramatischen Folgen solcher Haushaltskürzungen für die Demokratie.*

--- a/content/blog/2024/2024-07-03-dateninstitut-wmde-okf.md
+++ b/content/blog/2024/2024-07-03-dateninstitut-wmde-okf.md
@@ -2,8 +2,7 @@
 authors:
 - Aline Blankertz
 - Henriette Litta
-date: 2024-07-03
-image: 
+image:
   src: /files/blog/2020/03/data-joshua-sortino-unsplash.jpg
   title: Photo by Joshua Sortino on Unsplash
 tags:
@@ -12,9 +11,9 @@ tags:
 - zivilgesellschaft
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Das Dateninstitut kommt. Die Gemeinwohlorientierung bleibt fraglich"
+title: Das Dateninstitut kommt. Die Gemeinwohlorientierung bleibt fraglich
+publishedDate: 2024-07-03
 ---
 
 Das Dateninstitut wird kommen: Bis zum 4. Juli 2024 [läuft](https://bieterportal.pd-g.e-va.eu/?tid=dd7c196d2ee42c5b953d617afb8ab0b0) die Frist für Bewerbungen für „Konzeptionierung, Gründung und Betrieb des Dateninstituts“. Mit diesem Startschuss löst die Ampel ein Versprechen aus ihrem Koalitionsvertrag ein. In Sachen Daten gibt es wahrlich viel zu tun. Gut, dass hier etwas passiert. Trotzdem haben sich Wikimedia Deutschland und die Open Knowledge Foundation Deutschland gegen eine Beteiligung an dem Bewerbungsverfahren entschieden. Im Weiteren erklären wir, welche Überlegungen zu unserer Entscheidung geführt haben und welche nächsten Schritte für ein gemeinwohlorientiertes Dateninstitut wichtig sind.

--- a/content/blog/2024/2024-07-16-ospo-deu.md
+++ b/content/blog/2024/2024-07-16-ospo-deu.md
@@ -1,8 +1,7 @@
 ---
 authors:
 - Henriette Litta
-date: 2024-07-16
-image: 
+image:
   src: /files/blog/2024/2024-07-16_Blogpost_OSPO2024.jpg
   title: private photo OSPO 2024
 tags:
@@ -11,9 +10,9 @@ tags:
 - united nations
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Globale Anstrengungen zur Stärkung von Open Source Ansätzen – Eindrücke von der OSPO-Konferenz bei den Vereinten Nationen"
+title: Globale Anstrengungen zur Stärkung von Open Source Ansätzen – Eindrücke von der OSPO-Konferenz bei den Vereinten Nationen
+publishedDate: 2024-07-16
 ---
 
 **Letzte Woche fand die zweite Auflage der Konferenz [Open Source Programme Offices for Good](https://www.un.org/techenvoy/content/ospos-good-2024) (#OSPOsForGood) in New York statt. Auf Einladung der Vereinten Nationen (UN) reisten etwa 450 Open-Source-Enthusiast:innen aus aller Welt an - ein Riesenerfolg für die Veranstalter:innen, waren es 2023 noch rund 80 Teilnehmende. Es ging um nichts weniger als die Rolle von Open Source Software für die Erreichung der Sustainable Development Goals - also Weltrettung, Kernaufgabe der UN.**
@@ -34,4 +33,4 @@ Die vielen hochrangigen Vertretet:innen der Vereinten Nationen und ihrer vielen 
 
 ## Für das nächste Mal: Mehr in die Tiefe gehen
 
-Konferenzen sind immer auch Orte der Selbstvergewisserung. Es zeigte sich, dass eine Vielzahl von Teilnehmenden quer durch alle Sektoren vor ähnlichen Herausforderungen bei der Umsetzung von Open-Source-Ansätzen stehen: Die Suche nach guten und skalierbaren Beispielen, der interne Kompetenzaufbau, die Überwindung des Silo-Denkens, die fehlenden Modelle für die langfristige Finanzierung von Infrastruktur und die fehlenden internationalen Standards zum Austausch von Daten sind aktuelle Beispiele. Und auch das Dilemma, dass offene Software immer breitere Verwendung findet, aber die Entwicklungs- und Maintenance-Strukturen dahinter nicht gleichermaßen unterstützt und gefördert werden, wurde immer wieder thematisiert. Es bleibt also genug Diskussionsstoff für die nächsten OSPO-Konferenzen. 
+Konferenzen sind immer auch Orte der Selbstvergewisserung. Es zeigte sich, dass eine Vielzahl von Teilnehmenden quer durch alle Sektoren vor ähnlichen Herausforderungen bei der Umsetzung von Open-Source-Ansätzen stehen: Die Suche nach guten und skalierbaren Beispielen, der interne Kompetenzaufbau, die Überwindung des Silo-Denkens, die fehlenden Modelle für die langfristige Finanzierung von Infrastruktur und die fehlenden internationalen Standards zum Austausch von Daten sind aktuelle Beispiele. Und auch das Dilemma, dass offene Software immer breitere Verwendung findet, aber die Entwicklungs- und Maintenance-Strukturen dahinter nicht gleichermaßen unterstützt und gefördert werden, wurde immer wieder thematisiert. Es bleibt also genug Diskussionsstoff für die nächsten OSPO-Konferenzen.

--- a/content/blog/2024/2024-07-16-ospo-en.md
+++ b/content/blog/2024/2024-07-16-ospo-en.md
@@ -1,8 +1,7 @@
 ---
 authors:
 - Henriette Litta
-date: 2024-07-16
-image: 
+image:
   src: /files/blog/2024/2024-07-16_Blogpost_OSPO2024.jpg
   title: private photo OSPO 2024
 tags:
@@ -11,9 +10,9 @@ tags:
 - united nations
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Global efforts to strengthen open source concepts – Insights from the OSPO conference at the United Nations"
+title: Global efforts to strengthen open source concepts – Insights from the OSPO conference at the United Nations
+publishedDate: 2024-07-16
 ---
 
 **Last week, the second edition of the conference [Open Source Programme Offices for Good](https://www.un.org/techenvoy/content/ospos-good-2024) (#OSPOsForGood) took place in New York. At the invitation of the United Nations (UN), around 450 open source enthusiasts from all over the world traveled to the event - a huge success for the organizers, as there were around 80 participants in 2023. It was about nothing less than the role of open source software in achieving the Sustainable Development Goals - i.e. saving the world, the UN's core task.**

--- a/content/blog/2024/2024-10-18-Digitalgipfel PM F5.md
+++ b/content/blog/2024/2024-10-18-Digitalgipfel PM F5.md
@@ -2,8 +2,7 @@
 authors:
 - Henriette Litta
 - Christina Willems
-date: 2024-10-18
-image: 
+image:
   src: /files/blog/2024/2024-10-18-Digitalgipfel-Megaphone.jpg
   license: cc by Oleg Laptev
   license_url: https://creativecommons.org/licenses/by/4.0/
@@ -13,9 +12,9 @@ tags:
 - Pressemitteilung
 type: post
 layout: post
-published: true
 featured: blue
-title: "Bündnis F5 beim Digital-Gipfel – Die Zivilgesellschaft muss um jeden Zentimeter Raum kämpfen"
+title: Bündnis F5 beim Digital-Gipfel – Die Zivilgesellschaft muss um jeden Zentimeter Raum kämpfen
+publishedDate: 2024-10-18
 ---
 
 **Pressemitteilung des Bündnis F5**
@@ -41,4 +40,3 @@ Bei der [Plattform 7](https://www.de.digital/DIGITAL/Navigation/DE/Digital-Gipfe
 +++
 
 Pressekontakt: presse@okfn.de
-

--- a/content/blog/2024/2024-10-20-PFH-CFP-2024.md
+++ b/content/blog/2024/2024-10-20-PFH-CFP-2024.md
@@ -1,8 +1,7 @@
 ---
 authors:
 - Maximilian Voigt
-date: 2024-10-20
-image: 
+image:
   src: /files/blog/2024/PFH_CFP_2024.png
   license: cc by Maximilian Voigt
   license_url: https://creativecommons.org/licenses/by/4.0/
@@ -12,9 +11,9 @@ tags:
 - Umweltschutz
 type: post
 layout: post
-published: true
 featured: blue
-title: "Prototpye Fund Hardware Runde 2: Open Hardware für den Umweltschutz"
+title: 'Prototpye Fund Hardware Runde 2: Open Hardware für den Umweltschutz'
+publishedDate: 2024-10-20
 ---
 
 Wie stark ist das Grundwasser mit Nitrat belastet? Welche Insektenarten sind bedroht? Und was sind zielführende Maßnahmen, dem entgegenzuwirken? Solche und andere Fragen drängen bei der effektiven Gestaltung des Umweltschutzes. Offene Technologien und Daten können dabei helfen, Antworten zu entwickeln und breit nutzbar zu machen. Mit der 2. Runde des Prototype Fund Hardware „KI-Ideenwerkstatt X Prototype Fund Hardware: Offene Technologien für den Umweltschutz“ suchen die Open Knowledge Foundation Deutschland in Kooperation mit der KI-Ideenwerkstatt für den Umweltschutz Menschen, die die technischen Möglichkeiten für Umweltschützende sinnvoll erweitern und es anderen erleichtern, am Schutz der Umwelt mitzuwirken. Unterstützt werden zehn Projektteams mit 24.500€ sowie mit Expertise. Die Bewerbung ist bis zum 31. Oktober möglich.
@@ -25,4 +24,3 @@ Im Fokus des Ideenwettbewerbs stehen zivilgesellschaftlich betriebene Umweltsens
 Durch den Einsatz offener Technologien wird nicht nur die Datenerfassung dezentralisiert, sondern auch die Möglichkeit geschaffen, dass Bürger*innen direkt am Schutz ihrer Umwelt mitwirken. Internationale Erfahrungen deuten darauf hin, dass die aktive Beteiligung der Zivilgesellschaft am Monitoring von Umweltproblemen ein größeres Bewusstsein schafft. Das kann dazu beitragen, dass die Bekämpfung der Probleme als vorrangiges Thema auf die lokale und nationale politische Tagesordnung gelangt. Außerdem bieten zivilgesellschaftliche Messungen Regulierungsbehörden praktische Unterstützung bei der laufenden Überwachung und der Berichterstattung über Umweltverschmutzungen. Des Weiteren können sie dazu beitragen, eine Kultur der partizipativen Demokratie aufzubauen. 
 Eingereicht werden dürfen realisierbare Ideenskizzen und solche, die sich bereits in der Umsetzung befinden, denen aber Ressourcen für den praktischen Einsatz und die Dokumentation fehlen. Für die Umsetzung bis zur öffentlichen Vorstellung haben die Teams 12 Monate Zeit.
 Mehr auf [hardware.prototypefund.de](https://hardware.prototypefund.de/)
-

--- a/content/blog/2024/20240513_PIAZZA_CallforWorkshops.md
+++ b/content/blog/2024/20240513_PIAZZA_CallforWorkshops.md
@@ -1,8 +1,7 @@
 ---
 authors:
 - OKF DE
-date: 2024-05-13
-image: 
+image:
   src: /files/blog/2024/20240513_PIAZZA_2024-SharePic-CfW-2.png
   license: cc by Kompetenzzentrum Öffentliche IT (ÖFIT)
   license_url: https://creativecommons.org/licenses/by/4.0/
@@ -11,9 +10,9 @@ tags:
 - Verwaltung
 type: post
 layout: post
-published: true
 featured: yellow
-title: "PIAZZA-Konferenz 2024: Call for Workshops"
+title: 'PIAZZA-Konferenz 2024: Call for Workshops'
+publishedDate: 2024-05-13
 ---
 
 Am **14. November 2024** findet die Konferenz „PIAZZA – Für digitale Verwaltung & Gesellschaft“ zum vierten Mal online statt. Die OKF wird dieses Jahr erstmalig im Trägerkreis dabei sein. Wir freuen uns sehr! 

--- a/content/blog/2024/24-06-20-jahresbericht-2023.md
+++ b/content/blog/2024/24-06-20-jahresbericht-2023.md
@@ -1,8 +1,7 @@
 ---
 authors:
 - Henriette Litta
-date: 2024-06-20
-image: 
+image:
   src: /files/blog/2024/2023 Jahresbericht Blogbild.png
 tags:
 - OKFDE
@@ -10,11 +9,10 @@ tags:
 - jahresbericht
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Das war 2023: Unser Jahresbericht ist online!"
+title: 'Das war 2023: Unser Jahresbericht ist online!'
+publishedDate: 2024-06-20
 ---
-
 
 Unser Jahresbericht 2023 ist online! Viel ist passiert, und wir blicken zurück auf ein ereignisreiches Jahr voller spannender Projekt und beeindruckender Highlights. Nach der erfolgreich abgeschlossenen Wirtschaftsprüfung könnt ihr ab sofort unseren vollständigen Jahresbericht auf [2023.okfn.de](https://2023.okfn.de/) einsehen. Selbstverständlich steht auch eine [PDF Version](https://2023.okfn.de/assets/documents/OKF_Jahresbericht_2023.pdf) zum Download bereit. Taucht ein und erfahrt mehr über unsere Erfolge und Fortschritte im vergangenen Jahr!
 

--- a/content/blog/2024/24-06-28-zum-NKWS-Entwurf.md
+++ b/content/blog/2024/24-06-28-zum-NKWS-Entwurf.md
@@ -1,8 +1,7 @@
 ---
 authors:
 - Maximilian Voigt
-date: 2024-06-28
-image: 
+image:
   src: /files/blog/2024/rc2.JPG
   license: cc by Maximilian Voigt
   license_url: https://creativecommons.org/licenses/by/4.0/
@@ -14,9 +13,9 @@ tags:
 - Produkttransparenz
 type: post
 layout: post
-published: true
 featured: blue
-title: "Zum Entwurf der NKWS: ambitioniert bleiben!"
+title: 'Zum Entwurf der NKWS: ambitioniert bleiben!'
+publishedDate: 2024-06-28
 ---
 
 Die Bundesregierung arbeitet an einer Strategie, die "[Ziele und Maßnahmen zum zirkulären Wirtschaften und zur Ressourcenschonung aus allen relevanten Strategien](https://www.bmuv.de/themen/kreislaufwirtschaft/kreislaufwirtschaftsstrategie)" zusammenführen und den primären Rohstoffbedarf "absolut" senken soll. Mehr Informationen auf der Produktebene und offene Designs können maßgeblich zum Erfolg dieses Zieles beitragen. Dafür setzt sich die OKF zusammen mit der [Open Hardware Allianz](https://open-hardware-allianz.de/) ein.
@@ -43,4 +42,3 @@ Für eine effektive Kreislaufgesellschaft muss Technologie grundsätzlich neu ge
 ## Die Stellungnahme der OKF DE und der Open Hardware Allianz in voller Länge
 
 {{< pdf url="/files/documents/NKWS_Kommentierung_OKFDE_OHAGERMANY.pdf" >}}
-

--- a/content/blog/2024/24-07-04-recap-republica.md
+++ b/content/blog/2024/24-07-04-recap-republica.md
@@ -1,8 +1,7 @@
 ---
 authors:
 - OKF DE
-date: 2024-07-04
-image: 
+image:
   src: /files/blog/2024/2024-07-04-Republica24-F5.jpg
   license: CC-BY SA 4.0
 tags:
@@ -10,9 +9,9 @@ tags:
 - digitaleZivilgesellschaft
 type: post
 layout: post
-published: true
 featured: blue
-title: "Das war die re:publica 2024: Unser Recap"
+title: 'Das war die re:publica 2024: Unser Recap'
+publishedDate: 2024-07-04
 ---
 
 Vom 27. - 29.05.2024 fand in Berlin die **re:publica** statt - das Festival für die digitale Gesellschaft! Die OKF war mit vielen verschiedenen [Themen und Formaten](https://okfn.de/blog/2024/05/triffdieokfaufderrepublica24/) dabei. Während unseres Programms haben wir uns mit Expert:innen aus verschiedenen Bereichen ausgetauscht, führten zahlreiche spannende Gespräche und konnten dem Publikum unsere Projekte vorstellen. Hier könnt ihr einen kurzen Recap unserer Zeit vor Ort nachlesen:

--- a/content/blog/2024/24-07-17-team-retreat.md
+++ b/content/blog/2024/24-07-17-team-retreat.md
@@ -1,17 +1,16 @@
 ---
 authors:
 - OKF DE
-date: 2024-07-17
-image: 
+image:
   src: /files/blog/2024/2024-07-15-retreat1.jpeg
 tags:
 - retreat
 - Brandenburg
 type: post
 layout: post
-published: true
 featured: blue
-title: "Team-Retreat in Stechlin/Brandenburg: Natur, Teambuilding, Zukunftsvisionen"
+title: 'Team-Retreat in Stechlin/Brandenburg: Natur, Teambuilding, Zukunftsvisionen'
+publishedDate: 2024-07-17
 ---
 
 ## Team-Retreat
@@ -40,4 +39,4 @@ Die Zukunftsplanung stand im Zentrum: Unser Policy-Team sammelte Forderungen und
 
 Unsere zwei Tage im Stechlin-Institut haben viele Ergebnisse geliefert, mit denen wir im Lauf des Jahres konkret weiterarbeiten werden; von einigen Gesprächen und Erlebnissen werden wir indirekt profitieren, durch verbesserte Zusammenarbeit und gestärkte Beziehungen. Das Retreat ist auch für das Jahr 2025 wieder in Planung! Wir freuen uns auf die gemeinsame Zeit und neuen Input.
 
-![Gruppenbild](/files/blog/2024/2024-07-15-retreat6.jpeg) 
+![Gruppenbild](/files/blog/2024/2024-07-15-retreat6.jpeg)

--- a/content/blog/2024/24-08-05-jugend-hackt-sommer.md
+++ b/content/blog/2024/24-08-05-jugend-hackt-sommer.md
@@ -1,17 +1,16 @@
 ---
 authors:
 - Jugend hackt
-date: 2024-08-05
-image: 
+image:
   src: /files/blog/2024/JH_Logo_Claim_RGB.png
 tags:
 - Jugendhackt
 - Termine
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Sommer bei Jugend hackt: Ein buntes Programm für junge Hacker*innen"
+title: 'Sommer bei Jugend hackt: Ein buntes Programm für junge Hacker*innen'
+publishedDate: 2024-08-05
 ---
 
 ## Sommerprogramm-Highlights

--- a/content/blog/2024/24-09-05-demo-day.md
+++ b/content/blog/2024/24-09-05-demo-day.md
@@ -1,17 +1,16 @@
 ---
 authors:
 - OKFDE
-date: 2024-09-05
-image: 
+image:
   src: /files/blog/2024/PTF-DemoDay-Titel.jpg
 tags:
 - PrototypeDemos
 - Demo Day
 type: post
 layout: post
-published: true
 featured: blue
-title: "Demo Day von Prototype Fund: die 15. Förderrunde im Rampenlicht"
+title: 'Demo Day von Prototype Fund: die 15. Förderrunde im Rampenlicht'
+publishedDate: 2024-09-05
 ---
 
 ## Rückblick

--- a/content/blog/2024/24-09-09-hack-day.md
+++ b/content/blog/2024/24-09-09-hack-day.md
@@ -1,17 +1,16 @@
 ---
 authors:
 - OKFDE
-date: 2024-09-09
-image: 
+image:
   src: /files/blog/2024/Hackday Titel.png
 tags:
 - Jugendhackt
 - Hackday
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Hackday am 3. Oktober!"
+title: Hackday am 3. Oktober!
+publishedDate: 2024-09-09
 ---
 
 ## Jugend hackt: Hackday

--- a/content/blog/2024/24-09-10-spenden-erbschaften.md
+++ b/content/blog/2024/24-09-10-spenden-erbschaften.md
@@ -1,17 +1,16 @@
 ---
 authors:
 - OKFDE
-date: 2024-09-10
-image: 
+image:
   src: /files/blog/2024/Spenden_Erbschaften OKF.png
 tags:
 - Spenden
 - Erbschaften
 type: post
 layout: post
-published: true
 featured: blue
-title: "Spenden und Erbschaften für die OKF"
+title: Spenden und Erbschaften für die OKF
+publishedDate: 2024-09-10
 ---
 
 ## Spenden und Erbschaften

--- a/content/blog/2024/24-10-02-neuwahl-vorstand-okf.md
+++ b/content/blog/2024/24-10-02-neuwahl-vorstand-okf.md
@@ -1,16 +1,15 @@
 ---
 authors:
 - OKFDE
-date: 2024-10-15
-image: 
+image:
   src: /files/blog/2024/2024-Vorstand.png
 tags:
 - Vorstand
 type: post
 layout: post
-published: true
 featured: yellow
-title: "Neuwahl des Vorstands - Pressemitteilung"
+title: Neuwahl des Vorstands - Pressemitteilung
+publishedDate: 2024-10-15
 ---
 
 ## Neuer Vorstand gewählt

--- a/content/blog/2024/24-10-18-DE-Reparaturpolitik.md
+++ b/content/blog/2024/24-10-18-DE-Reparaturpolitik.md
@@ -1,8 +1,7 @@
 ---
 authors:
 - Maximilian Voigt
-date: 2024-10-19
-image: 
+image:
   src: /files/blog/2024/r2r_de.png
   license: cc by Maximilian Voigt
   license_url: https://creativecommons.org/licenses/by/4.0/
@@ -11,9 +10,9 @@ tags:
 - Produkttransparenz
 type: post
 layout: post
-published: true
 featured: blue
-title: "Licht ins Dunkel deutscher Reparaturpolitik"
+title: Licht ins Dunkel deutscher Reparaturpolitik
+publishedDate: 2024-10-19
 ---
 
 Als die Bundesregierung 2021 angetreten ist, hatte sie sich vorgenommen das sogenannte „Recht auf Reparatur“ voranzubringen und die Reparierbarkeit eines Produktes „zum erkennbaren Merkmal der Produkteigenschaft“ zu machen (siehe [Koalitionsvertrag](https://www.bundesregierung.de/breg-de/aktuelles/koalitionsvertrag-2021-1990800)). In den folgenden Jahren gab es immer wieder Berichterstattung zu den Entwicklungen auf EU-Ebene. Deutschland wollte mit einem Aktionsprogramm „Reparieren statt wegwerfen“ eine Vorreiterrolle einnehmen. Doch bisher ist nichts passiert. Dafür haben wir ein EU-weites Recht auf Reparatur bekommen, das [seinen Namen nicht verdient](https://okfn.de/blog/2024/04/right-to-repair-entschieden-final/). Mich hat ein Jahr die Frage beschäftigt: Für was hat sich die Bundesregierung nun wirklich eingesetzt? Zahlreiche Anfragen im Rahmen des Informationsfreiheitsgesetzes und eine Klage gegen das Bundes Justizministerium später gibt es einen Haufen Papier und ein paar Antworten. Anlässlich des [internationalen Tages der Reparatur](https://openrepair.org/international-repair-day/) fasse ich sie hier zusammen.
@@ -38,4 +37,3 @@ Alle Unterlagen finden sich auf [fragdenstaat.de](https://fragdenstaat.de/)
 * [Zu den deutschen Kommentaren und Weisungen zum Recht auf Reparatur auf EU-Ebene](https://fragdenstaat.de/anfrage/positionsfindung-der-bundesregierung-zum-sogenannten-recht-auf-reparatur/#nachricht-944099)
 * [Zu den Positionen zum Recht auf Reparatur des BMJ](https://fragdenstaat.de/anfrage/positionsfindung-der-bundesregierung-zum-sogenannten-recht-auf-reparatur/#nachricht-943973)
 * [Zu den Positionen zum Recht auf Reparatur des BMUV](https://fragdenstaat.de/anfrage/positionsfindung-der-bundesregierung-zum-sogenannten-recht-auf-reparatur-1/#nachricht-938924)
-

--- a/content/jobs/assistenz-gf.md
+++ b/content/jobs/assistenz-gf.md
@@ -1,14 +1,14 @@
 ---
-authors: 
+authors:
 - Dr. Henriette Litta
-date: 2020-04-28
 image:
   src: /files/blog/2019/06/team-foto.jpg
-  title: "OKF Team"
-  license:
-  license_url:
-published: false
-title: "Neuer Job bei der OKF: Wir suchen eine Assistenz der Geschäftsführung (Vollzeit oder Teilzeit, ab sofort, zunächst befristet auf 1 Jahr)" 
+  title: OKF Team
+  license: null
+  license_url: null
+title: 'Neuer Job bei der OKF: Wir suchen eine Assistenz der Geschäftsführung (Vollzeit oder Teilzeit, ab sofort, zunächst befristet auf 1 Jahr)'
+draft: 'true'
+publishedDate: 2020-04-28
 ---
 
 ## Wer wir sind
@@ -70,5 +70,4 @@ Bitte schicke uns deine Bewerbung (Anschreiben, Lebenslauf) inkl. möglichem Beg
 
 Wir freuen uns insbesondere über die Bewerbungen von Frauen, Menschen mit Migrationshintergrund und Menschen anderer Gruppen, die generell und auch in unserer Welt unterrepräsentiert sind. 
  
-Die Gespräche finden zeitnah nach Bewerbungsschluss in Berlin statt bzw. remote per Videokonferenz. Die innerdeutschen Reisekosten für die Bewerbungsgespräche übernehmen wir, sofern sie nicht von der Arbeitsagentur getragen werden. 
-
+Die Gespräche finden zeitnah nach Bewerbungsschluss in Berlin statt bzw. remote per Videokonferenz. Die innerdeutschen Reisekosten für die Bewerbungsgespräche übernehmen wir, sofern sie nicht von der Arbeitsagentur getragen werden.

--- a/content/jobs/cfg-junior-community-redakteurin.md
+++ b/content/jobs/cfg-junior-community-redakteurin.md
@@ -1,15 +1,15 @@
 ---
 authors:
 - Sonja Fischbauer
-date: 2022-01-27
 image:
   src: /files/jobs/cfg-redakteurin.jpg
-  title: "Community Redakteur:in gesucht!"
-  license: "CC-BY 4.0, Urheber: Leonard Wolf"
+  title: Community Redakteur:in gesucht!
+  license: 'CC-BY 4.0, Urheber: Leonard Wolf'
   license_url: https://creativecommons.org/licenses/by/4.0/
-tags:
-published: false
-title: "Wir suchen eine:n Junior Community Redakteur:in für Code for Germany (Studentische Hilfskraft, 19h/Woche)"
+tags: null
+title: Wir suchen eine:n Junior Community Redakteur:in für Code for Germany (Studentische Hilfskraft, 19h/Woche)
+draft: 'true'
+publishedDate: 2022-01-27
 ---
 
 Um die Geschichten aus unserem ehrenamtlichen Netzwerk Code for Germany aufzubereiten, suchen wir eine:n 
@@ -75,4 +75,4 @@ Wir freuen uns insbesondere über die Bewerbungen von Frauen*, BPoC, Menschen mi
 Bitte schicke uns deine Bewerbung **bis spätestens Dienstag, 1. März 2022** mit Anschreiben, Lebenslauf und frühestmöglichem Arbeitsbeginn per E-Mail an Sonja via **jobs@okfn.de**. 
 Bitte verzichte in deiner Bewerbung auf Fotos und Angaben zu Alter und Familienstand. 
 
-Wir werden alle Bewerbungen sichten und unserem personalverantwortlichen Team zur Auswahl vorlegen (erste Runde). Danach laden wir einige von euch zum persönlichen Kennenlernen ein (zweite Runde), entweder vor Ort in Berlin oder online. 
+Wir werden alle Bewerbungen sichten und unserem personalverantwortlichen Team zur Auswahl vorlegen (erste Runde). Danach laden wir einige von euch zum persönlichen Kennenlernen ein (zweite Runde), entweder vor Ort in Berlin oder online.

--- a/content/jobs/community-builderin-code-for-germany.md
+++ b/content/jobs/community-builderin-code-for-germany.md
@@ -1,14 +1,14 @@
 ---
 authors:
 - Michael Peters
-date: 2019-10-31
 image:
   src: /files/blog/2019/10/CFG_logo.png
-  title: "CodeforGermany-logo"
-  license:
-  license_url:
-published: false
-title: "Neuer Job bei Code for Germany: Wir suchen Communitybuilder*in! (80%, ab Januar 2020)"
+  title: CodeforGermany-logo
+  license: null
+  license_url: null
+title: 'Neuer Job bei Code for Germany: Wir suchen Communitybuilder*in! (80%, ab Januar 2020)'
+draft: 'true'
+publishedDate: 2019-10-31
 ---
 
 [Code for Germany](https://codefor.de/) ist eine deutschlandweite Community, die sich dafür einsetzt, das Potenzial der Digitalisierung für alle Menschen zugänglich zu machen. In 26 Städten treffen sich dazu technisch interessierte Menschen, um in den Open Knowledge Labs (kurz: OK Labs) zu coden, zu diskutieren und sich mit Bürger\*innen und politischen Vertreter\*innen auszutauschen.

--- a/content/jobs/finanzadministration-jugend-hackt.md
+++ b/content/jobs/finanzadministration-jugend-hackt.md
@@ -1,14 +1,14 @@
 ---
 authors:
 - Sonja Fischbauer
-date: 2021-01-14
 image:
   src: /files/blog/2021/01/jugend-hackt-team-2020.jpg
-  title: "Jugend hackt Team"
-  license:
-  license_url:
-published: false
-title: "Jugend hackt: Wir suchen studentische Finanzadministration (ab sofort)"
+  title: Jugend hackt Team
+  license: null
+  license_url: null
+title: 'Jugend hackt: Wir suchen studentische Finanzadministration (ab sofort)'
+draft: 'true'
+publishedDate: 2021-01-14
 ---
 
 ## Jugend hackt sucht eine\*n studentische\*n Mitarbeiter\*in (m/w/d) für Finanzadministration, 19h/Woche, ab sofort

--- a/content/jobs/geschaeftsfuehrung.md
+++ b/content/jobs/geschaeftsfuehrung.md
@@ -1,14 +1,14 @@
 ---
 authors:
 - OKF
-date: 2019-06-24
 image:
   src: /files/blog/2019/06/team-foto.jpg
-  title: "OKF Team 2018"
+  title: OKF Team 2018
   license: CC-BY
   license_url: https://creativecommons.org/licenses/by/2.0/
-published: false
-title: "Wir suchen eine*n Geschäftsführer*in, Bewerbungsfrist 28.07."
+title: Wir suchen eine*n Geschäftsführer*in, Bewerbungsfrist 28.07.
+draft: 'true'
+publishedDate: 2019-06-24
 ---
 
 Die **Open Knowledge Foundation Deutschland (OKF)** setzt sich seit 2011 erfolgreich für dezentrale Teilhabe, offenes Wissen, digitales zivilgesellschaftliches Engagement und offene Innovation ein. Um die Wirksamkeit der OKF zu stärken und die Organisation in enger Zusammenarbeit mit Team und Board weiterzuentwickeln, suchen wir zum nächstmöglichen Zeitpunkt eine neue **Geschäftsführung (in Vollzeit)**.

--- a/content/jobs/gf-buchhaltung-assistenz.md
+++ b/content/jobs/gf-buchhaltung-assistenz.md
@@ -1,15 +1,16 @@
 ---
 authors:
 - Giulia
-date: 2023-07-06
 image:
-  src: 
-  title:
-  license:
-  license_url:
-published: false
-title: "Gesucht: Buchhaltung- & Office-Assistenz (Minijob / Stud. Hilfskraft / TVL E12/S1)"
+  src: null
+  title: null
+  license: null
+  license_url: null
+title: 'Gesucht: Buchhaltung- & Office-Assistenz (Minijob / Stud. Hilfskraft / TVL E12/S1)'
+draft: 'true'
+publishedDate: 2023-07-06
 ---
+
 ### Um unser Team in Sachen Tabellen, Zahlen und Belegen zu untersützen, suchen wir eine Assistenz für Buchhaltung und Office: Minijob, Stud. Hilfskraft oder TVL E12/S1 mit 10-15h/Woche in Berlin, ab sofort, 2 Jahre befristet. Bewerbungsfrist: 06. August 2023
 
 #### Wer wir sind

--- a/content/jobs/gf-kommunikationsmanagerin 2024.md
+++ b/content/jobs/gf-kommunikationsmanagerin 2024.md
@@ -1,15 +1,15 @@
 ---
 authors:
 - Sonja Fischbauer
-date: 2024-01-24
 image:
   src: /files/jobs/cfg-redakteurin.jpg
-  title: "Kommunikationsmanager:in gesucht!"
-  license: "CC-BY 4.0, Urheber: Leonard Wolf"
+  title: Kommunikationsmanager:in gesucht!
+  license: 'CC-BY 4.0, Urheber: Leonard Wolf'
   license_url: https://creativecommons.org/licenses/by/4.0/
-tags:
-published: false
-title: "Wir suchen eine:n Kommunikationsmanager:in für die OKF (Teilzeit, 20-28h/Woche)"
+tags: null
+title: Wir suchen eine:n Kommunikationsmanager:in für die OKF (Teilzeit, 20-28h/Woche)
+draft: 'true'
+publishedDate: 2024-01-24
 ---
 
 Um unsere Arbeit zu Open Data & Co. in unseren Communities zu begleiten und öffentlichkeitswirksam zu verbreiten, suchen wir eine:n
@@ -87,4 +87,3 @@ Schick uns deine Bewerbungsunterlagen (Anschreiben, Lebenslauf, relevante Zeugni
 Wir sichten alle Bewerbungen in einem kleinen Berwerbungskommittee (erste Runde). Danach laden wir einige von euch zum persönlichen Kennenlernen ein, vor Ort in Berlin oder online (zweite Runde). 
 
 Die **Bewerbungsgespräche** finden voraussichtlich in der Zeit **von 19. bis 21. März** statt.
-

--- a/content/jobs/jugendhackt-fundraising.md
+++ b/content/jobs/jugendhackt-fundraising.md
@@ -1,15 +1,15 @@
 ---
 authors:
 - Sonja Fischbauer
-date: 2021-06-22
 image:
   src: /files/blog/2019/31632708378_9e627e19eb_z.jpg
-  title: "Sonja und Daniel vom Jugend hackt Programmleitungsteam"
+  title: Sonja und Daniel vom Jugend hackt Programmleitungsteam
   license: CC-BY
   license_url: https://creativecommons.org/licenses/by/4.0/
-tags:
-published: false
-title: "Jugend hackt sucht ein*e Fundraiser*in (80%, Bewerbungsschluss verlängert auf 31.08.2021)"
+tags: null
+title: Jugend hackt sucht ein*e Fundraiser*in (80%, Bewerbungsschluss verlängert auf 31.08.2021)
+draft: 'true'
+publishedDate: 2021-06-22
 ---
 
 Zur Verstärkung des Jugend hackt Teams suchen wir:

--- a/content/jobs/jugendhackt-programmleitung.md
+++ b/content/jobs/jugendhackt-programmleitung.md
@@ -1,15 +1,15 @@
 ---
 authors:
 - Paula Grünwald
-date: 2019-08-05
 image:
   src: /files/blog/2019/31632708378_9e627e19eb_z.jpg
-  title: "Sonja und Daniel vom Jugend hackt Programmleitungsteam"
+  title: Sonja und Daniel vom Jugend hackt Programmleitungsteam
   license: CC-BY
   license_url: https://creativecommons.org/licenses/by/4.0/
-tags:
-published: false
-title: "Verstärke das Programmleitungsteam von Jugend hackt (80-100%, Bewerbungsschluss 10.10.2019)"
+tags: null
+title: Verstärke das Programmleitungsteam von Jugend hackt (80-100%, Bewerbungsschluss 10.10.2019)
+draft: 'true'
+publishedDate: 2019-08-05
 ---
 
 [Jugend hackt](https://jugendhackt.org/) ist ein preisgekröntes Förderprogramm für programmier- und making-begeisterte Jugendliche zwischen 12 und 18 Jahren, die “mit Code die Welt verbessern” wollen. Jugend hackt ist ein gemeinsames Programm der Open Knowledge Foundation Deutschland e.V. mit mediale pfade.org - Verein für Medienbildung e.V. 

--- a/content/jobs/jugendhackt-projektmanagement.md
+++ b/content/jobs/jugendhackt-projektmanagement.md
@@ -1,15 +1,15 @@
 ---
 authors:
 - Nina Schröter
-date: 2022-02-08
 image:
   src: /files/blog/2019/31632708378_9e627e19eb_z.jpg
-  title: "Sonja und Daniel vom Jugend hackt Programmleitungsteam"
+  title: Sonja und Daniel vom Jugend hackt Programmleitungsteam
   license: CC-BY
   license_url: https://creativecommons.org/licenses/by/4.0/
-tags:
-published: false
-title: "Verstärke Jugend hackt als Projektmanager*in und Netzwerkkoordinator*in (50%)"
+tags: null
+title: Verstärke Jugend hackt als Projektmanager*in und Netzwerkkoordinator*in (50%)
+draft: 'true'
+publishedDate: 2022-02-08
 ---
 
 Zur Verstärkung des Jugend hackt Teams suchen wir:

--- a/content/jobs/juristin-fragdenstaat.md
+++ b/content/jobs/juristin-fragdenstaat.md
@@ -1,15 +1,15 @@
 ---
-authors: 
+authors:
 - Arne Semsrott
 - Phillip Hofmann
-date: 2020-12-04
 image:
   src: /files/jobs/fds1.png
-  title: "FragDenStaat-Logo"
-  license:
-  license_url: 
-published: false
-title: "FragDenStaat: Wir suchen Volljurist*in! (80-100%, ab Februar 2021)" 
+  title: FragDenStaat-Logo
+  license: null
+  license_url: null
+title: 'FragDenStaat: Wir suchen Volljurist*in! (80-100%, ab Februar 2021)'
+draft: 'true'
+publishedDate: 2020-12-04
 ---
 
 **Für unseren Bereich der strategischen Klagen suchen wir ab Februar des kommenden Jahres zur Verstärkung eine Volljurist\*in für FragDenStaat!**

--- a/content/jobs/kommunikation-projektmanagement-ptf.md
+++ b/content/jobs/kommunikation-projektmanagement-ptf.md
@@ -1,14 +1,14 @@
 ---
 authors:
 - Patricia Leu
-date: 2023-07-17
 image:
-  src:
-  title:
-  license:
-  license_url:
-published: false
-title: "Ausschreibung: Kommunikation und Projektmanagement für den Prototype Fund"
+  src: null
+  title: null
+  license: null
+  license_url: null
+title: 'Ausschreibung: Kommunikation und Projektmanagement für den Prototype Fund'
+draft: 'true'
+publishedDate: 2023-07-17
 ---
 
 Im Prototype Fund suchen wir eine Person, die unsere Arbeit und Ziele über verschiedene Kanäle kommuniziert. Dabei platzierst du sowohl unsere Inhalte als auch die der geförderten Projekte und hilfst ihnen, sich und ihre Ideen vorzustellen und zu vernetzen.

--- a/content/jobs/kommunikationsmanagement-ptf.md
+++ b/content/jobs/kommunikationsmanagement-ptf.md
@@ -1,14 +1,14 @@
 ---
 authors:
 - Katharina Meyer
-date: 2019-10-15
 image:
   src: /files/jobs/ptf1.gif
-  title:
-  license:
-  license_url:
-published: false
-title: "Prototype Fund: Kommunikationstalent für Content-Strategie gesucht! (100%, ab Januar 2020)"
+  title: null
+  license: null
+  license_url: null
+title: 'Prototype Fund: Kommunikationstalent für Content-Strategie gesucht! (100%, ab Januar 2020)'
+draft: 'true'
+publishedDate: 2019-10-15
 ---
 
 ## Job: Kommunikationstalent für Content-Strategie gesucht! (Bewerbungsfrist 15.November 2019)

--- a/content/jobs/okf-policy-opendata.md
+++ b/content/jobs/okf-policy-opendata.md
@@ -1,15 +1,15 @@
 ---
 authors:
 - Henriette Litta
-date: 2022-08-03
 image:
   src: /files/blog/2021/03/Logo_okfde_black_centered.png
-  title:
-  license: 
-  license_url:
-tags:
-published: false
-title: "Die OKF sucht eine:n Projektmanager:in für Policy und Open Data"
+  title: null
+  license: null
+  license_url: null
+tags: null
+title: Die OKF sucht eine:n Projektmanager:in für Policy und Open Data
+draft: 'true'
+publishedDate: 2022-08-03
 ---
 
 Die Open Knowledge Foundation Deutschland (OKF) ist ein gemeinnütziger Verein mit Sitz in Berlin, der sich für offenes Wissen, Transparenz und Beteiligung einsetzt. Unsere Arbeit ist unabhängig, überparteilich und interdisziplinär.

--- a/content/jobs/prototypefund-projektmanagerin-mit-schwerpunkt-events.md
+++ b/content/jobs/prototypefund-projektmanagerin-mit-schwerpunkt-events.md
@@ -1,15 +1,16 @@
 ---
 authors:
 - OKF
-date: 2019-03-22
 image:
   src: /files/jobs/helping.gif
-  title: #prototypeworks
+  title: null
   license: © Libby VanderPloeg
   license_url: https://www.libbyvanderploeg.com/
-published: false
-title: "Prototype Fund sucht Verstärkung: Projektmanager*in mit Schwerpunkt Events (m/w/*)"
+title: 'Prototype Fund sucht Verstärkung: Projektmanager*in mit Schwerpunkt Events (m/w/*)'
+draft: 'true'
+publishedDate: 2019-03-22
 ---
+
 Der Prototype Fund ist das erste Förderprogramm in Deutschland, das selbstständige Softwareentwickler\*innen, Hacker\*innen und Kreative dabei unterstützt, ihre Ideen in den Bereichen Civic Tech, Digital Literacy, IT-Sicherheit und Software-Infrastruktur umzusetzen. Unser Ziel ist es, technische Innovationen in den Dienst der Gesellschaft zu stellen. Wir (Adriana, Katharina und Thomas) suchen dabei jetzt Verstärkung mit Talent für Eventmanagement!
 
 Du willst gemeinsam mit uns ein Pionier-Projekt voranbringen? Du arbeitest eigenständig und hast Lust, dich weiterzuentwickeln und Neues zu lernen? Dann freuen wir uns auf deine Bewerbung:
@@ -55,4 +56,3 @@ Zeitl. Aufwand: 40h/Woche (Teilzeitregelung nach Absprache möglich)
 Gehalt: nach TV-L E12/S1  
 Ort: Berlin  
 Die Position ist bis Februar 2021 befristet.**
-

--- a/content/jobs/ptf-begleitforschung.md
+++ b/content/jobs/ptf-begleitforschung.md
@@ -1,14 +1,14 @@
 ---
 authors:
 - Autor\*in: Patricia Leu
-date: 2022-09-22
 image:
   src: /files/jobs/ptf-kommunikation.png
   title: Begleitforschung und Projektmanagement
-  license:
-  license_url:
-published: false
-title: "Der Prototype Fund sucht eine Person für Begleitforschung und Projektmanagement"
+  license: null
+  license_url: null
+title: Der Prototype Fund sucht eine Person für Begleitforschung und Projektmanagement
+draft: 'true'
+publishedDate: 2022-09-22
 ---
 
 Zur Unterstützung unseres Teams suchen wir eine Person, die die Evaluation und Weiterentwicklung unseres Förderprogramms im Rahmen der Begleitforschung vorantreibt. Dafür recherchierst du zu technologischen Trends, führst Interviews mit (ehemaligen) Geförderten, erhebst Daten und verarbeitest die Ergebnisse regelmäßig zu [Forschungsberichten](https://prototypefund.de/about/begleitforschung/). Außerdem übernimmst du im Team Projektmanagementaufgaben wie z. B. unsere [Events](https://prototypefund.de/demo-day-runde-11/). Dafür nutzen wir bereits etablierte Formate und freuen uns über neue Ideen und Vorschläge!

--- a/content/jobs/ptf-eventmanagement.md
+++ b/content/jobs/ptf-eventmanagement.md
@@ -1,15 +1,15 @@
 ---
 authors:
 - Patricia Leu
-date: 2024-07-25
 image:
   src: /files/jobs/ptf-kommunikation.png
-  title: "Eventmanagement"
-  license: 
-  license_url:
-tags:
-published: false
-title: "Der Prototype Fund sucht eine Person für das Eventmanagement (Laufzeit: 6 Monate)"
+  title: Eventmanagement
+  license: null
+  license_url: null
+tags: null
+title: 'Der Prototype Fund sucht eine Person für das Eventmanagement (Laufzeit: 6 Monate)'
+draft: 'true'
+publishedDate: 2024-07-25
 ---
 
 Zur Unterstützung unseres Teams suchen wir eine Person, die die Vorbereitung, Durchführung und Nachbereitung einer unserer Veranstaltungen am 29. März 2025 verantwortet. Dieses Event wird der große Abschluss nach acht Jahren Prototype Fund, 16  Förderrunden und fast 400 Förderprojekten. Geplant sind Panels, Keynotes, Lightning Talks, Demos und es gibt viel Raum zum Austauschen, Kennenlernen und natürlich zum Feiern mit ca. 500 Teilnehmenden. Dafür kümmerst du dich beispielsweise um die Koordination mit der Eventlocation in Berlin, kommunizierst mit Gästen, behältst am Tag des Events selbst den Überblick und kümmerst dich im Nachgang um die Abrechnung und Dokumentation.

--- a/content/jobs/ptf-ez-kommunikation.md
+++ b/content/jobs/ptf-ez-kommunikation.md
@@ -1,15 +1,15 @@
 ---
 authors:
 - Patricia Leu
-date: 2022-07-12
 image:
   src: /files/jobs/ptf-kommunikation.png
-  title: "Elternzeitvertretung: Kommunikations- und Content-Management"
-  license: 
-  license_url:
-tags:
-published: false
-title: "Der Prototype Fund sucht eine Person für Kommunikation und Content als Elternzeitvertretung"
+  title: 'Elternzeitvertretung: Kommunikations- und Content-Management'
+  license: null
+  license_url: null
+tags: null
+title: Der Prototype Fund sucht eine Person für Kommunikation und Content als Elternzeitvertretung
+draft: 'true'
+publishedDate: 2022-07-12
 ---
 
 Im Rahmen einer Elternzeitvertretung suchen wir eine Person, die unsere Arbeit und Ziele über verschiedene Kanäle kommuniziert. Dabei nutzt du proaktiv Möglichkeiten, um unsere Inhalte zu platzieren und unterstützt die geförderten Projekte (und ggf. Alumni) dabei, sich und ihre Ideen vorzustellen und zu vernetzen. Dafür nutzen wir bereits etablierte Formate und freuen uns über neue Ideen und Vorschläge!

--- a/content/jobs/ptf-programmmanagement.md
+++ b/content/jobs/ptf-programmmanagement.md
@@ -1,15 +1,15 @@
 ---
 authors:
 - Patricia Leu
-date: 2023-09-27
 image:
   src: /files/jobs/ptf-kommunikation.png
-  title: "Programmmanagement"
-  license: 
-  license_url:
-tags:
-published: false
-title: "Der Prototype Fund sucht eine Person für das Programmmanagement"
+  title: Programmmanagement
+  license: null
+  license_url: null
+tags: null
+title: Der Prototype Fund sucht eine Person für das Programmmanagement
+draft: 'true'
+publishedDate: 2023-09-27
 ---
 
 Im Prototype Fund suchen wir eine Person, die unsere Förderprojekte betreut. Dabei stehst du den Teams und Einzelentwicker*innen während ihrer Förderzeit zur Seite, übernimmst die Organisation unterschiedlicher Austausch- und Coachingformate und begleitest die Geförderten in der Vorbereitung ihrer Projektvorstellungen am Ende der Förderzeit.
@@ -64,4 +64,3 @@ Weil wir ein kleines Team sind, teilen wir uns zudem administrative Aufgaben wie
 * Die Position ist wie alle Stellen im Team zum 28. Februar 2025 befristet. Vorbehaltlich der Finanzierung ist eine Verlängerung angestrebt.
 
 Sende deine Unterlagen (Anschreiben, Lebenslauf ohne Foto und Geburtsdatum) bitte per E-Mail an bewerbung@prototypefund.de. Fragen zur Stelle und zum Bewerbungsprozess kannst du auch an diese Adresse richten.
-

--- a/content/jobs/ptf-shk.md
+++ b/content/jobs/ptf-shk.md
@@ -1,16 +1,16 @@
 ---
 authors:
 - Marie
-date: 2021-11-18
 image:
-  src: 
-  title:
-  license:
-  license_url:
-published: false
-title: "Studentische Hilfskraft mit Schwerpunkt Tech, ca. 15 Std./Woche &
-Studentische Hilfskraft mit Schwerpunkt Kommunikation, ca. 15 Std./Woche"
+  src: null
+  title: null
+  license: null
+  license_url: null
+title: Studentische Hilfskraft mit Schwerpunkt Tech, ca. 15 Std./Woche & Studentische Hilfskraft mit Schwerpunkt Kommunikation, ca. 15 Std./Woche
+draft: 'true'
+publishedDate: 2021-11-18
 ---
+
 Der Prototype Fund ist ein Förderprogramm des Bundesministeriums für Bildung und Forschung für Public-Interest-Technologien: Als erstes Programm seiner Art in Deutschland unterstützt es selbstständige Softwareentwickler*innen, Hacker*innen und Kreative dabei, ihre Open-Source-Ideen in den Bereichen Civic Tech, Digital Literacy, IT- Sicherheit und Software-Infrastruktur vom Konzept bis zur ersten Demo umzusetzen. Wir (Claudia, Marie und Patricia) begleiten unsere Förderprojekte, die das Potenzial von technischen Innovationen für die Gesellschaft testen.
 
 ## SHK mit Schwerpunkt Tech
@@ -84,4 +84,3 @@ Bei Rückfragen kannst du dich an unser Team wenden: bewerbung@prototypefund.de
 Der Prototype Fund ist ein Programm der Open Knowledge Foundation Deutschland.Der Verein mit Sitz in Berlin-Mitte setzt sich für offenes Wissen, Transparenz und Beteiligung ein. Unsere Arbeit ist unabhängig, überparteilich und interdisziplinär. Mehr erfährst du auf okfn.de.
 
 [Hier gibt es die Ausschreibung auch als PDF.](https://prototypefund.de/wp-content/uploads/2021/11/Stellenausschreibung-SHKs-20211.pdf)
-

--- a/content/jobs/regionale-koordination-jugend-hackt-lab-ulm.md
+++ b/content/jobs/regionale-koordination-jugend-hackt-lab-ulm.md
@@ -1,14 +1,14 @@
 ---
 authors:
 - OKF
-date: 2019-01-23
 image:
   src: /files/blog/2019/01/Stellenausschreibung_ReKoUlm.jpg
   title: Jugend hackt
-  license:
-  license_url:
-published: false
-title: "Stellenausschreibung: Regionale Koordinator*in (w/m/d) für Jugend hackt Labregion in Ulm (20h)"
+  license: null
+  license_url: null
+title: 'Stellenausschreibung: Regionale Koordinator*in (w/m/d) für Jugend hackt Labregion in Ulm (20h)'
+draft: 'true'
+publishedDate: 2019-01-23
 ---
 
 ### Wer wir sind

--- a/content/jobs/software-entwicklerin-fragdenstaat.md
+++ b/content/jobs/software-entwicklerin-fragdenstaat.md
@@ -1,14 +1,14 @@
 ---
 authors:
 - Arne Semsrott
-date: 2021-06-05
 image:
   src: /files/jobs/fds1.png
-  title: "FragDenStaat-Logo"
-  license:
-  license_url:
-published: false
-title: "Wir suchen eine eine*n Software-Entwickler*in für FragDenStaat!"
+  title: FragDenStaat-Logo
+  license: null
+  license_url: null
+title: Wir suchen eine eine*n Software-Entwickler*in für FragDenStaat!
+draft: 'true'
+publishedDate: 2021-06-05
 ---
 
 Der*die Software-Entwickler*in arbeitet als Teil eines kleinen Teams an der Code Base von FragDenStaat, um neue Funktionen zu entwickeln, Bugs zu fixen und Design-Entwürfe umzusetzen.

--- a/content/publikationen/2016_Handbuch Jugend Hackathons.md
+++ b/content/publikationen/2016_Handbuch Jugend Hackathons.md
@@ -1,10 +1,8 @@
 ---
 title: Handbuch Jugend-Hackathons
 subtitle: Ein Leitfaden für die Praxis
-published: true
-date: 2016-03-01
 layout: publikation
-image: 
+image:
   src: /files/images/Handbuch2.jpg
 kategorien: Handbücher
 language: de
@@ -16,8 +14,9 @@ pages: 56
 size: 1.4 MB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://jugendhackt.org/\" target=\"_blank\">Zur Website von Jugend hackt</a>"
+links:
+- url: <a href="https://jugendhackt.org/" target="_blank">Zur Website von Jugend hackt</a>
+publishedDate: 2016-03-01
 ---
 
-Dieses Handbuch richtet sich an Fachkräfte der (politischen) Bildung, der Jugend(verbands)arbeit und an Aktivist:innen aus dem technologischen Bereich, die Jugendliche in der Bildung ihrer technischen Fertigkeiten unterstützen möchten. Es fokussiert sich dabei auf spezifische Fragen zu (Jugend-)Hackathons. 
+Dieses Handbuch richtet sich an Fachkräfte der (politischen) Bildung, der Jugend(verbands)arbeit und an Aktivist:innen aus dem technologischen Bereich, die Jugendliche in der Bildung ihrer technischen Fertigkeiten unterstützen möchten. Es fokussiert sich dabei auf spezifische Fragen zu (Jugend-)Hackathons.

--- a/content/publikationen/2016_Studie_Wert persönlicher Daten.md
+++ b/content/publikationen/2016_Studie_Wert persönlicher Daten.md
@@ -1,14 +1,12 @@
 ---
 title: Der Wert persönlicher Daten
 subtitle: Ist Datenhandel der bessere Datenschutz?
-published: true
-date: 2016-09-01
 layout: publikation
 image:
   src: /files/images/Studie2.jpg
   title: Studie
-  license:
-  license_url:
+  license: null
+  license_url: null
 kategorien: Studien
 categories: Studies
 people:
@@ -19,7 +17,8 @@ pages: 57
 size: 1.03 MB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
+links: null
+publishedDate: 2016-09-01
 ---
 
 Ziel dieser Studie ist, eine allgemein verständliche Übersicht zum Handel mit Daten zu erstellen, die den Wert von Daten strukturiert erfasst.

--- a/content/publikationen/2018_Positionspapier Bündnis Freie Bildung.md
+++ b/content/publikationen/2018_Positionspapier Bündnis Freie Bildung.md
@@ -1,13 +1,11 @@
 ---
 title: Positionspapier Bündnis Freie Bildung
-subtitle:
-published: true
-date: 2018-01-01
+subtitle: null
 layout: publikation
-image: 
+image:
   src: /files/images/sonstiges6.jpg
-  license: 
-  license_url: 
+  license: null
+  license_url: null
 kategorien: Sonstiges
 categories: Other
 people:
@@ -18,8 +16,9 @@ pages: 12
 size: 2.15MB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://buendnis-freie-bildung.de/\" target=\"_blank\">Zur Website des Bündnis Freie Bildung</a>"
+links:
+- url: <a href="https://buendnis-freie-bildung.de/" target="_blank">Zur Website des Bündnis Freie Bildung</a>
+publishedDate: 2018-01-01
 ---
 
 Das Bündnis Freie Bildung vereinigt Organisationen, Institutionen und Einzelpersonen, die sich für freie Bildung, frei zugängliche Bildungsmaterialien, offene Bildungspraktiken und offene Lizenzen in der Bildung einsetzen.

--- a/content/publikationen/2019_Handbuch_ABC der Offenheit.md
+++ b/content/publikationen/2019_Handbuch_ABC der Offenheit.md
@@ -1,8 +1,6 @@
 ---
 title: ABC der Offenheit
-subtitle: 
-published: false
-date: 2019-11-06
+subtitle: null
 layout: publikation
 image:
   src: /files/images/Handbuch2.jpg
@@ -17,8 +15,10 @@ pages: 36
 size: 573 KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: 
+links:
+- url: null
+draft: 'true'
+publishedDate: 2019-11-06
 ---
 
 Open Data, Open Education, Open Government - Es gibt viele Bereiche, in denen Offenheit gefordert wird. Doch was bedeutet das eigentlich jeweils genau?

--- a/content/publikationen/2020_Landesinformationsfreiheitsgesetzes in BW.md
+++ b/content/publikationen/2020_Landesinformationsfreiheitsgesetzes in BW.md
@@ -1,14 +1,12 @@
 ---
 title: Informationsfreiheitsgesetz Baden-Württemberg
-subtitle: 
-published: true
-date: 2020-09-21
+subtitle: null
 layout: publikation
-image: 
+image:
   src: /files/images/Policy5.jpg
-  title:
-  license:
-  license_url:
+  title: null
+  license: null
+  license_url: null
 kategorien: Stellungnahmen
 categories: policy statements
 language: de
@@ -20,8 +18,9 @@ pages: 1
 size: 122 KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://www.landtag-bw.de/files/live/sites/LTBW/files/dokumente/WP16/Drucksachen/8000/16_8535_D.pdf\" target=\"_blank\">Zum Gesetzentwurf</a>"
+links:
+- url: <a href="https://www.landtag-bw.de/files/live/sites/LTBW/files/dokumente/WP16/Drucksachen/8000/16_8535_D.pdf" target="_blank">Zum Gesetzentwurf</a>
+publishedDate: 2020-09-21
 ---
 
 In dieser kurzen Stellungnahme lesen Sie unsere Anmerkungen und Kritikpunkte zum Gesetzentwurf der Fraktion FDP/DVP zur Änderung des Landesinformationsfreiheitsgesetzes in Baden-Württemberg.

--- a/content/publikationen/2020_Open Data in Kommunen.md
+++ b/content/publikationen/2020_Open Data in Kommunen.md
@@ -1,13 +1,11 @@
 ---
 title: Handbuch Open Data in Kommunen
-subtitle: 
-published: true
-date: 2020-03-16
+subtitle: null
 layout: publikation
 image:
   src: /files/images/Handbuch2.jpg
-  license: 
-  license_url:
+  license: null
+  license_url: null
 kategorien: Handbücher
 categories: handbooks
 people:
@@ -18,7 +16,8 @@ pages: 20
 size: 622KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
+links: null
+publishedDate: 2020-03-16
 ---
 
-Dieses Handbuch bietet einen Überblick, was unter Open Data in Kommunen (offenen Verwaltungsdaten) zu verstehen ist, skizziert Argumente für Open Data aus Sicht der Verwaltung, der Bürger:innen und der Wirtschaft und veranschaulicht Anwendungsbeispiele für offene Daten.  
+Dieses Handbuch bietet einen Überblick, was unter Open Data in Kommunen (offenen Verwaltungsdaten) zu verstehen ist, skizziert Argumente für Open Data aus Sicht der Verwaltung, der Bürger:innen und der Wirtschaft und veranschaulicht Anwendungsbeispiele für offene Daten.

--- a/content/publikationen/2020_Stellungnahme_Zweiter Aktionsplan OGP.md
+++ b/content/publikationen/2020_Stellungnahme_Zweiter Aktionsplan OGP.md
@@ -1,8 +1,6 @@
 ---
 title: Zweiter Aktionsplan Open Government Partnership (2019-2021)
 subtitle: Stellungnahme zum Zwischenbericht
-published: true
-date: 2020-08-31
 layout: publikation
 image:
   src: /files/images/Policy5.jpg
@@ -11,17 +9,18 @@ categories: policy statements
 people:
 - name: Henriette Litta
 file: /files/publikationen/2020-08-31_OKF_OGP-NAP_Stellungnahme.pdf?raw=true
-format: pdf 
+format: pdf
 pages: 8
 size: 153KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://www.bundesregierung.de/breg-de/service/publikationen/open-government-deutschland-zweiter-nationaler-aktionsplan-2019-2022-zwischenbericht-1997160\" target=\"_blank\">Zum Zwischenbericht</a>"
+links:
+- url: <a href="https://www.bundesregierung.de/breg-de/service/publikationen/open-government-deutschland-zweiter-nationaler-aktionsplan-2019-2022-zwischenbericht-1997160" target="_blank">Zum Zwischenbericht</a>
+publishedDate: 2020-08-31
 ---
 
 Die Open Knowledge Foundation Deutschland unterstützt Deutschlands Bemühungen, die Ziele der Open Government Partnership umzusetzen und begrüßt die vielen Fortschritte, die im Vergleich zum Ersten Nationalen Aktionsplan zu verzeichnen sind. 
 Insbesondere das ernsthafte Bemühen um einen konstruktiven Austausch mit zivilgesellschaftlichen Akteur*innen und Organisationen ist positiv hervorzuheben.
 Im Jahr vier der Mitgliedschaft Deutschlands in der Open Government Partnership hätten wir uns aber gewünscht, jenseits der bestehenden Meilensteine auch ambitioniertere Ziele mit in den Blick zu nehmen, wie etwa die Transparenzgesetzgebung, die grundlegend für viele Open Government Prozesse wäre.
 
-Unsere Anmerkungen und Kritikpunkte sind detailliert in dieser Stellungnahme zu finden. 
+Unsere Anmerkungen und Kritikpunkte sind detailliert in dieser Stellungnahme zu finden.

--- a/content/publikationen/2021_Datenstrategie_Breg.md
+++ b/content/publikationen/2021_Datenstrategie_Breg.md
@@ -1,8 +1,6 @@
 ---
 title: Datenstrategie der Bundesregierung
-subtitle: 
-published: true
-date: 2021-02-22
+subtitle: null
 layout: publikation
 image:
   src: /files/images/Policy5.jpg
@@ -16,12 +14,12 @@ pages: 7
 size: 79KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://www.bundesregierung.de/breg-de/suche/datenstrategie-der-bundesregierung-1845632\" target=\"_blank\">Zur Datenstrategie der Bundesregierung</a>"
+links:
+- url: <a href="https://www.bundesregierung.de/breg-de/suche/datenstrategie-der-bundesregierung-1845632" target="_blank">Zur Datenstrategie der Bundesregierung</a>
+publishedDate: 2021-02-22
 ---
 
 Die Bundesregierung hat am 27.01.2021 ihre erste Datenstrategie im Kabinett verabschiedet. Die Datenstrategie ist ein Schritt in die richtige Richtung. Die Datenstrategie folgt aus unserer Sicht einer richtigen gesellschaftlichen Zielsetzung: Rahmenbedingungen zu schaffen für eine verantwortungsvolle und innovative Datennutzung, die sich an
 den Werten der informationellen Selbstbestimmung und des Schutzes persönlicher Daten orientiert und dem Gemeinwohl verpflichtet ist. Leider versäumt es die Bundesregierung in der Datenstrategie, diesen Werten das nötige Gewicht zu verleihen. Die Datenstrategie verengt sich zu stark auf wirtschaftliche Aspekte und lässt dabei weitere, ge-
 meinwohlorientierte Aspekte der Datennutzung unter den Tisch fallen. Die Zivilgesellschaft bleibt weiterhin Zaungast in der Diskussion: In der Datenstrategie finden sich die Vorschläge, die aus der Zivilgesellschaft kamen, nur teilweise berücksichtigt. Ungehört bleibt auch der Wunsch nach einem Regulativ: Die Gefahr des Datenmissbrauchs durch
-staatliche Behörden lässt die Datenstrategie gänzlich unbehandelt. 
- 
+staatliche Behörden lässt die Datenstrategie gänzlich unbehandelt.

--- a/content/publikationen/2021_Stellungnahme_E-Gov Gesetz.md
+++ b/content/publikationen/2021_Stellungnahme_E-Gov Gesetz.md
@@ -1,8 +1,6 @@
 ---
 title: Zweites Open-Data-Gesetz des Bundes
-subtitle: 
-published: true
-date: 2021-01-12
+subtitle: null
 layout: publikation
 image:
   src: /files/images/Policy5.jpg
@@ -16,9 +14,10 @@ pages: 5
 size: 60KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://www.bmwk.de/Redaktion/DE/Downloads/G/gesetzentwurf-aenderung-des-e-government-gesetzes-und-%20Gesetz-fuer-die-nutzung-von-daten-des-oeffentlichen-sektors.pdf?__blob=publicationFile&v=8\" target=\"_blank\">Zum Gesetzentwurf</a>"
+links:
+- url: <a href="https://www.bmwk.de/Redaktion/DE/Downloads/G/gesetzentwurf-aenderung-des-e-government-gesetzes-und-%20Gesetz-fuer-die-nutzung-von-daten-des-oeffentlichen-sektors.pdf?__blob=publicationFile&v=8" target="_blank">Zum Gesetzentwurf</a>
+publishedDate: 2021-01-12
 ---
 
 Die OKF DE begrüßt die Änderung des E-Government-Gesetzes und die Einführung des Gesetzes für die Nutzung von Daten des öffentlichen Sektors grundsätzlich. Insbesondere sind die Ausweitung der Datenöffnung auf die gesamte Bundesverwaltung sowie die Einbeziehung von Forschungsdaten sehr zu begrüßen. Trotz Fortschritte ist es nach Auffassung der OKF DE so, dass sich die Bundesregierung mit dem vorliegenden Entwurf auf das absolute Minimum an Reformen beschränkt. Die wiederholten Ankündigungen einer ernsthaften und weitreichenden Datenöffnung bleiben uneingelöst. Weder bekennt sich die Bundesregierung zu einer Weiterentwicklung des Informationsfreiheitsgesetzes zu einem echten Transparenzgesetz, noch wird den Bürgerinnen und Bürgern ein Rechtsanspruch auf offene Verwaltungsdaten eingeräumt.
-In dieser Stellungnahme finden Sie unsere Anmerkungen und Kritikpunkte zur Änderung des E-Government-Gesetzes und zur Einführung des Gesetzes für die Nutzung von Daten des öffentlichen Sektors  im Detail. 
+In dieser Stellungnahme finden Sie unsere Anmerkungen und Kritikpunkte zur Änderung des E-Government-Gesetzes und zur Einführung des Gesetzes für die Nutzung von Daten des öffentlichen Sektors  im Detail.

--- a/content/publikationen/2021_Stellungnahme_Open Data_SH.md
+++ b/content/publikationen/2021_Stellungnahme_Open Data_SH.md
@@ -1,8 +1,6 @@
 ---
-title: Open-Data-Gesetz Schleswig-Holstein 
+title: Open-Data-Gesetz Schleswig-Holstein
 subtitle: Gesetzentwurf zur Förderung der Digitalisierung und Bereitstellung von offenen Daten in der Verwaltung der Landesregierung Schleswig-Holstein
-published: true
-date: 2021-07-19
 layout: publikation
 image:
   src: /files/images/Policy5.jpg
@@ -16,8 +14,9 @@ pages: 6
 size: 146KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://www.landtag.ltsh.de/infothek/wahl19/unterrichtungen/00300/unterrichtung-19-00301.pdf\" target=\"_blank\">Zum Gesetzentwurf</a>"
+links:
+- url: <a href="https://www.landtag.ltsh.de/infothek/wahl19/unterrichtungen/00300/unterrichtung-19-00301.pdf" target="_blank">Zum Gesetzentwurf</a>
+publishedDate: 2021-07-19
 ---
 
 Die Bereitstellung von Open Data ist ein zentrales Element in der Umsetzung des Offenen Regierungshandeln und maßgebliche Voraussetzung für Transparenz, Nachvollziehbarkeit und Überprüfbarkeit politischen Handelns, Akzeptanz politischer Entscheidungen, Meinungsbildung und Partizipation.

--- a/content/publikationen/2021_sovereigntechfeasibility.en.md
+++ b/content/publikationen/2021_sovereigntechfeasibility.en.md
@@ -1,7 +1,5 @@
 ---
 title: Sovereign Tech Fund - Feasibility Study
-published: true
-date: 2021-11-16
 layout: publikation
 image:
   src: /files/images/Studie2.jpg
@@ -15,8 +13,9 @@ pages: 55
 size: 28 MB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "[Website Sovereign Tech Fund](https://sovereigntechfund.de/)"
+links:
+- url: '[Website Sovereign Tech Fund](https://sovereigntechfund.de/)'
+publishedDate: 2021-11-16
 ---
 
 In the study the authors examined the needs and possibilities for a funding program to strengthen open digital infrastructure. The idea for a fund is based, among other things, on Open Technology Funds Core Infrastructure Fund and can learn from this and the experiences from other programs, e.g. the Prototype Fund, and adopt already tested procedures. For the design of the Sovereign Tech Fund, numerous other existing programs were analyzed, interviews were conducted with developers and stakeholders in the open source ecosystem, and expert workshops were held.

--- a/content/publikationen/2021_sovereigntechfeasibility.md
+++ b/content/publikationen/2021_sovereigntechfeasibility.md
@@ -1,7 +1,5 @@
 ---
 title: Sovereign Tech Fund - Machbarkeitsstudie
-published: true
-date: 2021-11-16
 layout: publikation
 image:
   src: /files/images/Studie2.jpg
@@ -14,8 +12,9 @@ pages: 55
 size: 28 MB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "[Zur Website des Sovereign Tech Fund](https://sovereigntechfund.de/)"
+links:
+- url: '[Zur Website des Sovereign Tech Fund](https://sovereigntechfund.de/)'
+publishedDate: 2021-11-16
 ---
 
 Im Rahmen einer Machbarkeitsstudie, die vom Bundesministerium für Wirtschaft und Klimaschutz gefördert wurde, prüfte die OKF die Bedarfe und Möglichkeiten für ein Förderprogramm für Offene Digitale Basistechnologien. Die Idee für einen Fund orientiert sich u. a. an Open Technology Funds Core Infrastructure Fund und kann von dessen und den Erfahrungen aus anderen Programmen, z. B. des Prototype Funds, lernen und bereits getestete Verfahren übernehmen. Für das Design des Sovereign Tech Fund wurden zahlreiche weitere, bereits existierende Programme analysiert, Interviews mit Entwickler:innen und Stakeholdern im Open-Source-Ökosystem geführt sowie Expert:innen-Workshops gehalten.

--- a/content/publikationen/2022-jahresbericht.en.md
+++ b/content/publikationen/2022-jahresbericht.en.md
@@ -1,7 +1,5 @@
 ---
 title: Open Knowledge Foundation Germany e.V. - 2022 Annual report
-published: true
-date: 2023-06-28
 layout: publikation
 image:
   src: /files/images/Jahresbericht1.png
@@ -16,7 +14,9 @@ pages: 71
 size: 2,17MB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "[https://2022.okfn.de](https://2022.okfn.de)"
+links:
+- url: '[https://2022.okfn.de](https://2022.okfn.de)'
+publishedDate: 2023-06-28
 ---
+
 The report looks back at the work of the Open Knowledge Foundation Germany in 2022. The report summarizes the most important activities, describes how the organization works, and presents all projects in brief. The final part of the annual report includes information on the organizational structure and finances.

--- a/content/publikationen/2022-jahresbericht.md
+++ b/content/publikationen/2022-jahresbericht.md
@@ -1,7 +1,5 @@
 ---
 title: Jahresbericht Open Knowledge Foundation Deutschland e.V. 2022
-published: true
-date: 2023-06-28
 layout: publikation
 image:
   src: /files/images/Jahresbericht1.png
@@ -15,7 +13,9 @@ pages: 71
 size: 2,17MB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "[https://2022.okfn.de](https://2022.okfn.de)"
+links:
+- url: '[https://2022.okfn.de](https://2022.okfn.de)'
+publishedDate: 2023-06-28
 ---
+
 Der folgende Bericht blickt zurück auf die Arbeit der Open Knowledge Foundation Deutschland im Jahr 2022. Im Bericht werden die wichtigsten Aktivitäten zusammengefasst, die Arbeitsweise der Organisation beschrieben sowie alle Projekte in Kürze dargestellt. Der abschließende Teil des Berichts umfasst Informationen zur Organisationsstruktur und den Finanzen

--- a/content/publikationen/2022_BitsundBäume_Forderungen.md
+++ b/content/publikationen/2022_BitsundBäume_Forderungen.md
@@ -1,8 +1,6 @@
 ---
-title: "Forderungspapier: Digitalisierung zukunftsfähig und nachhaltig gestalten"
+title: 'Forderungspapier: Digitalisierung zukunftsfähig und nachhaltig gestalten'
 subtitle: Politische Forderungen anlässlich der „Bits & Bäume“-Konferenz 2022
-published: true
-date: 2022-09-05
 layout: publikation
 image:
   src: /files/images/Policy5.jpg
@@ -16,8 +14,9 @@ pages: 14
 size: 1.2MB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://bits-und-baeume.org/konferenz-2022/programm/\" target=\"_blank\">Zum Programm der Bits&Bäume Konferenz 2022</a>"
+links:
+- url: <a href="https://bits-und-baeume.org/konferenz-2022/programm/" target="_blank">Zum Programm der Bits&Bäume Konferenz 2022</a>
+publishedDate: 2022-09-05
 ---
 
 Die Digitalisierung muss stärker in den Dienst der Gesellschaft und des sozial-ökologischen Wandels gestellt werden. Digitale Technologien sollten durch gleichberechtigte gesellschaftliche Teilhabe und innerhalb der planetaren Grenzen zur Verbesserung von Lebensbedingungen und der Umwelt beitragen, anstatt durch explodierenden Energiebedarf, Ressourcenverbrauch und mangelnde Teilhabe vor allem des Globalen Südens existierende Krisen noch weiter zu verschärfen. Mit diesem Appell und insgesamt mehr als 60 thematischen Forderungen wenden sich 13 Organisationen aus Umwelt,- Klima- und Naturschutz, Digitalpolitik, Entwicklungszusammenarbeit und Wissenschaft anlässlich der „Bits & Bäume“-Konferenz an die Bundesregierung, die Europäische Union und politische Akteure weltweit.

--- a/content/publikationen/2022_F5_Demokratiefördergesetz.md
+++ b/content/publikationen/2022_F5_Demokratiefördergesetz.md
@@ -1,8 +1,6 @@
 ---
 title: Bündnis F5 zum Demokratiefördergesetz (DFördG)
-subtitle: 
-published: true
-date: 2022-03-21
+subtitle: null
 layout: publikation
 image:
   src: /files/images/Policy5.jpg
@@ -16,14 +14,14 @@ pages: 4
 size: 292KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://www.bmfsfj.de/bmfsfj/service/gesetze/gesetz-zur-staerkung-von-massnahmen-zur-demokratiefoerderung-vielfaltgestaltung-extremismuspraevention-und-politischen-bildung-demokratiefoerdergesetz--207726/\" target=\"_blank\">Zum Gesetzgebungsverfahren</a>"
-  - url: "<a href=\"https://buendnis-f5.de/\" target=\"_blank\">Zur Website des Bündnis F5</a>"
+links:
+- url: <a href="https://www.bmfsfj.de/bmfsfj/service/gesetze/gesetz-zur-staerkung-von-massnahmen-zur-demokratiefoerderung-vielfaltgestaltung-extremismuspraevention-und-politischen-bildung-demokratiefoerdergesetz--207726/" target="_blank">Zum Gesetzgebungsverfahren</a>
+- url: <a href="https://buendnis-f5.de/" target="_blank">Zur Website des Bündnis F5</a>
+publishedDate: 2022-03-21
 ---
 
 Eine lebendige Demokratie braucht zivilgesellschaftliches Engagement; dieses Engagement wiederum braucht Schutz und Förderung.
 
 Das Bündnis F5 (Algorithmwatch, Gesellschaft für Freiheitsrechte, Open Knowledge Foundation Deutschland, Reporter ohne Grenzen, Wikimedia Deutschland) begrüßt daher den Vorschlag des Bundesministeriums für Familie, Senioren, Frauen und Jugend und des Bundesministeriums des Innern und für Heimat für ein Gesetz zur Stärkung von Maßnahmen zur Demokratieförderung, Vielfaltgestaltung, Extremismusprävention und politischen Bildung (Demokratiefördergesetz – DFördG).
 
-An einigen Stellen bedarf es aus unserer Sicht der Ergänzung. Unsere Anmerkungen und Kritikpunkte lesen Sie in dieser Stellungnahme. 
- 
+An einigen Stellen bedarf es aus unserer Sicht der Ergänzung. Unsere Anmerkungen und Kritikpunkte lesen Sie in dieser Stellungnahme.

--- a/content/publikationen/2022_F5_Demokratiefördergesetz_Referentenentwurf.md
+++ b/content/publikationen/2022_F5_Demokratiefördergesetz_Referentenentwurf.md
@@ -1,8 +1,6 @@
 ---
 title: Bündnis F5 zum Referentenentwurf des Demokratiefördergesetz (DFördG)
-subtitle: 
-published: true
-date: 2022-11-01
+subtitle: null
 layout: publikation
 image:
   src: /files/images/Policy5.jpg
@@ -16,13 +14,13 @@ pages: 4
 size: 282KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://www.bmfsfj.de/bmfsfj/service/gesetze/gesetz-zur-staerkung-von-massnahmen-zur-demokratiefoerderung-vielfaltgestaltung-extremismuspraevention-und-politischen-bildung-demokratiefoerdergesetz--207726\" target=\"_blank\">Zum Gesetzgebungsverfahren</a>"
-  - url: "<a href=\"https://buendnis-f5.de/\" target=\"_blank\">Zur Website des Bündnis F5</a>"
+links:
+- url: <a href="https://www.bmfsfj.de/bmfsfj/service/gesetze/gesetz-zur-staerkung-von-massnahmen-zur-demokratiefoerderung-vielfaltgestaltung-extremismuspraevention-und-politischen-bildung-demokratiefoerdergesetz--207726" target="_blank">Zum Gesetzgebungsverfahren</a>
+- url: <a href="https://buendnis-f5.de/" target="_blank">Zur Website des Bündnis F5</a>
+publishedDate: 2022-11-01
 ---
 
 Das Bündnis F5 (Algorithmwatch, Gesellschaft für Freiheitsrechte, Open Knowledge Foundation Deutschland, Reporter ohne Grenzen, Wikimedia Deutschland) begrüßt den Vorschlag des Bundesministeriums für Familie, Senioren, Frauen und Jugend und des Bundesministeriums des Innern und für Heimat für ein Gesetz zur Stärkung von Maßnahmen zur Demokratieförderung, Vielfaltgestaltung, Extremismusprävention und politischen Bildung (Demokratiefördergesetz – DFördG).
 An einigen Stellen bedarf es aus unserer Sicht der Ergänzung. 
 
-Unsere Anmerkungen und Kritikpunkte lesen Sie in dieser Stellungnahme. 
- 
+Unsere Anmerkungen und Kritikpunkte lesen Sie in dieser Stellungnahme.

--- a/content/publikationen/2022_F5_Zukunftsstrategie.md
+++ b/content/publikationen/2022_F5_Zukunftsstrategie.md
@@ -1,8 +1,6 @@
 ---
 title: Bündnis F5 zur Zukunftsstrategie Forschung und Innovation
-subtitle: 
-published: true
-date: 2022-11-17
+subtitle: null
 layout: publikation
 image:
   src: /files/images/Policy5.jpg
@@ -16,12 +14,12 @@ pages: 9
 size: 265KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://www.bmbf.de/bmbf/de/forschung/zukunftsstrategie/zukunftsstrategie_node.html\" target=\"_blank\">Zur Zukunftsstrategie Forschung und Innovation des BMBF</a>"
-  - url: "<a href=\"https://buendnis-f5.de/\" target=\"_blank\">Zur Website des Bündnis F5</a>"
+links:
+- url: <a href="https://www.bmbf.de/bmbf/de/forschung/zukunftsstrategie/zukunftsstrategie_node.html" target="_blank">Zur Zukunftsstrategie Forschung und Innovation des BMBF</a>
+- url: <a href="https://buendnis-f5.de/" target="_blank">Zur Website des Bündnis F5</a>
+publishedDate: 2022-11-17
 ---
 
 Wir sind davon überzeugt, dass die Bewältigung der gesellschaftlichen und globalen Herausforderungen nur gelingen wird, wenn das Innovationssystem auf den Prinzipien der Offenheit und Partizipation beruht. 
 
-Im Bündnis F5 (Algorithmwatch, Gesellschaft für Freiheitsrechte, Open Knowledge Foundation Deutschland, Reporter ohne Grenzen, Wikimedia Deutschland) haben wir im Rahmen der Online-Konsultation des Bundesministeriums für Bildung und Forschung (BMBF) eine Stellungnahme auf die vorgegebenen Fragen zur „Zukunftsstrategie Forschung und Innovation“ abgegeben, in der wir unsere Anmerkungen und Kritikpunkte detailliert aufführen. 
- 
+Im Bündnis F5 (Algorithmwatch, Gesellschaft für Freiheitsrechte, Open Knowledge Foundation Deutschland, Reporter ohne Grenzen, Wikimedia Deutschland) haben wir im Rahmen der Online-Konsultation des Bundesministeriums für Bildung und Forschung (BMBF) eine Stellungnahme auf die vorgegebenen Fragen zur „Zukunftsstrategie Forschung und Innovation“ abgegeben, in der wir unsere Anmerkungen und Kritikpunkte detailliert aufführen.

--- a/content/publikationen/2022_Offene Hardware in die Wissenschaft.md
+++ b/content/publikationen/2022_Offene Hardware in die Wissenschaft.md
@@ -1,8 +1,6 @@
 ---
-title: Offene Hardware in die Wissenschaft 
-subtitle: "Stellungnahme zur »Zukunftstrategie Forschung und Innovation«"
-published: false
-date: 2022-11-21
+title: Offene Hardware in die Wissenschaft
+subtitle: Stellungnahme zur »Zukunftstrategie Forschung und Innovation«
 layout: publikation
 image:
   src: /files/images/Policy5.jpg
@@ -16,8 +14,10 @@ pages: 3
 size: 89.1KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://open-hardware-allianz.de/\" target=\"_blank\">Zur Website der Open Hardware Allianz</a>"
+links:
+- url: <a href="https://open-hardware-allianz.de/" target="_blank">Zur Website der Open Hardware Allianz</a>
+draft: 'true'
+publishedDate: 2022-11-21
 ---
 
 In dieser Stellungnahme werden Maßnahmen zur Umsetzung von Open Science Hardware erläutert. Diese sind erforderlich, um das Transfersystem zu verbessern und die Potenziale von Open Science Hardware zu fördern.

--- a/content/publikationen/2022_Stellungnahme_Verkündungs- und Bekanntmachungswesens.md
+++ b/content/publikationen/2022_Stellungnahme_Verkündungs- und Bekanntmachungswesens.md
@@ -1,8 +1,6 @@
 ---
 title: Gesetzentwurf E-Verkündung
 subtitle: Referentenentwurf des Bundesministeriums der Justiz für ein Gesetz zur Modernisierung des Verkündungs- und Bekanntmachungswesens
-published: true
-date: 2022-05-03
 layout: publikation
 image:
   src: /files/images/Policy5.jpg
@@ -16,11 +14,12 @@ pages: 3
 size: 207KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://www.bmj.de/SharedDocs/Gesetzgebungsverfahren/DE/2022_Modernisierung_des_Verkuendungs_und_Bekanntmachungswesens.html\" target=\"_blank\">Zum Gesetzgebungsverfahren</a>"
+links:
+- url: <a href="https://www.bmj.de/SharedDocs/Gesetzgebungsverfahren/DE/2022_Modernisierung_des_Verkuendungs_und_Bekanntmachungswesens.html" target="_blank">Zum Gesetzgebungsverfahren</a>
+publishedDate: 2022-05-03
 ---
 
 Organisationen der digitalen Zivilgesellschaft fordern bereits seit vielen Jahren die Bereitstellung von Gesetzestexten als Open Data. Die Open Knowledge Foundation Deutschland begrüßt daher, dass die Bundesregierung das
 Verkündungs- und Bekanntmachungswesen insofern modernisieren möchte, dass Gesetzestexte digital bekannt gemacht werden können. Die geplante Reform ist längst überfällig und unterstützenswert.
 
-Unsere Anmerkungen und Kritikpunkte sind in dieser Stellungnahme nachzulesen. 
+Unsere Anmerkungen und Kritikpunkte sind in dieser Stellungnahme nachzulesen.

--- a/content/publikationen/2022_handbuch-funding-for-future.en.md
+++ b/content/publikationen/2022_handbuch-funding-for-future.en.md
@@ -1,8 +1,6 @@
 ---
 title: Funding for Future
 subtitle: Ein Handbuch des Prototype Fund
-published: true
-date: 2022-04-01
 layout: publikation
 image:
   src: /files/images/Handbuch2.jpg
@@ -16,7 +14,9 @@ pages: 18
 size: 118KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "[PrototypeFund Website](https://www.prototypefund.de)"
+links:
+- url: '[PrototypeFund Website](https://www.prototypefund.de)'
+publishedDate: 2022-04-01
 ---
+
 In this handbook, the Prototype Fund offers a case study of open source software to demonstrate how individuals and small teams can benefit from unbureaucratic funding. The handbook examines the advantages of such funding and provides insights into its workings.

--- a/content/publikationen/2022_handbuch-funding-for-future.md
+++ b/content/publikationen/2022_handbuch-funding-for-future.md
@@ -1,8 +1,6 @@
 ---
 title: Funding for Future
 subtitle: Ein Handbuch des Prototype Fund
-published: true
-date: 2022-04-01
 layout: publikation
 image:
   src: /files/images/Handbuch2.jpg
@@ -15,8 +13,9 @@ pages: 18
 size: 118KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "[PrototypeFund Website](https://www.prototypefund.de)"
+links:
+- url: '[PrototypeFund Website](https://www.prototypefund.de)'
+publishedDate: 2022-04-01
 ---
 
 Mit diesem Handbuch gibt der Prototype Fund am Beispiel von Open-Source-Software einen Einblick darin, wie unbürokratisches Funding für Individuen und kleine Teams funktionieren kann und was die Vorteile davon sind.

--- a/content/publikationen/2023-jahresbericht.en.md
+++ b/content/publikationen/2023-jahresbericht.en.md
@@ -1,7 +1,5 @@
 ---
 title: Open Knowledge Foundation Germany e. V. - 2023 Annual report
-published: true
-date: 2024-06-20
 layout: publikation
 image:
   src: /files/images/Jahresbericht1.png
@@ -16,7 +14,9 @@ pages: 53
 size: 2,90MB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "[https://2023.okfn.de](https://2023.okfn.de)"
+links:
+- url: '[https://2023.okfn.de](https://2023.okfn.de)'
+publishedDate: 2024-06-20
 ---
+
 The report looks back at the work of the Open Knowledge Foundation Germany in 2023. The report summarizes the most important activities, describes how the organization works, and presents all projects in brief. The final part of the annual report includes information on the organizational structure and finances.

--- a/content/publikationen/2023-jahresbericht.md
+++ b/content/publikationen/2023-jahresbericht.md
@@ -1,7 +1,5 @@
 ---
 title: Jahresbericht Open Knowledge Foundation Deutschland e. V. 2023
-published: true
-date: 2024-06-20
 layout: publikation
 image:
   src: /files/images/Jahresbericht1.png
@@ -15,7 +13,9 @@ pages: 53
 size: 2,90MB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "[https://2023.okfn.de](https://2023.okfn.de)"
+links:
+- url: '[https://2023.okfn.de](https://2023.okfn.de)'
+publishedDate: 2024-06-20
 ---
+
 Der folgende Bericht blickt zurück auf die Arbeit der Open Knowledge Foundation Deutschland im Jahr 2023. Im Bericht werden die wichtigsten Aktivitäten zusammengefasst, die Arbeitsweise der Organisation beschrieben sowie alle Projekte in Kürze dargestellt. Der abschließende Teil des Berichts umfasst Informationen zur Organisationsstruktur und den Finanzen.

--- a/content/publikationen/2023_Diskussionspapier_offene_Technologien_für_die_Kreislaufgesellschaft.md
+++ b/content/publikationen/2023_Diskussionspapier_offene_Technologien_für_die_Kreislaufgesellschaft.md
@@ -1,22 +1,20 @@
 ---
 title: Diskussionspapier Open Circularity
-subtitle:
-published: true
-date: 2023-12-06
+subtitle: null
 layout: publikation
-image: 
-  src: "/files/images/sonstiges6.jpg"
+image:
+  src: /files/images/sonstiges6.jpg
 kategorien: Stellungnahmen
 categories: policy statements
 people:
 - name: Maximilian Voigt, Open Hardware Allianz
-file: "https://open-hardware-allianz.de/assets/files/OHA_Open-Hardware_Circularity.pdf"
+file: https://open-hardware-allianz.de/assets/files/OHA_Open-Hardware_Circularity.pdf
 format: pdf
 pages: 6
 size: 133.4KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-
+publishedDate: 2023-12-06
 ---
 
 Mit der Nationalen Kreislaufwirtschaftsstrategie und dem Circular Economy Action Plan arbeiten die Bundesregierung und die EU an Maßnahmen zur Entwicklung zirkulärer Wirtschafts- und Gesellschaftsformen. Dabei dürfen Informationstransparenz und die Bedarfe der Zivilgesellschaft nicht unter den Tisch fallen. Im Diskussionspapier zeigen wir auf, wie offene Technologien bestehende Herausforderungen effektiv lösen und die Zivilgesellschaft stärken.

--- a/content/publikationen/2023_F5_Datenstrategie.md
+++ b/content/publikationen/2023_F5_Datenstrategie.md
@@ -1,8 +1,6 @@
 ---
 title: Bündnis F5 zur Datenstrategie der Bundesregierung
-subtitle: 
-published: true
-date: 2023-09-12
+subtitle: null
 layout: publikation
 image:
   src: /files/images/Policy5.jpg
@@ -11,16 +9,17 @@ categories: policy statements
 people:
 - name: Bündnis F5
 file: /files/publikationen/2023-09-12_F5_Stellungnahme_Datenstrategie%20(1).pdf?raw=true
-format: pdf 
+format: pdf
 pages: 3
 size: 104KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://www.bundesregierung.de/breg-de/themen/digitalisierung/datenstrategie-2023-2216620\" target=\"_blank\">Zur Weiterentwicklung der Datenstrategie</a>"
-  - url: "<a href=\"https://buendnis-f5.de/\" target=\"_blank\">Zur Website des Bündnis F5</a>"
+links:
+- url: <a href="https://www.bundesregierung.de/breg-de/themen/digitalisierung/datenstrategie-2023-2216620" target="_blank">Zur Weiterentwicklung der Datenstrategie</a>
+- url: <a href="https://buendnis-f5.de/" target="_blank">Zur Website des Bündnis F5</a>
+publishedDate: 2023-09-12
 ---
 
 „Fortschritt durch Datennutzung“ – so lautet die Weiterentwicklung der Datenstrategie von 2021, die zur Mitte der Legislatur veröffentlicht wurde. Es ist deutlich erkennbar, dass die Bedeutung der Datenpolitik nun stärker als gesamtgesellschaftliches Thema begriffen wird. Dennoch verharrt das Dokument im üblichen Modus der zusammengeschusterten Strategiepapiere als Sammelsurium verschiedener bekannter Ansätze und Einzelmaßnahmen; ein Gesamtrahmen mit klaren Governance-Strukturen, Rollen und Prozessen sowie einer soliden Dateninfrastruktur für eine planvolle und effektive Umsetzung der bereits beschlossenen Maßnahmen fehlt weiterhin.
 
-Weitere Anmerkungen und Kritikpunkte finden Sie in dieser Stellungnahme des Bündnis F5. 
+Weitere Anmerkungen und Kritikpunkte finden Sie in dieser Stellungnahme des Bündnis F5.

--- a/content/publikationen/2023_F5_Engagementstrategie.en.md
+++ b/content/publikationen/2023_F5_Engagementstrategie.en.md
@@ -1,8 +1,6 @@
 ---
 title: The F5 Alliance on the Civic Engagement Strategy of the Federal Government
-subtitle: 
-published: true
-date: 2023-06-08
+subtitle: null
 layout: publikation
 image:
   src: /files/images/Policy5.jpg
@@ -16,9 +14,10 @@ pages: 4
 size: 40KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://www.bmfsfj.de/bmfsfj/themen/engagement-und-gesellschaft/engagement-staerken/engagementstrategie-des-bundes-222072\" target=\"_blank\"> Civic Engagement Strategy of the Federal Government</a>"
-  - url: "<a href=\"https://buendnis-f5.de/\" target=\"_blank\">F5 Alliance website</a>"
+links:
+- url: <a href="https://www.bmfsfj.de/bmfsfj/themen/engagement-und-gesellschaft/engagement-staerken/engagementstrategie-des-bundes-222072" target="_blank"> Civic Engagement Strategy of the Federal Government</a>
+- url: <a href="https://buendnis-f5.de/" target="_blank">F5 Alliance website</a>
+publishedDate: 2023-06-08
 ---
 
 In this legislative period, a new federal strategy for civic engagement is to be developed with the participation of civil society. The last Civic Engagement Strategy dates back to 2010, so it's about time - because a lot has happened! Digital volunteering has grown significantly and new technologies are increasingly permeating our lives.

--- a/content/publikationen/2023_F5_Engagementstrategie.md
+++ b/content/publikationen/2023_F5_Engagementstrategie.md
@@ -1,8 +1,6 @@
 ---
 title: Bündnis F5 zur Engagementstrategie des Bundes
-subtitle: 
-published: true
-date: 2023-06-08
+subtitle: null
 layout: publikation
 image:
   src: /files/images/Policy5.jpg
@@ -16,9 +14,10 @@ pages: 4
 size: 40KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://www.bmfsfj.de/bmfsfj/themen/engagement-und-gesellschaft/engagement-staerken/engagementstrategie-des-bundes-222072\" target=\"_blank\">Zur Engangementstrategie des Bundes</a>"
-  - url: "<a href=\"https://buendnis-f5.de/\" target=\"_blank\">Zur Website des Bündnis F5</a>"
+links:
+- url: <a href="https://www.bmfsfj.de/bmfsfj/themen/engagement-und-gesellschaft/engagement-staerken/engagementstrategie-des-bundes-222072" target="_blank">Zur Engangementstrategie des Bundes</a>
+- url: <a href="https://buendnis-f5.de/" target="_blank">Zur Website des Bündnis F5</a>
+publishedDate: 2023-06-08
 ---
 
 Noch in dieser Legislaturperiode soll unter Beteiligung der Zivilgesellschaft eine neue Engagementstrategie des Bundes erarbeitet werden. Die letzte Engagementstrategie stammt noch aus dem Jahr 2010. Es wird also Zeit – denn es hat sich viel getan! Das digitale Ehrenamt ist stark gewachsen und neue Technologien durchdringen mehr und mehr unser Leben.

--- a/content/publikationen/2023_F5_PM_DDG.en.md
+++ b/content/publikationen/2023_F5_PM_DDG.en.md
@@ -1,8 +1,6 @@
 ---
 title: F5 Alliance Press Release on the Digital Services Act (DSA)
-subtitle: 
-published: true
-date: 2023-07-06
+subtitle: null
 layout: publikation
 image:
   src: /files/images/Policy5.jpg
@@ -16,10 +14,10 @@ pages: 3
 size: 65.7KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://okfn.de/blog/2023/07/pm-dsc\" target=\"_blank\">Open blogpost</a>"
-  - url: "<a href=\"https://buendnis-f5.de\" target=\"_blank\">F5 Alliance website</a>"
-  
+links:
+- url: <a href="https://okfn.de/blog/2023/07/pm-dsc" target="_blank">Open blogpost</a>
+- url: <a href="https://buendnis-f5.de" target="_blank">F5 Alliance website</a>
+publishedDate: 2023-07-06
 ---
 
-Germany is at risk of losing the opportunity to bring internet platforms - such as social networks or online marketplaces - under effective, independent supervision. The Digital Services Act (DSA) aims to protect users' rights online and sets out due diligence obligations for platforms such as TikTok, Facebook and Twitter. In order to effectively achieve these goals, a centralized and well-organized platform supervisory authority in EU member states is needed to quickly and competently handle complaints from affected parties and enforce their rights. The Digital Services Coordinators (DSCs), in cooperation with the EU Commission, are entrusted with this task. However, the German authorities have been arguing about responsibilities for months, delaying the urgently needed preparations for effective platform supervision. 
+Germany is at risk of losing the opportunity to bring internet platforms - such as social networks or online marketplaces - under effective, independent supervision. The Digital Services Act (DSA) aims to protect users' rights online and sets out due diligence obligations for platforms such as TikTok, Facebook and Twitter. In order to effectively achieve these goals, a centralized and well-organized platform supervisory authority in EU member states is needed to quickly and competently handle complaints from affected parties and enforce their rights. The Digital Services Coordinators (DSCs), in cooperation with the EU Commission, are entrusted with this task. However, the German authorities have been arguing about responsibilities for months, delaying the urgently needed preparations for effective platform supervision.

--- a/content/publikationen/2023_F5_PM_DDG.md
+++ b/content/publikationen/2023_F5_PM_DDG.md
@@ -1,8 +1,6 @@
 ---
 title: Pressemitteilung des Bündnis F5 zum Digitale-Dienste-Gesetz (DDG)
-subtitle: 
-published: true
-date: 2023-07-06
+subtitle: null
 layout: publikation
 image:
   src: /files/images/Policy5.jpg
@@ -16,11 +14,10 @@ pages: 3
 size: 65.7KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://okfn.de/blog/2023/07/pm-dsc\" target=\"_blank\">Zum Blogartikel</a>"
-  - url: "<a href=\"https://buendnis-f5.de\" target=\"_blank\">Zur Website des Bündnis F5</a>"
-  
+links:
+- url: <a href="https://okfn.de/blog/2023/07/pm-dsc" target="_blank">Zum Blogartikel</a>
+- url: <a href="https://buendnis-f5.de" target="_blank">Zur Website des Bündnis F5</a>
+publishedDate: 2023-07-06
 ---
 
 Deutschland droht die Chance zu verspielen, Internetplattformen – wie soziale Netzwerke oder Online-Marktplätze – unter eine effektive, unabhängige Aufsicht zu stellen. Der Digital Services Act (DSA) soll Nutzer*innenrechte online schützen und legt Sorgfaltspflichten für Plattformen wie TikTok, Facebook und Twitter fest. Um diese Ziele wirkungsvoll zu erreichen, bedarf es einer zentralen und gut organisierten Plattformaufsicht in den EU-Mitgliedstaaten, die Beschwerden von Betroffenen zügig und kompetent bearbeitet und ihre Rechte durchsetzt. Mit dieser Aufgabe sind die sogenannten Koordinatoren für Digitale Dienste (Digital Services Coordinators, DSCs) in Zusammenarbeit mit der EU-Kommission betraut. Jedoch streiten sich die deutschen Behörden seit Monaten um Zuständigkeiten und verzögern damit die dringend notwendigen Vorbereitungen für eine effektive Plattformaufsicht.
- 

--- a/content/publikationen/2023_Handbuch_Informationsfreiheit.md
+++ b/content/publikationen/2023_Handbuch_Informationsfreiheit.md
@@ -1,8 +1,6 @@
 ---
-title: Handbuch Informationsfreiheitsrecht 
-subtitle: 
-published: true
-date: 2023-10-23
+title: Handbuch Informationsfreiheitsrecht
+subtitle: null
 layout: publikation
 image:
   src: /files/images/Handbuch2.jpg
@@ -16,11 +14,11 @@ pages: 448
 size: 9.27MB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://fragdenstaat.de/recht/handbuch-informationsfreiheit/\" target=\"_blank\">Zur Online-Version des Handbuchs</a>"
-  - url: "<a href=\"https://www.universitaetsverlag.uni-kiel.de/de/programm/einzelschriften/Informationsfreiheitsrecht\" target=\"_blank\">Zur Print-Version beim Universitätsverlag Kiel</a>"
-  - url: "<a href=\"https://fragdenstaat.de/blog/2023/10/23/handbuch-informationsfreiheit/\" target=\"_blank\">Zum Blogbeitrag von FragDenStaat</a>"
-  
+links:
+- url: <a href="https://fragdenstaat.de/recht/handbuch-informationsfreiheit/" target="_blank">Zur Online-Version des Handbuchs</a>
+- url: <a href="https://www.universitaetsverlag.uni-kiel.de/de/programm/einzelschriften/Informationsfreiheitsrecht" target="_blank">Zur Print-Version beim Universitätsverlag Kiel</a>
+- url: <a href="https://fragdenstaat.de/blog/2023/10/23/handbuch-informationsfreiheit/" target="_blank">Zum Blogbeitrag von FragDenStaat</a>
+publishedDate: 2023-10-23
 ---
 
 Das Ziel dieses Handbuch ist es, einen gut verständlichen und praxistauglichen Überblick des Informationsfreiheitsrechts in Deutschland zu schaffen. Und zwar nicht nur für die, die es sich leisten können, sondern für alle. 
@@ -29,6 +27,4 @@ Das Handbuch orientiert sich nicht an einzelnen Paragraphen, sondern an Themenge
 
 Die Entstehungsgeschichte dieses Gemeinschaftswerks wird im unten verlinkten Blogbeitrag erläutert. 
 
-In der Online-Version wird das Handbuch aktualisiert und fortentwickelt.  
-
-
+In der Online-Version wird das Handbuch aktualisiert und fortentwickelt.

--- a/content/publikationen/2023_Handbuch_Open_Hardware_Nachhaltigkeit_FOH.md
+++ b/content/publikationen/2023_Handbuch_Open_Hardware_Nachhaltigkeit_FOH.md
@@ -1,20 +1,19 @@
 ---
 title: Unboxing Blackboxes
 subtitle: Mit Open Hardware & Zivilgesellschaft in eine nachhaltige Zukunft
-published: true
-date: 2023-03-13
 layout: publikation
 image:
-  src: "/files/images/sonstiges6.jpg"
+  src: /files/images/sonstiges6.jpg
 kategorien: Handbücher
 people:
-  - name: Maximilian Voigt, Daniel Wessolek, Open Hardware Allianz
-file: "https://open-hardware-allianz.de/assets/files/FOH23_Publikation_2023_WEB.pdf"
+- name: Maximilian Voigt, Daniel Wessolek, Open Hardware Allianz
+file: https://open-hardware-allianz.de/assets/files/FOH23_Publikation_2023_WEB.pdf
 format: pdf
 pages: 56
 size: 4.5MB
 license_type: CC-BY 4.0
 license_link: https://creativecommons.org/licenses/by/4.0/
+publishedDate: 2023-03-13
 ---
 
-Die Herausforderungen unser Zeit sind bekannt, die auf sozialer, ökologischer und wirtschaftlicher Ebene vor uns liegen. Offene Hardware kann ein Teil der Lösung werden. In der Publikation "Unboxing Blackboxes" zeigen wir, wie. Außerdem stellen wir die sechs Projekte vor, die Teil der ersten Runde des Prototype Fund Hardware waren. 
+Die Herausforderungen unser Zeit sind bekannt, die auf sozialer, ökologischer und wirtschaftlicher Ebene vor uns liegen. Offene Hardware kann ein Teil der Lösung werden. In der Publikation "Unboxing Blackboxes" zeigen wir, wie. Außerdem stellen wir die sechs Projekte vor, die Teil der ersten Runde des Prototype Fund Hardware waren.

--- a/content/publikationen/2023_Stellungnahme Hessischen E-Government-Gesetzes.en.md
+++ b/content/publikationen/2023_Stellungnahme Hessischen E-Government-Gesetzes.en.md
@@ -1,8 +1,6 @@
 ---
 title: E-Government Act of Hesse
-subtitle: 
-published: true
-date: 2023-01-31
+subtitle: null
 layout: publikation
 image:
   src: /files/images/Policy5.jpg
@@ -16,12 +14,13 @@ pages: 6
 size: 1.16MB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "[All policy statements for the draft law - Part 1](https://starweb.hessen.de/cache/AV/20/DDA/DDA-AV-031-T1.pdf)"
-  - url: "[All policy statements for the draft law - Part 2](https://starweb.hessen.de/cache/AV/20/DDA/DDA-AV-031-T2.pdf)"
+links:
+- url: '[All policy statements for the draft law - Part 1](https://starweb.hessen.de/cache/AV/20/DDA/DDA-AV-031-T1.pdf)'
+- url: '[All policy statements for the draft law - Part 2](https://starweb.hessen.de/cache/AV/20/DDA/DDA-AV-031-T2.pdf)'
+publishedDate: 2023-01-31
 ---
 
 The draft law essentially deals with the implementation of the digital provision of administrative services in state law, which has become mandatory as a result of the Federal Law on Online Access (OZG).
 
 In the view of the Open Knowledge Foundation Germany, the Hessian state government is implementing necessary changes in the area of user accounts and official mailboxes with the draft law, but is missing the opportunity, after more than four years, to formulate further-reaching regulations and objectives with a genuine amendment to the HEGovG as to how the digital transformation could contribute to an efficient and transparent administration.
-Further comments and criticisms can be found in this statement. 
+Further comments and criticisms can be found in this statement.

--- a/content/publikationen/2023_Stellungnahme Hessischen E-Government-Gesetzes.md
+++ b/content/publikationen/2023_Stellungnahme Hessischen E-Government-Gesetzes.md
@@ -1,8 +1,6 @@
 ---
 title: E-Government-Gesetz Hessen
-subtitle: 
-published: true
-date: 2023-01-31
+subtitle: null
 layout: publikation
 image:
   src: /files/images/Policy5.jpg
@@ -17,12 +15,13 @@ pages: 6
 size: 1.16MB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "[Alle Stellungnahmen zum Gesetzentwurf - Teil 1](https://starweb.hessen.de/cache/AV/20/DDA/DDA-AV-031-T1.pdf)"
-  - url: "[Alle Stellungnahmen zum Gesetzentwurf - Teil 2](https://starweb.hessen.de/cache/AV/20/DDA/DDA-AV-031-T2.pdf)"
+links:
+- url: '[Alle Stellungnahmen zum Gesetzentwurf - Teil 1](https://starweb.hessen.de/cache/AV/20/DDA/DDA-AV-031-T1.pdf)'
+- url: '[Alle Stellungnahmen zum Gesetzentwurf - Teil 2](https://starweb.hessen.de/cache/AV/20/DDA/DDA-AV-031-T2.pdf)'
+publishedDate: 2023-01-31
 ---
 
 Der vorliegende Entwurf behandelt im Wesentlichen die landesrechtliche Umsetzung der durch das Onlinezugangsgesetz (OZG) des Bundes verpflichtend gewordenen digitalen Bereitstellung von Verwaltungsleistungen.
 
 Aus Sicht der Open Knowledge Foundation Deutschland setzt die Landesregierung Hessen mit dem Gesetzentwurf zwar notwendige Änderungen im Bereich der Nutzer:innenkonten und Behördenpostfächer um, verpasst aber die Chance, nach über vier Jahren mit einer echten Novelle des HEGovG weiterreichende Regelungen und Ziele zu formulieren, wie die digitale Transformation zu einer effizienten und transparenten Verwaltung beitragen könnte.
-Weitere Anmerkungen und Kritikpunkte finden Sie in dieser Stellungnahme. 
+Weitere Anmerkungen und Kritikpunkte finden Sie in dieser Stellungnahme.

--- a/content/publikationen/2023_Stellungnahme Hessisches OpenDataGesetz.en.md
+++ b/content/publikationen/2023_Stellungnahme Hessisches OpenDataGesetz.en.md
@@ -1,10 +1,8 @@
 ---
 title: Hesse Open Data Act (HODaG)
-subtitle:
-published: true
-date: 2023-03-23
+subtitle: null
 layout: publikation
-image: 
+image:
   src: /files/images/Policy5.jpg
 kategorien: policy statements
 language: de
@@ -16,10 +14,11 @@ pages: 8
 size: 2.2MB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://www.parlamentsdokumentation.brandenburg.de/starweb/LBB/ELVIS/parladoku/w7/drs/ab_8000/8080.pdf\" target=\"_blank\">Draft law</a>"
+links:
+- url: <a href="https://www.parlamentsdokumentation.brandenburg.de/starweb/LBB/ELVIS/parladoku/w7/drs/ab_8000/8080.pdf" target="_blank">Draft law</a>
+publishedDate: 2023-03-23
 ---
 
 The provision of open data is a central element in the implementation of open government and a key prerequisite for transparency, accountability and verifiability of political actions, acceptance of political decisions, opinion formation and participation.
 
-Although the Hessian government has taken the overdue first step with the Open Data Act, it is failing to draw the right conclusions from the numerous examples of other already existing open data laws. We have outlined our comments and criticisms in this statement. 
+Although the Hessian government has taken the overdue first step with the Open Data Act, it is failing to draw the right conclusions from the numerous examples of other already existing open data laws. We have outlined our comments and criticisms in this statement.

--- a/content/publikationen/2023_Stellungnahme Hessisches OpenDataGesetz.md
+++ b/content/publikationen/2023_Stellungnahme Hessisches OpenDataGesetz.md
@@ -1,10 +1,8 @@
 ---
 title: Open-Data-Gesetz Hessen (HODaG)
-subtitle:
-published: true
-date: 2023-03-23
+subtitle: null
 layout: publikation
-image: 
+image:
   src: /files/images/Policy5.jpg
 kategorien: Stellungnahmen
 categories: policy statements
@@ -16,10 +14,11 @@ pages: 8
 size: 2.2MB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://www.parlamentsdokumentation.brandenburg.de/starweb/LBB/ELVIS/parladoku/w7/drs/ab_8000/8080.pdf\" target=\"_blank\">Zum Gesetzentwurf</a>"
+links:
+- url: <a href="https://www.parlamentsdokumentation.brandenburg.de/starweb/LBB/ELVIS/parladoku/w7/drs/ab_8000/8080.pdf" target="_blank">Zum Gesetzentwurf</a>
+publishedDate: 2023-03-23
 ---
 
 Die Bereitstellung von Open Data ist ein zentrales Element in der Umsetzung des Offenen Regierungshandeln und maßgebliche Voraussetzung für Transparenz, Nachvollziehbarkeit und Überprüfbarkeit politischen Handelns, Akzeptanz politischer Entscheidungen, Meinungsbildung und Partizipation.
  
-Die Hessische Regierung macht mit dem Open-Data-Gesetz zwar den überfälligen ersten Schritt, verpasst es aber, aus den zahlreichen Beispielen anderer Open-Data-Gesetze die richtigen Schlüsse zu ziehen. Unsere Anmerkungen und Kritkpunkte haben wir in dieser Stellungnahme ausgeführt. 
+Die Hessische Regierung macht mit dem Open-Data-Gesetz zwar den überfälligen ersten Schritt, verpasst es aber, aus den zahlreichen Beispielen anderer Open-Data-Gesetze die richtigen Schlüsse zu ziehen. Unsere Anmerkungen und Kritkpunkte haben wir in dieser Stellungnahme ausgeführt.

--- a/content/publikationen/2023_egovernment-brandenburg.en.md
+++ b/content/publikationen/2023_egovernment-brandenburg.en.md
@@ -1,8 +1,6 @@
 ---
 title: E-Government Act Brandenburg
 subtitle: Second Amendment Act (Drs.7/8080)
-published: true
-date: 2023-09-28
 layout: publikation
 image:
   src: /files/images/Policy5.jpg
@@ -16,8 +14,9 @@ pages: 3
 size: 912KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://www.parlamentsdokumentation.brandenburg.de/starweb/LBB/ELVIS/parladoku/w7/drs/ab_8000/8080.pdf\" target=\"_blank\">Open draft law</a>"
+links:
+- url: <a href="https://www.parlamentsdokumentation.brandenburg.de/starweb/LBB/ELVIS/parladoku/w7/drs/ab_8000/8080.pdf" target="_blank">Open draft law</a>
+publishedDate: 2023-09-28
 ---
 
 The state government of Brandenburg wants to incorporate open data into the legal framework by amending the existing law. However, the OKF considers the proposed changes to be insufficient. In a short statement we outline several points of criticism.

--- a/content/publikationen/2023_egovernment-brandenburg.md
+++ b/content/publikationen/2023_egovernment-brandenburg.md
@@ -1,8 +1,6 @@
 ---
 title: E-Government-Gesetz Brandenburg
 subtitle: Zweites Gesetz zur Änderung (Drs.7/8080)
-published: true
-date: 2023-09-28
 layout: publikation
 image:
   src: /files/images/Policy5.jpg
@@ -16,8 +14,9 @@ pages: 3
 size: 912KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://www.parlamentsdokumentation.brandenburg.de/starweb/LBB/ELVIS/parladoku/w7/drs/ab_8000/8080.pdf\" target=\"_blank\">Zum Gesetzentwurf</a>"
+links:
+- url: <a href="https://www.parlamentsdokumentation.brandenburg.de/starweb/LBB/ELVIS/parladoku/w7/drs/ab_8000/8080.pdf" target="_blank">Zum Gesetzentwurf</a>
+publishedDate: 2023-09-28
 ---
 
 Mit einer Gesetzesänderung möchte die Brandenburger Landesregierung das Thema Open Data endlich auch in den Rechtsrahmen aufnehmen. Doch die geplanten Änderungen gehen aus Sicht der OKF nicht weit genug. In einer kurzen Initiativstellungnahme haben wir einige Kritikpunkte zusammengefasst.

--- a/content/publikationen/2023_globaldigitalcompact.en.md
+++ b/content/publikationen/2023_globaldigitalcompact.en.md
@@ -1,8 +1,6 @@
 ---
 title: Position on the Global Digital Compact of German Digital Civil Society Organizations
-subtitle: 
-published: true
-date: 2023-09-13
+subtitle: null
 layout: publikation
 image:
   src: /files/images/Policy5.jpg
@@ -16,9 +14,10 @@ pages: 7
 size: 184KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://www.un.org/techenvoy/global-digital-compact\" target=\"_blank\">Global Digital Compact</a>"
-  - url: "<a href=\"https://indonesia.un.org/sites/default/files/2023-07/our-common-agenda-policy-brief-gobal-digi-compact-en.pdf\" target=\"_blank\">United Nations, Common Agenda Policy Brief 5: A Global Digital Compact — an Open, Free and Secure Digital Future for All</a>"
+links:
+- url: <a href="https://www.un.org/techenvoy/global-digital-compact" target="_blank">Global Digital Compact</a>
+- url: '<a href="https://indonesia.un.org/sites/default/files/2023-07/our-common-agenda-policy-brief-gobal-digi-compact-en.pdf" target="_blank">United Nations, Common Agenda Policy Brief 5: A Global Digital Compact — an Open, Free and Secure Digital Future for All</a>'
+publishedDate: 2023-09-13
 ---
 
 As part of the Global Digital Compact (GDC), the United Nations is working to shape the digital future on a global scale. In May 2023, the UN Secretary-General presented a policy brief on this issue. Governments are now positioning themselves and should listen to the voices of civil society. Over the past few weeks, the Open Knowledge Foundation, as part of an alliance of civil society organizations (on the initiative of Wikimedia Germany), has taken a closer look at the policy brief and made suggestions for desirable adjustments.

--- a/content/publikationen/2023_globaldigitalcompact.md
+++ b/content/publikationen/2023_globaldigitalcompact.md
@@ -1,8 +1,6 @@
 ---
 title: Position deutscher digitaler zivilgesellschaftlicher Organisationen zum Global Digital Compact
-subtitle: 
-published: true
-date: 2023-09-13
+subtitle: null
 layout: publikation
 image:
   src: /files/images/Policy5.jpg
@@ -16,9 +14,10 @@ pages: 7
 size: 184KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://www.un.org/techenvoy/global-digital-compact\" target=\"_blank\">Global Digital Compact</a>"
-  - url: "<a href=\"https://indonesia.un.org/sites/default/files/2023-07/our-common-agenda-policy-brief-gobal-digi-compact-en.pdf\" target=\"_blank\">United Nations, Common Agenda Policy Brief 5: A Global Digital Compact — an Open, Free and Secure Digital Future for All</a>"
+links:
+- url: <a href="https://www.un.org/techenvoy/global-digital-compact" target="_blank">Global Digital Compact</a>
+- url: '<a href="https://indonesia.un.org/sites/default/files/2023-07/our-common-agenda-policy-brief-gobal-digi-compact-en.pdf" target="_blank">United Nations, Common Agenda Policy Brief 5: A Global Digital Compact — an Open, Free and Secure Digital Future for All</a>'
+publishedDate: 2023-09-13
 ---
 
 Die Vereinten Nationen befassen sich im Rahmen des Global Digital Compact (GDC) mit der Gestaltung der digitalen Zukunft im globalen Rahmen. Hierzu hatte der UN-Generalsekretär im Mai 2023 einen Policy Brief vorgelegt. Die Regierungen verorten derzeit ihre Positionen dazu und sollten dabei insbesondere auch die Stimmen aus der Zivilgesellschaft hören. Über die letzten Wochen hatte sich die Open Knowledge Foundation im Rahmen eines Bündnisses aus zivilgesellschaftlichen Organisationen (auf Initiative von Wikimedia Deutschland) den Policy Brief genauer angeschaut und Vorschläge für wünschenswerte Anpassungen gemacht. Beim Internet Governance Forum Deutschland in der letzten Woche bot sich nun die Gelegenheit für einen neuen Austausch.

--- a/content/publikationen/2024-04-18-F5-Forderungen-DMK.md
+++ b/content/publikationen/2024-04-18-F5-Forderungen-DMK.md
@@ -1,8 +1,6 @@
 ---
 title: Forderungen des Bündnis F5 zur ersten Digitalministerkonferenz
-subtitle: 
-published: true
-date: 2024-04-18
+subtitle: null
 layout: publikation
 image:
   src: /files/images/Policy5.jpg
@@ -16,9 +14,10 @@ pages: 12
 size: 290KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://okfn.de/blog/2024/04/f5-forderungen-dmk/\" target=\"_blank\">Zur Pressemitteilung des Bündnis F5</a>"
-  - url: "<a href=\"https://buendnis-f5.de/\" target=\"_blank\">Zur Website des Bündnis F5</a>"
+links:
+- url: <a href="https://okfn.de/blog/2024/04/f5-forderungen-dmk/" target="_blank">Zur Pressemitteilung des Bündnis F5</a>
+- url: <a href="https://buendnis-f5.de/" target="_blank">Zur Website des Bündnis F5</a>
+publishedDate: 2024-04-18
 ---
 
 Mit der Gründung der ersten Digitalministerkonferenz (DMK) am 19. April 2024 in Potsdam setzen sich die 16 Bundesländer das gemeinsame Ziel, die digitale Transformation zum Wohle der Bürger*innen zu gestalten. Die Vision eines offenen, freien, verlässlichen und sicheren Internets kann nur durch eine gemeinwohlorientierte Digitalpolitik unter Einbeziehung der Zivilgesellschaft Wirklichkeit werden. F5 appelliert an die Verantwortlichen der DMK, die in unserem Forderungspapier ausgeführten Anliegen politisch umzusetzen.

--- a/content/publikationen/2024-05-22-F5ForderungenzurEUWahl.en.md
+++ b/content/publikationen/2024-05-22-F5ForderungenzurEUWahl.en.md
@@ -1,8 +1,6 @@
 ---
 title: Positions of the F5-Alliance on the 2024 European Elections
-subtitle: 
-published: true
-date: 2024-05-22
+subtitle: null
 layout: publikation
 image:
   src: /files/images/Policy5.jpg
@@ -16,8 +14,9 @@ pages: 15
 size: 2,3 MB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://buendnis-f5.de/\" target=\"_blank\">F5 Alliance Webpage</a>"
+links:
+- url: <a href="https://buendnis-f5.de/" target="_blank">F5 Alliance Webpage</a>
+publishedDate: 2024-05-22
 ---
 
 The European Union has established itself as a pioneer in digital policy. Over the past five years, important laws have been introduced to curb the power of big tech companies and to strengthen human rights in the digital world. At the same time, European digital policy is still too often driven by technical trends and profit-oriented interests. The focus on the common good is lost.

--- a/content/publikationen/2024-05-22-F5ForderungenzurEUWahl.md
+++ b/content/publikationen/2024-05-22-F5ForderungenzurEUWahl.md
@@ -1,8 +1,6 @@
 ---
 title: Positionen des Bündnis F5 zur Europawahl 2024
-subtitle: 
-published: true
-date: 2024-05-22
+subtitle: null
 layout: publikation
 image:
   src: /files/images/Policy5.jpg
@@ -16,9 +14,10 @@ pages: 15
 size: 380KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://buendnis-f5.de/publikationen/2024-05-21-positionsonthe2024europeanelections/\" target=\"_blank\">Positions of the F5-Alliance on the 2024 EU-elections in english</a>"
-  - url: "<a href=\"https://buendnis-f5.de/\" target=\"_blank\">Zur Website des Bündnis F5</a>"
+links:
+- url: <a href="https://buendnis-f5.de/publikationen/2024-05-21-positionsonthe2024europeanelections/" target="_blank">Positions of the F5-Alliance on the 2024 EU-elections in english</a>
+- url: <a href="https://buendnis-f5.de/" target="_blank">Zur Website des Bündnis F5</a>
+publishedDate: 2024-05-22
 ---
 
 Die Europäische Union hat sich als wegweisende Akteurin in der Digitalpolitik etabliert. In den letzten fünf Jahren wurden bedeutende Gesetze auf den Weg gebracht, um die Macht von Big-Tech Unternehmen einzudämmen und die Einhaltung von Grund- und Menschenrechten im Digitalen zu stärken. Gleichzeitig ist die europäische Digitalpolitik zu oft von technischen Trends und gewinnorientierten Interessen getrieben. Der Fokus auf das Gemeinwohl geht dabei verloren.

--- a/content/publikationen/2024-Kommentierung-Entwurf-NKWS-OKFDE_OHA.md
+++ b/content/publikationen/2024-Kommentierung-Entwurf-NKWS-OKFDE_OHA.md
@@ -1,8 +1,6 @@
 ---
 title: Stellungnahme zum Entwurf einer Nationalen Kreislaufwirtschaftsstrategie
-subtitle: 
-published: true
-date: 2024-07-09
+subtitle: null
 layout: publikation
 image:
   src: /files/images/Policy5.jpg
@@ -16,10 +14,10 @@ pages: 3
 size: 238KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://okfn.de/blog/2024/06/zum-entwurf-der-nkws-ambitioniert-bleiben/\" target=\"_blank\">Zum Blogartikel</a>"
-  - url: "<a href=\"https://open-hardware-allianz.de/\" target=\"_blank\">Zur Website der Open Hardware Allianz</a>"
+links:
+- url: <a href="https://okfn.de/blog/2024/06/zum-entwurf-der-nkws-ambitioniert-bleiben/" target="_blank">Zum Blogartikel</a>
+- url: <a href="https://open-hardware-allianz.de/" target="_blank">Zur Website der Open Hardware Allianz</a>
+publishedDate: 2024-07-09
 ---
 
 Wir begrüßen den Entwurf einer Nationalen Kreislaufwirtschaftsstrategie (NKWS) des Bundesministeriums für Umwelt, Naturschutz, nukleare Sicherheit und Verbraucherschutz (BMUV) und sehen ihn als ersten wichtigen Schritt hin zu einer ressourcenschonenden und transparenten Kreislaufwirtschaft in Deutschland. Mit dem Netzwerk Ressourcenwende haben wir bereits die wichtigen Kernziele und Maßnahmen kommentiert. Wir unterstützen die dort bereits genannten Forderungen. Mit der vorliegenden Kommentierung fokussieren wir insbesondere die Rolle und Potenziale von Open Source, die stellenweise im aktuellen Entwurf enthalten sind. Neben Rohstoffkreisläufen sollten auch damit zusammenhängende Informationen im Zentrum stehen. Eine Kreislaufwirtschaft ist in erster Linie ein Kooperationsprojekt, das viele Akteure braucht. Informationen sind die wesentliche Triebkraft dabei. Dafür braucht es die allgemeine Ausrichtung auf das Zirkulieren von produkt- und rohstoffspezifischen Informationen und Anreize, offene Ansätze zu etablieren, die Produkttransparenz von Beginn an mitdenken (Open Source Hardware, Open Data, Open Source Software).
-

--- a/content/publikationen/2024-OKF_Stellungnahme_Rundfunk.md
+++ b/content/publikationen/2024-OKF_Stellungnahme_Rundfunk.md
@@ -1,8 +1,6 @@
 ---
-title: "Stellungnahme zur Reform des Öffentlich-Rechtlichen Rundfunks"
-subtitle: 
-published: true
-date: 2024-10-11
+title: Stellungnahme zur Reform des Öffentlich-Rechtlichen Rundfunks
+subtitle: null
 layout: publikation
 image:
   src: /files/images/Policy5.jpg
@@ -16,8 +14,9 @@ pages: 3
 size: 314KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-links: 
-  - url: "<a href=\"https://rundfunkkommission.rlp.de/rundfunkkommission-der-laender/reformstaatsvertrag/\" target=\"_blank\">Zum Reformstaatsvertrag</a>"
+links:
+- url: <a href="https://rundfunkkommission.rlp.de/rundfunkkommission-der-laender/reformstaatsvertrag/" target="_blank">Zum Reformstaatsvertrag</a>
+publishedDate: 2024-10-11
 ---
 
 Die Open Knowledge Foundation Deutschland (OKF) beteiligt sich an der Konsultation zu den vorgelegten Änderungsvorschlägen des Reformstaatsvertrags. In Zeiten von Vertrauenskrise und Falschinformationen muss ein zeitgemäßes Medienangebot sicherstellen, dass faktenbasierte, gut recherchierte Informationen der Öffentlich-Rechtlichen gut auffindbar, breit gestreut und dauerhaft abrufbar sind. Die Pflicht zur Depublizierung für nicht-fiktionale Inhalte muss daher bedingungslos gestrichen werden. Im Zeitalter von immenser digitaler Desinformation, Fake News, Deep Fakes und Hassrede braucht es starke Player, die dagegen halten und Menschen mit gut recherchierten Informationen versorgen und zeitgemäße hochwertige online-Angebote bereitstellen.


### PR DESCRIPTION
This is to fix compatibility with the latest hugo version.

Migrated using this script:
```
import os
import frontmatter


def process_markdown_files(directory):
    for root, _, files in os.walk(directory):
        for file in files:
            if file.endswith('.md') or file.endswith('.markdown'):
                file_path = os.path.join(root, file)
                with open(file_path, 'r', encoding='utf-8') as f:
                    post = frontmatter.load(f)

                published = post.get('published')
                if published is None:
                    continue
                    
                elif published ==  False:
                    post['draft'] = 'true'
                    del post['published']
                elif published == True:
                    del post['published']

                if post.get('date'):
                    post['publishedDate'] = post.get('date')
                    del post['date']


                with open(file_path, 'w', encoding='utf-8') as f:
                    f.write(frontmatter.dumps(post, sort_keys=False, width=500))


if __name__ == "__main__":
    process_markdown_files('./content')
```

See this discussion: https://discourse.gohugo.io/t/invalid-front-matter-bool-error/51848

Due to the de- and re-serialization, some `field: ` were changed to `field: null` in the frontmatter and some trailing newlines were removed but there should be no changed in the rendered results.

This change also reverts the recent commit which pins the old hugo version in GitHub actions.