### PR TITLE
Display current page as active page, not always Spenden

### DIFF
--- a/assets/sass/layout/base.sass
+++ b/assets/sass/layout/base.sass
@@ -38,7 +38,7 @@
   align-items: center
   gap: 1ch
 
-  .l__nav-link--donate
+  .active
     color: $anchor
 
     &:hover

--- a/config.toml
+++ b/config.toml
@@ -32,7 +32,7 @@ weight =  80
     name = 'tags'
     weight = 60
 
-[mediaTypes]        
+[mediaTypes]
   [mediaTypes."application/atom"]
     suffixes = ["xml"]
   [mediaTypes."application/json"]
@@ -54,14 +54,63 @@ weight =  80
 [languages]
   [languages.de]
     title = "OKF"
-    languageName = "DE" 
+    languageName = "DE"
     weight = 1
+    [languages.de.menus]
+      [[languages.de.menus.main]]
+        name = 'Spenden'
+        pageRef = '/spenden'
+        weight = 10
+      [[languages.de.menus.main]]
+        name = 'Über uns'
+        pageRef = '/profil'
+        weight = 20
+      [[languages.de.menus.main]]
+        name = 'Projekte'
+        pageRef = '/projekte'
+        weight = 30
+      [[languages.de.menus.main]]
+        name = 'Publikationen'
+        pageRef = '/publikationen'
+        weight = 40
+      [[languages.de.menus.main]]
+        name = 'Events'
+        pageRef = '/events'
+        weight = 50
+      [[languages.de.menus.main]]
+        name = 'Blog'
+        pageRef = '/blog'
+        weight = 60
   [languages.en]
     title = "OKF DE"
     languageName = "EN"
     weight = 2
-    
-  
+    [languages.en.menus]
+      [[languages.en.menus.main]]
+        name = 'Donate'
+        pageRef = '/spenden'
+        weight = 10
+      [[languages.en.menus.main]]
+        name = 'About'
+        pageRef = '/profil'
+        weight = 20
+      [[languages.en.menus.main]]
+        name = 'Projects'
+        pageRef = '/projekte'
+        weight = 30
+      [[languages.en.menus.main]]
+        name = 'Publications'
+        pageRef = '/publikationen'
+        weight = 40
+      [[languages.en.menus.main]]
+        name = 'Events'
+        pageRef = '/events'
+        weight = 50
+      [[languages.en.menus.main]]
+        name = 'Blog'
+        pageRef = '/blog'
+        weight = 60
+
 [outputs]
 home = ["HTML", "Json"]
 section = [ "HTML", "Atom", "Json", "Rss" ]

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -13,12 +13,13 @@
       </button>
     </div>
     <ul class="l__nav c__nav-list c__nav-list--top" id="js-topnav-menu">
-      {{ with .Site.GetPage "/spenden" }}<li class="l__item"><a href="{{ .Permalink }}" class="l__nav-link--donate">{{ .Title }}</a></li>{{ end }}
-      {{ with .Site.GetPage "/profil" }}<li class="l__item"><a href="{{ .Permalink }}">{{ .Title }}</a></li>{{ end }}
-      {{ with .Site.GetPage "/projekte" }}<li class="l__item"><a href="{{ .Permalink }}">{{ .Title }}</a></li>{{ end }}
-      {{ with .Site.GetPage "/publikationen" }}<li class="l__item"><a href="{{ .Permalink }}">{{ .Title }}</a></li>{{ end }}
-      {{ with .Site.GetPage "/events" }}<li class="l__item"><a href="{{ .Permalink }}">{{ .Title }}</a></li>{{ end }}
-      <li class="l__item"><a href="/blog">Blog</a></li>
+      {{ $currentPage := . }}
+      {{ range .Site.Menus.main }}
+      {{ $active := or ($currentPage.IsMenuCurrent "main" .) ($currentPage.HasMenuCurrent "main" .) }}
+      <li>
+      <a {{ if $active }}class="active"{{ end }} href="{{ .URL }}">{{ .Name }}</a>
+      </li>
+      {{ end }}
 
       {{ $langList := (.Page.AllTranslations) }}
       {{ $currentLang := .Language}}


### PR DESCRIPTION
This also uses the more standard hugo setup of having a menu in the toml config and using that to build the navigation in the template. This enables us to always mark the currently active section.