### PR TITLE
Make team page header static

### DIFF
--- a/layouts/_default/team.html
+++ b/layouts/_default/team.html
@@ -24,9 +24,9 @@
     <div class="row l__team__title">
       <h1 class="col col-12 col-sm-10">
         {{ if eq .Lang "en"}}
-          We are {{ len $team }} activists, policy specialists & developers
+          Team
         {{ else }}
-          Wir sind {{ len $team }} Aktivist*innen, Policy-Spezialist*innen & Entwickler*innen
+          Unser Team
         {{ end }}
       </h1>
     </div>


### PR DESCRIPTION
The number becomes outdated too quickly. It's better not to show it at all.