### PR TITLE
Reorder projects & rearchitect CSS

### DIFF
--- a/assets/sass/layout/home.sass
+++ b/assets/sass/layout/home.sass
@@ -65,11 +65,3 @@
     img
       position: absolute
       top: -16em
-
-@include media-breakpoint-down(xs)
-  .l__home
-    .l__projects__list--home
-      .l__projects__item
-          padding: 0
-          &:first-child
-            margin-top: 1.15em

--- a/assets/sass/layout/projects.sass
+++ b/assets/sass/layout/projects.sass
@@ -56,31 +56,38 @@ $theight-large: 503px
   text-align: center
 
 .l__projects__list--home
+  display: grid
+  row-gap: $space
   width: 100%
-  display: flex
-  flex-flow: row wrap
-  li:nth-child(1),
-  li:nth-child(4),
+  .c__tile
+    height: 100%
+
+  li:nth-child(1)
+    grid-area: a
+  li:nth-child(2)
+    grid-area: b
+  li:nth-child(3)
+    grid-area: c
+  li:nth-child(4)
+    grid-area: d
   li:nth-child(5)
-    .c__tile
-      height: $theight-large
+    grid-area: e
+  li:nth-child(6)
+    grid-area: f
+
+  @include media-breakpoint-down(sm)
+    grid-template-rows: 250px 500px 250px  500px 250px 500px
+    grid-template-areas: "a" "b" "c" "d" "e" "f"
+
   @include media-breakpoint-up(sm)
-    max-height: 1080px
-    flex-flow: column wrap
-    li:nth-child(4) // exception for this size
-      .c__tile
-        height: $theight-small
+    grid-template-rows: repeat(4, 250px)
+    grid-template-columns: repeat(2, 1fr)
+    grid-template-areas: "a b" "a c" "d c" "e f"
 
   @include media-breakpoint-up(md)
-    flex-flow: column wrap
-    max-height: 800px
-    li:nth-child(1),
-    li:nth-child(4),
-    li:nth-child(5)
-      .c__tile
-        height: $theight-large
-  .l__projects__item
-    margin-bottom: 0
+    grid-template-rows: repeat(3, 250px)
+    grid-template-columns: repeat(3, 1fr)
+    grid-template-areas: "a b c" "a e c" "d e f"
 
 .l__projects__list--center
   margin-top: $space

--- a/content/projekte/codeforde.en.md
+++ b/content/projekte/codeforde.en.md
@@ -21,7 +21,7 @@ people:
     role:
 contact_person: michaelpeters
 years: 2014 - heute
-weight: 4
+weight: 5
 partners:
   - Code for All
 website: https://codefor.de

--- a/content/projekte/codeforde.md
+++ b/content/projekte/codeforde.md
@@ -10,7 +10,7 @@ kategorien:
   - Civic Tech
 tile: double
 layout: project
-weight: 2
+weight: 5
 img: projects/codefor_BigTile.gif
 img_header: projects/codefor_Header.png
 people:

--- a/content/projekte/datenschule.en.md
+++ b/content/projekte/datenschule.en.md
@@ -7,7 +7,6 @@ kategorien:
 categories:
   - education
 tile: single
-weight: 5
 layout: project
 img: projects/Datenschule_Projektuebersicht_smallTile.png
 img_header:

--- a/content/projekte/datenschule.md
+++ b/content/projekte/datenschule.md
@@ -7,7 +7,6 @@ kategorien:
 categories:
   - education
 tile: single
-weight: 5
 layout: project
 img: projects/Datenschule_Projektuebersicht_smallTile.png
 img_square:

--- a/content/projekte/opendata.en.md
+++ b/content/projekte/opendata.en.md
@@ -8,6 +8,7 @@ categories:
 tile: double
 type: featured 
 layout: project
+weight: 3
 img: projects/opendata_tile.png
 img_header: projects/opendata_header.jpg
 people:

--- a/content/projekte/opendata.md
+++ b/content/projekte/opendata.md
@@ -8,6 +8,7 @@ kategorien:
 tile: double
 type: featured 
 layout: project
+weight: 3
 img: projects/opendata_tile.png
 img_header: projects/opendata_header.jpg
 people:

--- a/content/projekte/prototypefund.en.md
+++ b/content/projekte/prototypefund.en.md
@@ -12,7 +12,7 @@ img: projects/PrototypeFund_Projektuebersicht_bigTile.png
 img_square: projects/PrototypeFund_logo_icon_dark.svg
 img_header: projects/PrototypeFund_logo_dark.svg
 layout: project
-weight: 4
+weight: 2
 type: featured
 people:
   - name: Marie Kreil

--- a/content/projekte/prototypefund.md
+++ b/content/projekte/prototypefund.md
@@ -13,7 +13,7 @@ img: projects/PrototypeFund_Projektuebersicht_bigTile.png
 img_square: projects/PrototypeFund_logo_icon_dark.svg
 img_header: projects/PrototypeFund_logo_dark.svg
 layout: project
-weight: 4
+weight: 2
 people:
   - name: Patricia Leu
     role: Co-Projektleitung - Schwerpunkt Kommunikation und Projektmanagement

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -61,7 +61,7 @@
         <ul class="l__projects__list--home mb-l">
           {{ $lang := .Lang }}
           {{ range first 6 ( sort (where $.Site.RegularPages "Section" "projekte") "Weight" "desc") }}
-          <li class="col col-12 col-xs-6 col-md-4 l__projects__item">
+          <li class="col">
             <a  href="{{.Permalink}}" class="c__tile c__tile--single" style="background-image: url(/files/{{.Params.img}})" title="{{.Title}}">
               <h2 class="h3 c__tile__title">{{.Title}}</h2>
               <div class="c__tile__overlay">


### PR DESCRIPTION
This change adapts the order of the projects on the home page and ensures that they are sorted as they are on the /projekte page.

CSS needed to change so that the order is the same on `/` as on `/projekte`.


Fixes #169 (the order of the projects is set through the frontmatter in the `.md` files. It was just set differently between German and English versions for some of the projects)
Fixes #164 
Fixes #165 