### PR TITLE
Fix top navigation on tablet size

### DIFF
--- a/assets/sass/components/logo.sass
+++ b/assets/sass/components/logo.sass
@@ -1,6 +1,4 @@
 .c__logo
-  top: 7px // ($topbar-height - 66px) / 2
-  left: -0.3em
   svg
     width: 138px
     height: 66px

--- a/assets/sass/components/nav-list.sass
+++ b/assets/sass/components/nav-list.sass
@@ -39,12 +39,12 @@
 
 
 .c__nav-list--top
-  align-items: end
+  align-items: center
+  justify-content: end
   @include media-breakpoint-down(md)
     text-align: center
   @include media-breakpoint-up(md)
     flex-direction: row
-    line-height: 5
   a
     padding-bottom: 1px
     border-bottom: 2px solid transparent

--- a/assets/sass/layout/base.sass
+++ b/assets/sass/layout/base.sass
@@ -32,27 +32,20 @@
     @include make-col(6)
     @include make-col-offset(4)
 
-  .l__nav-link--anniversary
-    color: #9558b7
-
-    &:hover
-      color: #59439c
-      border-bottom-color: #59439c
-
   .l__nav-link--donate
     color: $anchor
 
     &:hover
       color: $anchor
       border-bottom-color: $anchor
-    
+
   .l__item
     margin-inline: 0.15rem;
 
 @media print
   .js
     padding-top: 0
-    
+
     .l__topbar
       position: static
       margin-bottom: $space
@@ -60,7 +53,7 @@
       > div
         min-height: auto !important
         height: auto !important
-        
+
 
   .l__topbar
     .l__inner

--- a/assets/sass/layout/base.sass
+++ b/assets/sass/layout/base.sass
@@ -13,24 +13,30 @@
 .l__topbar
   background-color: $white
   border-bottom: $greyish 1px solid
-  > div
+  .l__wrapper
+    padding-top: 7px
     max-width: map-get($container-max-widths, xl)
-    @include make-container()
+    display: grid
+    grid-template-areas: "logo burger" "nav nav"
+    margin: auto
+
+    @media (max-width: map-get($container-max-widths, xl))
+      padding-inline: $space-half
+
+    .l__logo
+      grid-area: logo
+
+    .l__topbar__toggle
+      grid-area: burger
+
 
 .l__inner
   @include make-row()
 
-.l__logo
-  @include make-col-ready()
-  @include make-col(2)
-
 .l__nav
-  @include make-col-ready()
   justify-content: end
   align-items: center
-  @include media-breakpoint-up(md)
-    @include make-col(6)
-    @include make-col-offset(4)
+  gap: 1ch
 
   .l__nav-link--donate
     color: $anchor
@@ -38,9 +44,6 @@
     &:hover
       color: $anchor
       border-bottom-color: $anchor
-
-  .l__item
-    margin-inline: 0.15rem;
 
 @media print
   .js

--- a/assets/sass/layout/topbar.sass
+++ b/assets/sass/layout/topbar.sass
@@ -1,13 +1,7 @@
 .l__topbar
   margin-bottom: $space-m
-  > div
-    @include media-breakpoint-down(sm)
-      padding-bottom: 1em
 
 .l__topbar__toggle
-  @include make-col-ready()
-  @include make-col(2)
-  @include make-col-offset(8)
   display: flex
   align-items: center
   @include media-breakpoint-up(md)
@@ -61,16 +55,11 @@
 // Toggle the menu via hambuger btn
 // JS found in /assets/js/toggle.js
 .js
-  .l__topbar
-    > div
-      min-height: $topbar-height
-      @include media-breakpoint-up(md)
-        height: $topbar-height
-
   @include media-breakpoint-down(sm)
     .c__nav-list--top
       transition: height cubic-bezier(.46,.03,.52,.96) 100ms
       position: static
+      grid-area: nav
       width: 100%
       height: 264px
       &.is-hidden

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,47 +1,45 @@
 <header class="l__topbar">
-  <div>
-    <div class="l__inner">
-      <a href="#content" class="show-on-focus skip">Skip to content</a>
-      {{ with .Site.GetPage "/"}}
-        <a href="{{.Permalink}}" title="Startseite" class="c__logo l__logo">
-          {{ readFile "static/okf/okf-logo-topbar.svg" | safeHTML }}
-        </a>
-      {{end}}
-      <div class="l__topbar__toggle">
-        <button type="button" id="js-topnav-toggle" tabindex="">
-          <span class="l__topbar__toggle--burger">{{ readFile "static/files/icons/menu.svg" | safeHTML }}</span>
-          <span class="l__topbar__toggle--close">{{ readFile "static/files/icons/close.svg" | safeHTML }}</span>
-        </button>
-      </div>
-      <ul class="l__nav c__nav-list c__nav-list--top" id="js-topnav-menu">
-        {{ with .Site.GetPage "/spenden" }}<li class="l__item"><a href="{{ .Permalink }}" class="l__nav-link--donate">{{ .Title }}</a></li>{{ end }}
-        {{ with .Site.GetPage "/profil" }}<li class="l__item"><a href="{{ .Permalink }}">{{ .Title }}</a></li>{{ end }}
-        {{ with .Site.GetPage "/projekte" }}<li class="l__item"><a href="{{ .Permalink }}">{{ .Title }}</a></li>{{ end }}
-        {{ with .Site.GetPage "/publikationen" }}<li class="l__item"><a href="{{ .Permalink }}">{{ .Title }}</a></li>{{ end }}
-        {{ with .Site.GetPage "/events" }}<li class="l__item"><a href="{{ .Permalink }}">{{ .Title }}</a></li>{{ end }}
-        <li class="l__item"><a href="/blog">Blog</a></li>
-
-        {{ $langList := (.Page.AllTranslations) }}
-        {{ $currentLang := .Language}}
-        {{ $lenLangList := len $langList}}
-        <li>{{ range $index, $translation := $langList }}
-          <a href="{{ $translation.Permalink }}" class="{{ if ne $currentLang .Language}}inactive{{ end }}">{{ $translation.Language.LanguageName }}</a>
-          {{ if (eq $index 0) }}|{{ end }}
-          {{ if (eq $lenLangList 1)}}
-          <a href="{{ $translation.Permalink}}">EN</a>
-          {{ end }}
-          {{ end }}
-        </li>
-        <li class="l__search__btn">
-          <button class="" id="js-search-button">
-            <span class="sr-only invisible">{{ i18n "search_open"}}</span>
-            <span class="d-md-none fake-link">Suche</span>
-            <span class="d-none d-md-block">
-              {{ readFile "static/files/icons/search.svg" | safeHTML }}
-            </span>
-          </button>
-        </li>
-      </ul>
+  <div class="l__wrapper">
+    <a href="#content" class="show-on-focus skip">Skip to content</a>
+    {{ with .Site.GetPage "/"}}
+      <a href="{{.Permalink}}" title="Startseite" class="c__logo l__logo">
+        {{ readFile "static/okf/okf-logo-topbar.svg" | safeHTML }}
+      </a>
+    {{end}}
+    <div class="l__topbar__toggle">
+      <button type="button" id="js-topnav-toggle" tabindex="">
+        <span class="l__topbar__toggle--burger">{{ readFile "static/files/icons/menu.svg" | safeHTML }}</span>
+        <span class="l__topbar__toggle--close">{{ readFile "static/files/icons/close.svg" | safeHTML }}</span>
+      </button>
     </div>
+    <ul class="l__nav c__nav-list c__nav-list--top" id="js-topnav-menu">
+      {{ with .Site.GetPage "/spenden" }}<li class="l__item"><a href="{{ .Permalink }}" class="l__nav-link--donate">{{ .Title }}</a></li>{{ end }}
+      {{ with .Site.GetPage "/profil" }}<li class="l__item"><a href="{{ .Permalink }}">{{ .Title }}</a></li>{{ end }}
+      {{ with .Site.GetPage "/projekte" }}<li class="l__item"><a href="{{ .Permalink }}">{{ .Title }}</a></li>{{ end }}
+      {{ with .Site.GetPage "/publikationen" }}<li class="l__item"><a href="{{ .Permalink }}">{{ .Title }}</a></li>{{ end }}
+      {{ with .Site.GetPage "/events" }}<li class="l__item"><a href="{{ .Permalink }}">{{ .Title }}</a></li>{{ end }}
+      <li class="l__item"><a href="/blog">Blog</a></li>
+
+      {{ $langList := (.Page.AllTranslations) }}
+      {{ $currentLang := .Language}}
+      {{ $lenLangList := len $langList}}
+      <li>{{ range $index, $translation := $langList }}
+        <a href="{{ $translation.Permalink }}" class="{{ if ne $currentLang .Language}}inactive{{ end }}">{{ $translation.Language.LanguageName }}</a>
+        {{ if (eq $index 0) }}|{{ end }}
+        {{ if (eq $lenLangList 1)}}
+        <a href="{{ $translation.Permalink}}">EN</a>
+        {{ end }}
+        {{ end }}
+      </li>
+      <li class="l__search__btn">
+        <button class="" id="js-search-button">
+          <span class="sr-only invisible">{{ i18n "search_open"}}</span>
+          <span class="d-md-none fake-link">Suche</span>
+          <span class="d-none d-md-block">
+            {{ readFile "static/files/icons/search.svg" | safeHTML }}
+          </span>
+        </button>
+      </li>
+    </ul>
   </div>
 </header>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -14,7 +14,6 @@
         </button>
       </div>
       <ul class="l__nav c__nav-list c__nav-list--top" id="js-topnav-menu">
-        <!-- {{ with .Site.GetPage "/anniversary" }}<li class="l__item"><a href="{{ .Permalink }}" class="l__nav-link--anniversary">{{ .Title }}</a></li>{{ end }} -->
         {{ with .Site.GetPage "/spenden" }}<li class="l__item"><a href="{{ .Permalink }}" class="l__nav-link--donate">{{ .Title }}</a></li>{{ end }}
         {{ with .Site.GetPage "/profil" }}<li class="l__item"><a href="{{ .Permalink }}">{{ .Title }}</a></li>{{ end }}
         {{ with .Site.GetPage "/projekte" }}<li class="l__item"><a href="{{ .Permalink }}">{{ .Title }}</a></li>{{ end }}


### PR DESCRIPTION
This change fixes the display of the top navigation on the size between desktop and tablet. It does so by switching the display to use grid which is now widely available and (in my opinion) simplifying the overall setup. 

|before|after|
|-|-|
| ![image](https://github.com/user-attachments/assets/5dc28f60-27df-4865-ac68-c6b11925f74f)|![image](https://github.com/user-attachments/assets/5109a6e0-6afe-445d-9682-6afaa7b4b282)|

_Should still look identical when opened on mobile:_
|before|after|
|-|-|
|![image](https://github.com/user-attachments/assets/4119cf72-1ce4-4cda-8cdb-544c2c0cfbf8)|![image](https://github.com/user-attachments/assets/f64fa310-0f5b-47e9-bc9b-2cfaa25f1c96)|


