### PR TITLE
Reduce padding on donation page

### DIFF
--- a/assets/sass/layout/donation.sass
+++ b/assets/sass/layout/donation.sass
@@ -1,6 +1,6 @@
 .l__fancy-donation
   max-width: $max-width
-  padding-block: 200px
+  padding-block: $space-double
 
   position: relative
   margin: auto


### PR DESCRIPTION
When we initially redesigned the Spenden page, we deliberately added quite large padding but now would like to reduce this to a more consistent look after all. 

Fixes [#146](https://github.com/okfde/okfn.de/issues/146)