### PR TITLE
Use title in blog post URLs again

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,7 +8,7 @@ enableRobotsTXT = true
   twitter = "okfde"
 
 [permalinks]
-  blog = 'blog/:year/:month/:slug/'
+  blog = 'blog/:year/:month/:title/'
   tags = 'tags/:slug/'
   authors = 'authors/:slug/'
 

--- a/content/blog/2011/2011-11-17-apps4de-opendata-hackday-in-bremen.markdown
+++ b/content/blog/2011/2011-11-17-apps4de-opendata-hackday-in-bremen.markdown
@@ -7,6 +7,7 @@ tags:
 - Hackday
 title: '#Apps4De Opendata Hackday in Bremen'
 type: post
+url: blog/2011/11/apps4de-opendata-hackday-in-bremen
 ---
 
 Am 9 November wurde der Apps 4 Deutschland Wettbewerb gestartet. Begleitend zu diesem Wettbewerb veranstaltet die Open Knowledge Foundation Deutschland e.V. eine Reihe von Hackdays.

--- a/content/blog/2012/2012-08-25-oercamp-14-16-september-2012-uni-bremen.markdown
+++ b/content/blog/2012/2012-08-25-oercamp-14-16-september-2012-uni-bremen.markdown
@@ -10,6 +10,7 @@ tags:
 - OER
 - Offenes Wissen
 title: '#OERcamp - 14.–16. September 2012, Uni Bremen'
+url: blog/2012/08/oercamp-14.16.-september-2012-uni-bremen
 type: post
 ---
 

--- a/content/blog/2014/2014-08-24-jetzt-anmelden-konferenz-zu-offenen-bildungsmaterialien-im-september-2014-in-berlin-oer14de.markdown
+++ b/content/blog/2014/2014-08-24-jetzt-anmelden-konferenz-zu-offenen-bildungsmaterialien-im-september-2014-in-berlin-oer14de.markdown
@@ -11,6 +11,7 @@ tags:
 - OER14de
 - Wikimedia
 title: 'Jetzt anmelden: Konferenz zu offenen Bildungsmaterialien im September 2014 in Berlin (#OER14de)'
+url: 2014/08/jetzt-anmelden-konferenz-zu-offenen-bildungsmaterialien-im-september-2014-in-berlin-oer14d
 type: post
 ---
 

--- a/content/blog/2014/2014-09-15-apps-for-europe-sucht-die-besten-opendata-apps.markdown
+++ b/content/blog/2014/2014-09-15-apps-for-europe-sucht-die-besten-opendata-apps.markdown
@@ -10,6 +10,7 @@ tags:
 - Europe
 - Innovation
 title: 'Apps for Europe sucht die besten #opendata Apps'
+url: /blog/2014/09/apps-for-europe-sucht-die-besten-opendata-apps
 type: post
 ---
 

--- a/content/blog/2014/2014-12-08-apps4europe-sucht-die-besten-opendata-apps.markdown
+++ b/content/blog/2014/2014-12-08-apps4europe-sucht-die-besten-opendata-apps.markdown
@@ -11,6 +11,7 @@ tags:
 - Community
 - Open Data
 title: 'Apps for Europe sucht die besten #opendata Apps'
+url: /blog/2014/12/apps-for-europe-sucht-die-besten-opendata-apps
 type: post
 ---
 

--- a/content/blog/2015/2015-07-22-mit-daten-gutes-tun.markdown
+++ b/content/blog/2015/2015-07-22-mit-daten-gutes-tun.markdown
@@ -8,6 +8,7 @@ layout: post
 tags:
 - Open Data
 title: 'Gastbeitrag - #openimpact: 10 Projekte, die mit Daten Gutes tun'
+url: blog/2015/07/gastbeitrag-openimpact-10-projekte-die-mit-daten-gutes-tu
 type: post
 ---
 

--- a/content/blog/2015/2015-11-16-oer-atlas.markdown
+++ b/content/blog/2015/2015-11-16-oer-atlas.markdown
@@ -10,6 +10,7 @@ tags:
 - Open Education
 - Open Knowledge
 title: "OER-Atlas 2016: Jetzt #OER-Projekte einreichen"
+url: /blog/2016/11/oer-atlas-2016-jetzt-oer-projekte-einreichen
 type: post
 ---
 Für den OER-Atlas 2016 werden Projekte, Akteure und Angebote zum Thema Open Educational Resources gesammelt. Als Open Educational Resources, kurz OER, werden Lern- und Lehrmaterialien bezeichnet, die kostenlos genutzt, verbreitet und bearbeitet werden dürfen. Als eine Art Jahrbuch nimmt der OER-Atlas alle deutschsprachigen Angebote im Bereich freier Lehr- und Lernmittel auf. Die Daten zu Akteuren und Projekten werden im vierten Quartal 2015 in Zusammenarbeit mit dem OER World Map-Projekt des Hochschulbibliothekszentrums NRW (hbz) erhoben. Die Ergebnisse werden parallel in der interaktiven Datenbank der OER World Map auf [oerworldmap.org](oerworldmap.org) und als Buch veröffentlicht. Noch bis zum 02.12.2015 können sich alle Projekte und Organisationen rund um offene Lehr-Lern-Inhalte, über die Webseite [www.o-e-r.de/16/cfp](http://www.o-e-r.de/16/cfp) eintragen .

--- a/content/blog/2016/2016-09-28-tagderinformationsfreiheit.md
+++ b/content/blog/2016/2016-09-28-tagderinformationsfreiheit.md
@@ -12,6 +12,7 @@ card: true
 tags:
 - FragDenStaat
 title: '#000000 - FragDenStaat enthüllt Kunstedition zur Informationsfreiheit'
+url: blog/2016/09/000000-fragdenstaat-enthüllt-kunstedition-zur-informationsfreiheit
 ---
 
 Heute ist internationaler Tag der Informationsfreiheit! Vor 250 Jahren trat in Schweden das erste Informationsfreiheitsgesetz der Welt in Kraft.

--- a/content/blog/2020/2020-08-15-kick-off-forum-open-education-2020.md
+++ b/content/blog/2020/2020-08-15-kick-off-forum-open-education-2020.md
@@ -7,6 +7,7 @@ card: true
 featured: yellow
 title: 'Kick-Off #FOE20: Offene Bildung politisch stärken'
 publishedDate: 2020-08-03
+url: /blog/2020/08/kick-off-foe20-offene-bildung-politisch-stärken
 ---
 
 Mit dem dritten [Forum Open Education](https://education.forum-open.de/) intensivieren wir gemeinsam mit Wikimedia Deutschland und dem [Bündnis Freie Bildung](https://buendnis-freie-bildung.de/) den Austausch zwischen Zivilgesellschaft, Bildungspraxis und politischen Entscheidungsgremien, um zeitgemäßes Lehren und Lernen für eine digitale und offene Gesellschaft voranzubringen. Die folgenden Themen stehen 2020 im Fokus:

--- a/content/blog/2024/2024-10-19-DE-Reparaturpolitik.md
+++ b/content/blog/2024/2024-10-19-DE-Reparaturpolitik.md
@@ -13,8 +13,6 @@ layout: post
 featured: blue
 title: 'Licht ins Dunkel deutscher Reparaturpolitik'
 publishedDate: 2024-10-19
-aliases:
-- /blog/2024/10/licht-ins-dunkel-deutscher-reparaturpolitik/
 ---
 
 Als die Bundesregierung 2021 angetreten ist, hatte sie sich vorgenommen das sogenannte „Recht auf Reparatur“ voranzubringen und die Reparierbarkeit eines Produktes „zum erkennbaren Merkmal der Produkteigenschaft“ zu machen (siehe [Koalitionsvertrag](https://www.bundesregierung.de/breg-de/aktuelles/koalitionsvertrag-2021-1990800)). In den folgenden Jahren gab es immer wieder Berichterstattung zu den Entwicklungen auf EU-Ebene. Deutschland wollte mit einem Aktionsprogramm „Reparieren statt wegwerfen“ eine Vorreiterrolle einnehmen. Doch bisher ist nichts passiert. Dafür haben wir ein EU-weites Recht auf Reparatur bekommen, das [seinen Namen nicht verdient](https://okfn.de/blog/2024/04/right-to-repair-entschieden-final/). Mich hat ein Jahr die Frage beschäftigt: Für was hat sich die Bundesregierung nun wirklich eingesetzt? Zahlreiche Anfragen im Rahmen des Informationsfreiheitsgesetzes und eine Klage gegen das Bundes Justizministerium später gibt es einen Haufen Papier und ein paar Antworten. Anlässlich des [internationalen Tages der Reparatur](https://openrepair.org/international-repair-day/) fasse ich sie hier zusammen.


### PR DESCRIPTION
It seems that with the unpinning of the hugo version in 2732566 and the updating of the dates in 627e1dd, something in hugo changed with regards to how it generates slugs.

The [hugo documentation](https://gohugo.io/content-management/urls/#tokens) says regarding slugs:
> The slug as defined in front matter, else the title as defined in front matter, else the automatic title. Hugo generates titles automatically for section, taxonomy, and term pages that are not backed by a file.

It seems like something in our setup made it not take into account the `title` from the frontmatter anymore though. I have hence changed the configuration to explicitly use the title instead. This now causes problems because hugo doesn't escape hashes and creates filenames which won't render to valid URLs (see [this issue](https://github.com/gohugoio/hugo/issues/4926)) So I had add some `url` fields manually to force escaped URLs for blog posts hat have hashes in their titles.

All in all, this should hopefully restore the old structure that everything was rendered in before the upgrade.