### PR TITLE
Improve figcaption accessibility

### DIFF
--- a/assets/sass/base/base.sass
+++ b/assets/sass/base/base.sass
@@ -73,19 +73,17 @@ figure.license
     font-weight: 500
   figcaption
     position: absolute
-    //text-shadow: 1px 0px black
     bottom: 8px
     left: 8px
-    color: #FFEC00
-    //background-color: rgba(black, 0.4)
-    padding: 0 .4em
+    color: $white
+    background-color: $black
+    padding: .4em
     font-size: 10px
-    //max-width: 200px
     opacity: 0
     transition: opacity 200ms ease
   a
     text-decoration: underline
-    color: #FFEC00
+    color: $white
   &:hover,
   &:active
     figcaption

--- a/layouts/partials/blog_image_license.html
+++ b/layouts/partials/blog_image_license.html
@@ -1,5 +1,6 @@
 <figure class="license">
-  <img src="{{.Params.image.src}}" alt="{{.Params.image.title}}">
+  {{/* Empty alt tag because title is provided as figcaption */}}
+  <img src="{{.Params.image.src}}" alt="">
   {{ if .Params.image.license}}
   <figcaption>{{ with .Params.image.title }}{{.}}{{end}}
     {{ with .Params.image.license_url }}<a href="{{ . }}">{{ end }}


### PR DESCRIPTION
We are making two changes to figure captions (that are shown on hover)
- When hovered, we show the image alt text and some attribution. Right now, this is yellow text on a transparent background which makes it very difficult to read in many circumstances. With the change, we add a black background and make the text white
- Since there is a fig caption *and* we also used to store the title as the alt tag, this information was redundant. With this change, we are removing the alt text so that screen reader users don't hear the same text twice.