### PR TITLE
Fix date filter for publikationen

### DIFF
--- a/content/publikationen/2016_Handbuch Jugend Hackathons.md
+++ b/content/publikationen/2016_Handbuch Jugend Hackathons.md
@@ -16,7 +16,7 @@ license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://jugendhackt.org/" target="_blank">Zur Website von Jugend hackt</a>
-publishedDate: 2016-03-01
+date: 2016-03-01
 ---
 
 Dieses Handbuch richtet sich an Fachkräfte der (politischen) Bildung, der Jugend(verbands)arbeit und an Aktivist:innen aus dem technologischen Bereich, die Jugendliche in der Bildung ihrer technischen Fertigkeiten unterstützen möchten. Es fokussiert sich dabei auf spezifische Fragen zu (Jugend-)Hackathons.

--- a/content/publikationen/2016_Studie_Wert persönlicher Daten.md
+++ b/content/publikationen/2016_Studie_Wert persönlicher Daten.md
@@ -18,7 +18,7 @@ size: 1.03 MB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links: null
-publishedDate: 2016-09-01
+date: 2016-09-01
 ---
 
 Ziel dieser Studie ist, eine allgemein verständliche Übersicht zum Handel mit Daten zu erstellen, die den Wert von Daten strukturiert erfasst.

--- a/content/publikationen/2018_Positionspapier Bündnis Freie Bildung.md
+++ b/content/publikationen/2018_Positionspapier Bündnis Freie Bildung.md
@@ -18,7 +18,7 @@ license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://buendnis-freie-bildung.de/" target="_blank">Zur Website des Bündnis Freie Bildung</a>
-publishedDate: 2018-01-01
+date: 2018-01-01
 ---
 
 Das Bündnis Freie Bildung vereinigt Organisationen, Institutionen und Einzelpersonen, die sich für freie Bildung, frei zugängliche Bildungsmaterialien, offene Bildungspraktiken und offene Lizenzen in der Bildung einsetzen.

--- a/content/publikationen/2020_Landesinformationsfreiheitsgesetzes in BW.md
+++ b/content/publikationen/2020_Landesinformationsfreiheitsgesetzes in BW.md
@@ -20,7 +20,7 @@ license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://www.landtag-bw.de/files/live/sites/LTBW/files/dokumente/WP16/Drucksachen/8000/16_8535_D.pdf" target="_blank">Zum Gesetzentwurf</a>
-publishedDate: 2020-09-21
+date: 2020-09-21
 ---
 
 In dieser kurzen Stellungnahme lesen Sie unsere Anmerkungen und Kritikpunkte zum Gesetzentwurf der Fraktion FDP/DVP zur Änderung des Landesinformationsfreiheitsgesetzes in Baden-Württemberg.

--- a/content/publikationen/2020_Open Data in Kommunen.md
+++ b/content/publikationen/2020_Open Data in Kommunen.md
@@ -17,7 +17,7 @@ size: 622KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links: null
-publishedDate: 2020-03-16
+date: 2020-03-16
 ---
 
 Dieses Handbuch bietet einen Überblick, was unter Open Data in Kommunen (offenen Verwaltungsdaten) zu verstehen ist, skizziert Argumente für Open Data aus Sicht der Verwaltung, der Bürger:innen und der Wirtschaft und veranschaulicht Anwendungsbeispiele für offene Daten.

--- a/content/publikationen/2020_Stellungnahme_Zweiter Aktionsplan OGP.md
+++ b/content/publikationen/2020_Stellungnahme_Zweiter Aktionsplan OGP.md
@@ -16,7 +16,7 @@ license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://www.bundesregierung.de/breg-de/service/publikationen/open-government-deutschland-zweiter-nationaler-aktionsplan-2019-2022-zwischenbericht-1997160" target="_blank">Zum Zwischenbericht</a>
-publishedDate: 2020-08-31
+date: 2020-08-31
 ---
 
 Die Open Knowledge Foundation Deutschland unterstützt Deutschlands Bemühungen, die Ziele der Open Government Partnership umzusetzen und begrüßt die vielen Fortschritte, die im Vergleich zum Ersten Nationalen Aktionsplan zu verzeichnen sind. 

--- a/content/publikationen/2021_Datenstrategie_Breg.md
+++ b/content/publikationen/2021_Datenstrategie_Breg.md
@@ -16,7 +16,7 @@ license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://www.bundesregierung.de/breg-de/suche/datenstrategie-der-bundesregierung-1845632" target="_blank">Zur Datenstrategie der Bundesregierung</a>
-publishedDate: 2021-02-22
+date: 2021-02-22
 ---
 
 Die Bundesregierung hat am 27.01.2021 ihre erste Datenstrategie im Kabinett verabschiedet. Die Datenstrategie ist ein Schritt in die richtige Richtung. Die Datenstrategie folgt aus unserer Sicht einer richtigen gesellschaftlichen Zielsetzung: Rahmenbedingungen zu schaffen für eine verantwortungsvolle und innovative Datennutzung, die sich an

--- a/content/publikationen/2021_Stellungnahme_E-Gov Gesetz.md
+++ b/content/publikationen/2021_Stellungnahme_E-Gov Gesetz.md
@@ -16,7 +16,7 @@ license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://www.bmwk.de/Redaktion/DE/Downloads/G/gesetzentwurf-aenderung-des-e-government-gesetzes-und-%20Gesetz-fuer-die-nutzung-von-daten-des-oeffentlichen-sektors.pdf?__blob=publicationFile&v=8" target="_blank">Zum Gesetzentwurf</a>
-publishedDate: 2021-01-12
+date: 2021-01-12
 ---
 
 Die OKF DE begrüßt die Änderung des E-Government-Gesetzes und die Einführung des Gesetzes für die Nutzung von Daten des öffentlichen Sektors grundsätzlich. Insbesondere sind die Ausweitung der Datenöffnung auf die gesamte Bundesverwaltung sowie die Einbeziehung von Forschungsdaten sehr zu begrüßen. Trotz Fortschritte ist es nach Auffassung der OKF DE so, dass sich die Bundesregierung mit dem vorliegenden Entwurf auf das absolute Minimum an Reformen beschränkt. Die wiederholten Ankündigungen einer ernsthaften und weitreichenden Datenöffnung bleiben uneingelöst. Weder bekennt sich die Bundesregierung zu einer Weiterentwicklung des Informationsfreiheitsgesetzes zu einem echten Transparenzgesetz, noch wird den Bürgerinnen und Bürgern ein Rechtsanspruch auf offene Verwaltungsdaten eingeräumt.

--- a/content/publikationen/2021_Stellungnahme_Open Data_SH.md
+++ b/content/publikationen/2021_Stellungnahme_Open Data_SH.md
@@ -16,7 +16,7 @@ license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://www.landtag.ltsh.de/infothek/wahl19/unterrichtungen/00300/unterrichtung-19-00301.pdf" target="_blank">Zum Gesetzentwurf</a>
-publishedDate: 2021-07-19
+date: 2021-07-19
 ---
 
 Die Bereitstellung von Open Data ist ein zentrales Element in der Umsetzung des Offenen Regierungshandeln und maßgebliche Voraussetzung für Transparenz, Nachvollziehbarkeit und Überprüfbarkeit politischen Handelns, Akzeptanz politischer Entscheidungen, Meinungsbildung und Partizipation.

--- a/content/publikationen/2021_sovereigntechfeasibility.en.md
+++ b/content/publikationen/2021_sovereigntechfeasibility.en.md
@@ -15,7 +15,7 @@ license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: '[Website Sovereign Tech Fund](https://sovereigntechfund.de/)'
-publishedDate: 2021-11-16
+date: 2021-11-16
 ---
 
 In the study the authors examined the needs and possibilities for a funding program to strengthen open digital infrastructure. The idea for a fund is based, among other things, on Open Technology Funds Core Infrastructure Fund and can learn from this and the experiences from other programs, e.g. the Prototype Fund, and adopt already tested procedures. For the design of the Sovereign Tech Fund, numerous other existing programs were analyzed, interviews were conducted with developers and stakeholders in the open source ecosystem, and expert workshops were held.

--- a/content/publikationen/2021_sovereigntechfeasibility.md
+++ b/content/publikationen/2021_sovereigntechfeasibility.md
@@ -14,7 +14,7 @@ license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: '[Zur Website des Sovereign Tech Fund](https://sovereigntechfund.de/)'
-publishedDate: 2021-11-16
+date: 2021-11-16
 ---
 
 Im Rahmen einer Machbarkeitsstudie, die vom Bundesministerium für Wirtschaft und Klimaschutz gefördert wurde, prüfte die OKF die Bedarfe und Möglichkeiten für ein Förderprogramm für Offene Digitale Basistechnologien. Die Idee für einen Fund orientiert sich u. a. an Open Technology Funds Core Infrastructure Fund und kann von dessen und den Erfahrungen aus anderen Programmen, z. B. des Prototype Funds, lernen und bereits getestete Verfahren übernehmen. Für das Design des Sovereign Tech Fund wurden zahlreiche weitere, bereits existierende Programme analysiert, Interviews mit Entwickler:innen und Stakeholdern im Open-Source-Ökosystem geführt sowie Expert:innen-Workshops gehalten.

--- a/content/publikationen/2022-jahresbericht.en.md
+++ b/content/publikationen/2022-jahresbericht.en.md
@@ -16,7 +16,7 @@ license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: '[https://2022.okfn.de](https://2022.okfn.de)'
-publishedDate: 2023-06-28
+date: 2023-06-28
 ---
 
 The report looks back at the work of the Open Knowledge Foundation Germany in 2022. The report summarizes the most important activities, describes how the organization works, and presents all projects in brief. The final part of the annual report includes information on the organizational structure and finances.

--- a/content/publikationen/2022-jahresbericht.md
+++ b/content/publikationen/2022-jahresbericht.md
@@ -15,7 +15,7 @@ license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: '[https://2022.okfn.de](https://2022.okfn.de)'
-publishedDate: 2023-06-28
+date: 2023-06-28
 ---
 
 Der folgende Bericht blickt zurück auf die Arbeit der Open Knowledge Foundation Deutschland im Jahr 2022. Im Bericht werden die wichtigsten Aktivitäten zusammengefasst, die Arbeitsweise der Organisation beschrieben sowie alle Projekte in Kürze dargestellt. Der abschließende Teil des Berichts umfasst Informationen zur Organisationsstruktur und den Finanzen

--- a/content/publikationen/2022_BitsundBäume_Forderungen.md
+++ b/content/publikationen/2022_BitsundBäume_Forderungen.md
@@ -16,7 +16,7 @@ license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://bits-und-baeume.org/konferenz-2022/programm/" target="_blank">Zum Programm der Bits&Bäume Konferenz 2022</a>
-publishedDate: 2022-09-05
+date: 2022-09-05
 ---
 
 Die Digitalisierung muss stärker in den Dienst der Gesellschaft und des sozial-ökologischen Wandels gestellt werden. Digitale Technologien sollten durch gleichberechtigte gesellschaftliche Teilhabe und innerhalb der planetaren Grenzen zur Verbesserung von Lebensbedingungen und der Umwelt beitragen, anstatt durch explodierenden Energiebedarf, Ressourcenverbrauch und mangelnde Teilhabe vor allem des Globalen Südens existierende Krisen noch weiter zu verschärfen. Mit diesem Appell und insgesamt mehr als 60 thematischen Forderungen wenden sich 13 Organisationen aus Umwelt,- Klima- und Naturschutz, Digitalpolitik, Entwicklungszusammenarbeit und Wissenschaft anlässlich der „Bits & Bäume“-Konferenz an die Bundesregierung, die Europäische Union und politische Akteure weltweit.

--- a/content/publikationen/2022_F5_Demokratiefördergesetz.md
+++ b/content/publikationen/2022_F5_Demokratiefördergesetz.md
@@ -17,7 +17,7 @@ license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://www.bmfsfj.de/bmfsfj/service/gesetze/gesetz-zur-staerkung-von-massnahmen-zur-demokratiefoerderung-vielfaltgestaltung-extremismuspraevention-und-politischen-bildung-demokratiefoerdergesetz--207726/" target="_blank">Zum Gesetzgebungsverfahren</a>
 - url: <a href="https://buendnis-f5.de/" target="_blank">Zur Website des Bündnis F5</a>
-publishedDate: 2022-03-21
+date: 2022-03-21
 ---
 
 Eine lebendige Demokratie braucht zivilgesellschaftliches Engagement; dieses Engagement wiederum braucht Schutz und Förderung.

--- a/content/publikationen/2022_F5_Demokratiefördergesetz_Referentenentwurf.md
+++ b/content/publikationen/2022_F5_Demokratiefördergesetz_Referentenentwurf.md
@@ -17,7 +17,7 @@ license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://www.bmfsfj.de/bmfsfj/service/gesetze/gesetz-zur-staerkung-von-massnahmen-zur-demokratiefoerderung-vielfaltgestaltung-extremismuspraevention-und-politischen-bildung-demokratiefoerdergesetz--207726" target="_blank">Zum Gesetzgebungsverfahren</a>
 - url: <a href="https://buendnis-f5.de/" target="_blank">Zur Website des Bündnis F5</a>
-publishedDate: 2022-11-01
+date: 2022-11-01
 ---
 
 Das Bündnis F5 (Algorithmwatch, Gesellschaft für Freiheitsrechte, Open Knowledge Foundation Deutschland, Reporter ohne Grenzen, Wikimedia Deutschland) begrüßt den Vorschlag des Bundesministeriums für Familie, Senioren, Frauen und Jugend und des Bundesministeriums des Innern und für Heimat für ein Gesetz zur Stärkung von Maßnahmen zur Demokratieförderung, Vielfaltgestaltung, Extremismusprävention und politischen Bildung (Demokratiefördergesetz – DFördG).

--- a/content/publikationen/2022_F5_Zukunftsstrategie.md
+++ b/content/publikationen/2022_F5_Zukunftsstrategie.md
@@ -17,7 +17,7 @@ license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://www.bmbf.de/bmbf/de/forschung/zukunftsstrategie/zukunftsstrategie_node.html" target="_blank">Zur Zukunftsstrategie Forschung und Innovation des BMBF</a>
 - url: <a href="https://buendnis-f5.de/" target="_blank">Zur Website des Bündnis F5</a>
-publishedDate: 2022-11-17
+date: 2022-11-17
 ---
 
 Wir sind davon überzeugt, dass die Bewältigung der gesellschaftlichen und globalen Herausforderungen nur gelingen wird, wenn das Innovationssystem auf den Prinzipien der Offenheit und Partizipation beruht. 

--- a/content/publikationen/2022_Stellungnahme_Verkündungs- und Bekanntmachungswesens.md
+++ b/content/publikationen/2022_Stellungnahme_Verkündungs- und Bekanntmachungswesens.md
@@ -16,7 +16,7 @@ license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://www.bmj.de/SharedDocs/Gesetzgebungsverfahren/DE/2022_Modernisierung_des_Verkuendungs_und_Bekanntmachungswesens.html" target="_blank">Zum Gesetzgebungsverfahren</a>
-publishedDate: 2022-05-03
+date: 2022-05-03
 ---
 
 Organisationen der digitalen Zivilgesellschaft fordern bereits seit vielen Jahren die Bereitstellung von Gesetzestexten als Open Data. Die Open Knowledge Foundation Deutschland begrüßt daher, dass die Bundesregierung das

--- a/content/publikationen/2022_handbuch-funding-for-future.en.md
+++ b/content/publikationen/2022_handbuch-funding-for-future.en.md
@@ -16,7 +16,7 @@ license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: '[PrototypeFund Website](https://www.prototypefund.de)'
-publishedDate: 2022-04-01
+date: 2022-04-01
 ---
 
 In this handbook, the Prototype Fund offers a case study of open source software to demonstrate how individuals and small teams can benefit from unbureaucratic funding. The handbook examines the advantages of such funding and provides insights into its workings.

--- a/content/publikationen/2022_handbuch-funding-for-future.md
+++ b/content/publikationen/2022_handbuch-funding-for-future.md
@@ -15,7 +15,7 @@ license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: '[PrototypeFund Website](https://www.prototypefund.de)'
-publishedDate: 2022-04-01
+date: 2022-04-01
 ---
 
 Mit diesem Handbuch gibt der Prototype Fund am Beispiel von Open-Source-Software einen Einblick darin, wie unbürokratisches Funding für Individuen und kleine Teams funktionieren kann und was die Vorteile davon sind.

--- a/content/publikationen/2023-jahresbericht.en.md
+++ b/content/publikationen/2023-jahresbericht.en.md
@@ -16,7 +16,7 @@ license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: '[https://2023.okfn.de](https://2023.okfn.de)'
-publishedDate: 2024-06-20
+date: 2024-06-20
 ---
 
 The report looks back at the work of the Open Knowledge Foundation Germany in 2023. The report summarizes the most important activities, describes how the organization works, and presents all projects in brief. The final part of the annual report includes information on the organizational structure and finances.

--- a/content/publikationen/2023-jahresbericht.md
+++ b/content/publikationen/2023-jahresbericht.md
@@ -15,7 +15,7 @@ license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: '[https://2023.okfn.de](https://2023.okfn.de)'
-publishedDate: 2024-06-20
+date: 2024-06-20
 ---
 
 Der folgende Bericht blickt zurück auf die Arbeit der Open Knowledge Foundation Deutschland im Jahr 2023. Im Bericht werden die wichtigsten Aktivitäten zusammengefasst, die Arbeitsweise der Organisation beschrieben sowie alle Projekte in Kürze dargestellt. Der abschließende Teil des Berichts umfasst Informationen zur Organisationsstruktur und den Finanzen.

--- a/content/publikationen/2023_Diskussionspapier_offene_Technologien_für_die_Kreislaufgesellschaft.md
+++ b/content/publikationen/2023_Diskussionspapier_offene_Technologien_für_die_Kreislaufgesellschaft.md
@@ -14,7 +14,7 @@ pages: 6
 size: 133.4KB
 license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
-publishedDate: 2023-12-06
+date: 2023-12-06
 ---
 
 Mit der Nationalen Kreislaufwirtschaftsstrategie und dem Circular Economy Action Plan arbeiten die Bundesregierung und die EU an Maßnahmen zur Entwicklung zirkulärer Wirtschafts- und Gesellschaftsformen. Dabei dürfen Informationstransparenz und die Bedarfe der Zivilgesellschaft nicht unter den Tisch fallen. Im Diskussionspapier zeigen wir auf, wie offene Technologien bestehende Herausforderungen effektiv lösen und die Zivilgesellschaft stärken.

--- a/content/publikationen/2023_F5_Datenstrategie.md
+++ b/content/publikationen/2023_F5_Datenstrategie.md
@@ -17,7 +17,7 @@ license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://www.bundesregierung.de/breg-de/themen/digitalisierung/datenstrategie-2023-2216620" target="_blank">Zur Weiterentwicklung der Datenstrategie</a>
 - url: <a href="https://buendnis-f5.de/" target="_blank">Zur Website des Bündnis F5</a>
-publishedDate: 2023-09-12
+date: 2023-09-12
 ---
 
 „Fortschritt durch Datennutzung“ – so lautet die Weiterentwicklung der Datenstrategie von 2021, die zur Mitte der Legislatur veröffentlicht wurde. Es ist deutlich erkennbar, dass die Bedeutung der Datenpolitik nun stärker als gesamtgesellschaftliches Thema begriffen wird. Dennoch verharrt das Dokument im üblichen Modus der zusammengeschusterten Strategiepapiere als Sammelsurium verschiedener bekannter Ansätze und Einzelmaßnahmen; ein Gesamtrahmen mit klaren Governance-Strukturen, Rollen und Prozessen sowie einer soliden Dateninfrastruktur für eine planvolle und effektive Umsetzung der bereits beschlossenen Maßnahmen fehlt weiterhin.

--- a/content/publikationen/2023_F5_Engagementstrategie.en.md
+++ b/content/publikationen/2023_F5_Engagementstrategie.en.md
@@ -17,7 +17,7 @@ license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://www.bmfsfj.de/bmfsfj/themen/engagement-und-gesellschaft/engagement-staerken/engagementstrategie-des-bundes-222072" target="_blank"> Civic Engagement Strategy of the Federal Government</a>
 - url: <a href="https://buendnis-f5.de/" target="_blank">F5 Alliance website</a>
-publishedDate: 2023-06-08
+date: 2023-06-08
 ---
 
 In this legislative period, a new federal strategy for civic engagement is to be developed with the participation of civil society. The last Civic Engagement Strategy dates back to 2010, so it's about time - because a lot has happened! Digital volunteering has grown significantly and new technologies are increasingly permeating our lives.

--- a/content/publikationen/2023_F5_Engagementstrategie.md
+++ b/content/publikationen/2023_F5_Engagementstrategie.md
@@ -17,7 +17,7 @@ license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://www.bmfsfj.de/bmfsfj/themen/engagement-und-gesellschaft/engagement-staerken/engagementstrategie-des-bundes-222072" target="_blank">Zur Engangementstrategie des Bundes</a>
 - url: <a href="https://buendnis-f5.de/" target="_blank">Zur Website des Bündnis F5</a>
-publishedDate: 2023-06-08
+date: 2023-06-08
 ---
 
 Noch in dieser Legislaturperiode soll unter Beteiligung der Zivilgesellschaft eine neue Engagementstrategie des Bundes erarbeitet werden. Die letzte Engagementstrategie stammt noch aus dem Jahr 2010. Es wird also Zeit – denn es hat sich viel getan! Das digitale Ehrenamt ist stark gewachsen und neue Technologien durchdringen mehr und mehr unser Leben.

--- a/content/publikationen/2023_F5_PM_DDG.en.md
+++ b/content/publikationen/2023_F5_PM_DDG.en.md
@@ -17,7 +17,7 @@ license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://okfn.de/blog/2023/07/pm-dsc" target="_blank">Open blogpost</a>
 - url: <a href="https://buendnis-f5.de" target="_blank">F5 Alliance website</a>
-publishedDate: 2023-07-06
+date: 2023-07-06
 ---
 
 Germany is at risk of losing the opportunity to bring internet platforms - such as social networks or online marketplaces - under effective, independent supervision. The Digital Services Act (DSA) aims to protect users' rights online and sets out due diligence obligations for platforms such as TikTok, Facebook and Twitter. In order to effectively achieve these goals, a centralized and well-organized platform supervisory authority in EU member states is needed to quickly and competently handle complaints from affected parties and enforce their rights. The Digital Services Coordinators (DSCs), in cooperation with the EU Commission, are entrusted with this task. However, the German authorities have been arguing about responsibilities for months, delaying the urgently needed preparations for effective platform supervision.

--- a/content/publikationen/2023_F5_PM_DDG.md
+++ b/content/publikationen/2023_F5_PM_DDG.md
@@ -17,7 +17,7 @@ license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://okfn.de/blog/2023/07/pm-dsc" target="_blank">Zum Blogartikel</a>
 - url: <a href="https://buendnis-f5.de" target="_blank">Zur Website des Bündnis F5</a>
-publishedDate: 2023-07-06
+date: 2023-07-06
 ---
 
 Deutschland droht die Chance zu verspielen, Internetplattformen – wie soziale Netzwerke oder Online-Marktplätze – unter eine effektive, unabhängige Aufsicht zu stellen. Der Digital Services Act (DSA) soll Nutzer*innenrechte online schützen und legt Sorgfaltspflichten für Plattformen wie TikTok, Facebook und Twitter fest. Um diese Ziele wirkungsvoll zu erreichen, bedarf es einer zentralen und gut organisierten Plattformaufsicht in den EU-Mitgliedstaaten, die Beschwerden von Betroffenen zügig und kompetent bearbeitet und ihre Rechte durchsetzt. Mit dieser Aufgabe sind die sogenannten Koordinatoren für Digitale Dienste (Digital Services Coordinators, DSCs) in Zusammenarbeit mit der EU-Kommission betraut. Jedoch streiten sich die deutschen Behörden seit Monaten um Zuständigkeiten und verzögern damit die dringend notwendigen Vorbereitungen für eine effektive Plattformaufsicht.

--- a/content/publikationen/2023_Handbuch_Informationsfreiheit.md
+++ b/content/publikationen/2023_Handbuch_Informationsfreiheit.md
@@ -18,7 +18,7 @@ links:
 - url: <a href="https://fragdenstaat.de/recht/handbuch-informationsfreiheit/" target="_blank">Zur Online-Version des Handbuchs</a>
 - url: <a href="https://www.universitaetsverlag.uni-kiel.de/de/programm/einzelschriften/Informationsfreiheitsrecht" target="_blank">Zur Print-Version beim Universitätsverlag Kiel</a>
 - url: <a href="https://fragdenstaat.de/blog/2023/10/23/handbuch-informationsfreiheit/" target="_blank">Zum Blogbeitrag von FragDenStaat</a>
-publishedDate: 2023-10-23
+date: 2023-10-23
 ---
 
 Das Ziel dieses Handbuch ist es, einen gut verständlichen und praxistauglichen Überblick des Informationsfreiheitsrechts in Deutschland zu schaffen. Und zwar nicht nur für die, die es sich leisten können, sondern für alle. 

--- a/content/publikationen/2023_Handbuch_Open_Hardware_Nachhaltigkeit_FOH.md
+++ b/content/publikationen/2023_Handbuch_Open_Hardware_Nachhaltigkeit_FOH.md
@@ -13,7 +13,7 @@ pages: 56
 size: 4.5MB
 license_type: CC-BY 4.0
 license_link: https://creativecommons.org/licenses/by/4.0/
-publishedDate: 2023-03-13
+date: 2023-03-13
 ---
 
 Die Herausforderungen unser Zeit sind bekannt, die auf sozialer, ökologischer und wirtschaftlicher Ebene vor uns liegen. Offene Hardware kann ein Teil der Lösung werden. In der Publikation "Unboxing Blackboxes" zeigen wir, wie. Außerdem stellen wir die sechs Projekte vor, die Teil der ersten Runde des Prototype Fund Hardware waren.

--- a/content/publikationen/2023_Stellungnahme Hessischen E-Government-Gesetzes.en.md
+++ b/content/publikationen/2023_Stellungnahme Hessischen E-Government-Gesetzes.en.md
@@ -17,7 +17,7 @@ license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: '[All policy statements for the draft law - Part 1](https://starweb.hessen.de/cache/AV/20/DDA/DDA-AV-031-T1.pdf)'
 - url: '[All policy statements for the draft law - Part 2](https://starweb.hessen.de/cache/AV/20/DDA/DDA-AV-031-T2.pdf)'
-publishedDate: 2023-01-31
+date: 2023-01-31
 ---
 
 The draft law essentially deals with the implementation of the digital provision of administrative services in state law, which has become mandatory as a result of the Federal Law on Online Access (OZG).

--- a/content/publikationen/2023_Stellungnahme Hessischen E-Government-Gesetzes.md
+++ b/content/publikationen/2023_Stellungnahme Hessischen E-Government-Gesetzes.md
@@ -18,7 +18,7 @@ license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: '[Alle Stellungnahmen zum Gesetzentwurf - Teil 1](https://starweb.hessen.de/cache/AV/20/DDA/DDA-AV-031-T1.pdf)'
 - url: '[Alle Stellungnahmen zum Gesetzentwurf - Teil 2](https://starweb.hessen.de/cache/AV/20/DDA/DDA-AV-031-T2.pdf)'
-publishedDate: 2023-01-31
+date: 2023-01-31
 ---
 
 Der vorliegende Entwurf behandelt im Wesentlichen die landesrechtliche Umsetzung der durch das Onlinezugangsgesetz (OZG) des Bundes verpflichtend gewordenen digitalen Bereitstellung von Verwaltungsleistungen.

--- a/content/publikationen/2023_Stellungnahme Hessisches OpenDataGesetz.en.md
+++ b/content/publikationen/2023_Stellungnahme Hessisches OpenDataGesetz.en.md
@@ -16,7 +16,7 @@ license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://www.parlamentsdokumentation.brandenburg.de/starweb/LBB/ELVIS/parladoku/w7/drs/ab_8000/8080.pdf" target="_blank">Draft law</a>
-publishedDate: 2023-03-23
+date: 2023-03-23
 ---
 
 The provision of open data is a central element in the implementation of open government and a key prerequisite for transparency, accountability and verifiability of political actions, acceptance of political decisions, opinion formation and participation.

--- a/content/publikationen/2023_Stellungnahme Hessisches OpenDataGesetz.md
+++ b/content/publikationen/2023_Stellungnahme Hessisches OpenDataGesetz.md
@@ -16,7 +16,7 @@ license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://www.parlamentsdokumentation.brandenburg.de/starweb/LBB/ELVIS/parladoku/w7/drs/ab_8000/8080.pdf" target="_blank">Zum Gesetzentwurf</a>
-publishedDate: 2023-03-23
+date: 2023-03-23
 ---
 
 Die Bereitstellung von Open Data ist ein zentrales Element in der Umsetzung des Offenen Regierungshandeln und maßgebliche Voraussetzung für Transparenz, Nachvollziehbarkeit und Überprüfbarkeit politischen Handelns, Akzeptanz politischer Entscheidungen, Meinungsbildung und Partizipation.

--- a/content/publikationen/2023_egovernment-brandenburg.en.md
+++ b/content/publikationen/2023_egovernment-brandenburg.en.md
@@ -16,7 +16,7 @@ license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://www.parlamentsdokumentation.brandenburg.de/starweb/LBB/ELVIS/parladoku/w7/drs/ab_8000/8080.pdf" target="_blank">Open draft law</a>
-publishedDate: 2023-09-28
+date: 2023-09-28
 ---
 
 The state government of Brandenburg wants to incorporate open data into the legal framework by amending the existing law. However, the OKF considers the proposed changes to be insufficient. In a short statement we outline several points of criticism.

--- a/content/publikationen/2023_egovernment-brandenburg.md
+++ b/content/publikationen/2023_egovernment-brandenburg.md
@@ -16,7 +16,7 @@ license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://www.parlamentsdokumentation.brandenburg.de/starweb/LBB/ELVIS/parladoku/w7/drs/ab_8000/8080.pdf" target="_blank">Zum Gesetzentwurf</a>
-publishedDate: 2023-09-28
+date: 2023-09-28
 ---
 
 Mit einer Gesetzesänderung möchte die Brandenburger Landesregierung das Thema Open Data endlich auch in den Rechtsrahmen aufnehmen. Doch die geplanten Änderungen gehen aus Sicht der OKF nicht weit genug. In einer kurzen Initiativstellungnahme haben wir einige Kritikpunkte zusammengefasst.

--- a/content/publikationen/2023_globaldigitalcompact.en.md
+++ b/content/publikationen/2023_globaldigitalcompact.en.md
@@ -17,7 +17,7 @@ license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://www.un.org/techenvoy/global-digital-compact" target="_blank">Global Digital Compact</a>
 - url: '<a href="https://indonesia.un.org/sites/default/files/2023-07/our-common-agenda-policy-brief-gobal-digi-compact-en.pdf" target="_blank">United Nations, Common Agenda Policy Brief 5: A Global Digital Compact — an Open, Free and Secure Digital Future for All</a>'
-publishedDate: 2023-09-13
+date: 2023-09-13
 ---
 
 As part of the Global Digital Compact (GDC), the United Nations is working to shape the digital future on a global scale. In May 2023, the UN Secretary-General presented a policy brief on this issue. Governments are now positioning themselves and should listen to the voices of civil society. Over the past few weeks, the Open Knowledge Foundation, as part of an alliance of civil society organizations (on the initiative of Wikimedia Germany), has taken a closer look at the policy brief and made suggestions for desirable adjustments.

--- a/content/publikationen/2023_globaldigitalcompact.md
+++ b/content/publikationen/2023_globaldigitalcompact.md
@@ -17,7 +17,7 @@ license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://www.un.org/techenvoy/global-digital-compact" target="_blank">Global Digital Compact</a>
 - url: '<a href="https://indonesia.un.org/sites/default/files/2023-07/our-common-agenda-policy-brief-gobal-digi-compact-en.pdf" target="_blank">United Nations, Common Agenda Policy Brief 5: A Global Digital Compact — an Open, Free and Secure Digital Future for All</a>'
-publishedDate: 2023-09-13
+date: 2023-09-13
 ---
 
 Die Vereinten Nationen befassen sich im Rahmen des Global Digital Compact (GDC) mit der Gestaltung der digitalen Zukunft im globalen Rahmen. Hierzu hatte der UN-Generalsekretär im Mai 2023 einen Policy Brief vorgelegt. Die Regierungen verorten derzeit ihre Positionen dazu und sollten dabei insbesondere auch die Stimmen aus der Zivilgesellschaft hören. Über die letzten Wochen hatte sich die Open Knowledge Foundation im Rahmen eines Bündnisses aus zivilgesellschaftlichen Organisationen (auf Initiative von Wikimedia Deutschland) den Policy Brief genauer angeschaut und Vorschläge für wünschenswerte Anpassungen gemacht. Beim Internet Governance Forum Deutschland in der letzten Woche bot sich nun die Gelegenheit für einen neuen Austausch.

--- a/content/publikationen/2024-04-18-F5-Forderungen-DMK.md
+++ b/content/publikationen/2024-04-18-F5-Forderungen-DMK.md
@@ -17,7 +17,7 @@ license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://okfn.de/blog/2024/04/f5-forderungen-dmk/" target="_blank">Zur Pressemitteilung des Bündnis F5</a>
 - url: <a href="https://buendnis-f5.de/" target="_blank">Zur Website des Bündnis F5</a>
-publishedDate: 2024-04-18
+date: 2024-04-18
 ---
 
 Mit der Gründung der ersten Digitalministerkonferenz (DMK) am 19. April 2024 in Potsdam setzen sich die 16 Bundesländer das gemeinsame Ziel, die digitale Transformation zum Wohle der Bürger*innen zu gestalten. Die Vision eines offenen, freien, verlässlichen und sicheren Internets kann nur durch eine gemeinwohlorientierte Digitalpolitik unter Einbeziehung der Zivilgesellschaft Wirklichkeit werden. F5 appelliert an die Verantwortlichen der DMK, die in unserem Forderungspapier ausgeführten Anliegen politisch umzusetzen.

--- a/content/publikationen/2024-05-22-F5ForderungenzurEUWahl.en.md
+++ b/content/publikationen/2024-05-22-F5ForderungenzurEUWahl.en.md
@@ -16,7 +16,7 @@ license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://buendnis-f5.de/" target="_blank">F5 Alliance Webpage</a>
-publishedDate: 2024-05-22
+date: 2024-05-22
 ---
 
 The European Union has established itself as a pioneer in digital policy. Over the past five years, important laws have been introduced to curb the power of big tech companies and to strengthen human rights in the digital world. At the same time, European digital policy is still too often driven by technical trends and profit-oriented interests. The focus on the common good is lost.

--- a/content/publikationen/2024-05-22-F5ForderungenzurEUWahl.md
+++ b/content/publikationen/2024-05-22-F5ForderungenzurEUWahl.md
@@ -17,7 +17,7 @@ license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://buendnis-f5.de/publikationen/2024-05-21-positionsonthe2024europeanelections/" target="_blank">Positions of the F5-Alliance on the 2024 EU-elections in english</a>
 - url: <a href="https://buendnis-f5.de/" target="_blank">Zur Website des Bündnis F5</a>
-publishedDate: 2024-05-22
+date: 2024-05-22
 ---
 
 Die Europäische Union hat sich als wegweisende Akteurin in der Digitalpolitik etabliert. In den letzten fünf Jahren wurden bedeutende Gesetze auf den Weg gebracht, um die Macht von Big-Tech Unternehmen einzudämmen und die Einhaltung von Grund- und Menschenrechten im Digitalen zu stärken. Gleichzeitig ist die europäische Digitalpolitik zu oft von technischen Trends und gewinnorientierten Interessen getrieben. Der Fokus auf das Gemeinwohl geht dabei verloren.

--- a/content/publikationen/2024-Kommentierung-Entwurf-NKWS-OKFDE_OHA.md
+++ b/content/publikationen/2024-Kommentierung-Entwurf-NKWS-OKFDE_OHA.md
@@ -17,7 +17,7 @@ license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://okfn.de/blog/2024/06/zum-entwurf-der-nkws-ambitioniert-bleiben/" target="_blank">Zum Blogartikel</a>
 - url: <a href="https://open-hardware-allianz.de/" target="_blank">Zur Website der Open Hardware Allianz</a>
-publishedDate: 2024-07-09
+date: 2024-07-09
 ---
 
 Wir begrüßen den Entwurf einer Nationalen Kreislaufwirtschaftsstrategie (NKWS) des Bundesministeriums für Umwelt, Naturschutz, nukleare Sicherheit und Verbraucherschutz (BMUV) und sehen ihn als ersten wichtigen Schritt hin zu einer ressourcenschonenden und transparenten Kreislaufwirtschaft in Deutschland. Mit dem Netzwerk Ressourcenwende haben wir bereits die wichtigen Kernziele und Maßnahmen kommentiert. Wir unterstützen die dort bereits genannten Forderungen. Mit der vorliegenden Kommentierung fokussieren wir insbesondere die Rolle und Potenziale von Open Source, die stellenweise im aktuellen Entwurf enthalten sind. Neben Rohstoffkreisläufen sollten auch damit zusammenhängende Informationen im Zentrum stehen. Eine Kreislaufwirtschaft ist in erster Linie ein Kooperationsprojekt, das viele Akteure braucht. Informationen sind die wesentliche Triebkraft dabei. Dafür braucht es die allgemeine Ausrichtung auf das Zirkulieren von produkt- und rohstoffspezifischen Informationen und Anreize, offene Ansätze zu etablieren, die Produkttransparenz von Beginn an mitdenken (Open Source Hardware, Open Data, Open Source Software).

--- a/content/publikationen/2024-OKF_Stellungnahme_Rundfunk.md
+++ b/content/publikationen/2024-OKF_Stellungnahme_Rundfunk.md
@@ -16,7 +16,7 @@ license_type: CC-BY-SA 4.0
 license_link: https://creativecommons.org/licenses/by-sa/4.0/
 links:
 - url: <a href="https://rundfunkkommission.rlp.de/rundfunkkommission-der-laender/reformstaatsvertrag/" target="_blank">Zum Reformstaatsvertrag</a>
-publishedDate: 2024-10-11
+date: 2024-10-11
 ---
 
 Die Open Knowledge Foundation Deutschland (OKF) beteiligt sich an der Konsultation zu den vorgelegten Änderungsvorschlägen des Reformstaatsvertrags. In Zeiten von Vertrauenskrise und Falschinformationen muss ein zeitgemäßes Medienangebot sicherstellen, dass faktenbasierte, gut recherchierte Informationen der Öffentlich-Rechtlichen gut auffindbar, breit gestreut und dauerhaft abrufbar sind. Die Pflicht zur Depublizierung für nicht-fiktionale Inhalte muss daher bedingungslos gestrichen werden. Im Zeitalter von immenser digitaler Desinformation, Fake News, Deep Fakes und Hassrede braucht es starke Player, die dagegen halten und Menschen mit gut recherchierten Informationen versorgen und zeitgemäße hochwertige online-Angebote bereitstellen.


### PR DESCRIPTION
The current list of publications is broken since the hugo update.

The reason for this is that in [publikationen.html layout](https://github.com/okfde/okfn.de/blob/a732b05749509f5bdbb5fb4021550a2b2ae3a32f/layouts/_default/publikationen.html#L34), we use `GroupByDate`. 
In the upgrade, we have renamed a lot of fields to `publishedDate`. In our [config](https://github.com/okfde/okfn.de/blob/a732b05749509f5bdbb5fb4021550a2b2ae3a32f/config.toml#L70), we set
```
[frontmatter]
date  = [":filename", ":default"]
```
instructing hugo to first look at the filename when trying to find a date, and then use the [default list](https://gohugo.io/getting-started/configuration/#configure-dates). This list notably doesn't include any field called `publishedDate`, only `publishDate` is listed.
This led to the filters only taking into account the dates from the file names and no longer from the front matter. Since only three fields had valid dates, only those would be considered for the date filter.

This change hence renames all the dates field in the `publikationen` pages to `date` again to be consistent with how hugo usually does things.