### PR TITLE
Use `css.Sass` instead of `resource.ToSass`

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -15,6 +15,6 @@
 <link rel="preload" href="/fonts/apercu-medium-pro.woff" as="font" type="font/woff" crossorigin>
 <link rel="preload" href="/fonts/apercu-regular-pro.woff" as="font" type="font/woff" crossorigin>
 
-{{ $style := resources.Get "sass/main.sass" | resources.ToCSS | resources.Minify | resources.Fingerprint }}
+{{ $style := resources.Get "sass/main.sass" | css.Sass | resources.Minify | resources.Fingerprint }}
 <link rel="stylesheet" href="{{$style.RelPermalink}}">
 {{- partial "js.html" . -}}


### PR DESCRIPTION
This has been renamed in v0.128.0 as per the
[documentation](https://gohugo.io/functions/resources/tocss/) and was showing depreaction warning nows on every run.