### PR TITLE
Apply some more accessibility improvements

### DIFF
--- a/assets/sass/base/base.sass
+++ b/assets/sass/base/base.sass
@@ -59,7 +59,6 @@ em, i
 
 a
   color: $anchor
-  text-decoration: none
   &:hover,
   &:active
     text-decoration: underline

--- a/assets/sass/components/nav-list.sass
+++ b/assets/sass/components/nav-list.sass
@@ -33,6 +33,10 @@
   @include media-breakpoint-down(md)
    grid-template-rows: repeat(4, auto)
 
+  ul
+    flex-direction: column
+    display: flex
+    gap: $space/8
   a
     color: black
     font-weight: 500
@@ -40,7 +44,6 @@
 .c__nav-list
   display: flex
   flex-direction: column
-  display: inline
   @include media-breakpoint-up(md)
     display: flex
     flex-direction: row
@@ -68,23 +71,6 @@
     color: $anchor
     padding-bottom: 1px
     border-bottom: 2px solid $anchor
-
-.c__nav-list--filter
-  font-weight: 400
-  font-size: 20px
-  a
-    padding-bottom: 0
-    border-bottom: 2px solid transparent
-
-  .active
-    color: $anchor
-    border-color: $anchor
-
-  @include media-breakpoint-down(md)
-    font-size: 18px
-    margin: 3em 0
-    a
-      margin: 0 0.4em
 
 .c__nav-list--report
   a

--- a/assets/sass/components/post.sass
+++ b/assets/sass/components/post.sass
@@ -24,6 +24,7 @@
   display: block
   padding: $space
   color: black
+  text-decoration: none
   &:hover
     text-decoration: none
     color: $blue
@@ -84,6 +85,13 @@
     width: 1em
     height: 2px
     background-color: $black
+
+  #tags
+    display: flex
+    flex-direction: column
+    gap: $space/8
+    a
+      text-decoration: none
 
 // Styles specific for blog posts
 .c__post--single

--- a/assets/sass/components/post.sass
+++ b/assets/sass/components/post.sass
@@ -21,25 +21,20 @@
       order: 3
 
 .c__post--featured
-  max-width: $max-width
-  margin-left: auto
-  margin-right: auto
-  .row
-    padding: $grid-gutter-width / 2 0
-    @include media-breakpoint-up(sm)
-      padding: $space 0 $space-m
-  a
-    width: 100%
-    color: $black
+  display: block
+  padding: $space
+  color: black
+  &:hover
     text-decoration: none
-    font-weight: 400
-  .h3 + .h3
-    margin-top: .5em
+    color: $blue
 
-  .c__post__image
-    margin-top: -1.7em
-    @include media-breakpoint-down(md)
-      margin-top: $space-m
+  figure
+    margin-top: $space * 2
+    max-width: Min(100%, 600px)
+    margin-inline: auto
+    img
+      margin-inline: auto
+      width: 100%
 
 .c__post__image,
 .c__post__image--regular

--- a/assets/sass/layout/footer.sass
+++ b/assets/sass/layout/footer.sass
@@ -1,51 +1,26 @@
 .l__footer
-  margin-top: $space
+  margin-top: $space * 4
+  max-width: map-get($container-max-widths, xl)
+  @include make-container()
+  border-top: $greyish 1px solid
+  padding-block: $space
+  display: grid
+  gap: $space
+
+  @include media-breakpoint-down(md)
+    grid-template-areas: "nav" "newsletter" "social-media" "contact" "fine-print"
+    grid-template-rows: repeat(5, auto)
+
   @include media-breakpoint-up(md)
-    padding-top: $space-m
-    padding-bottom: $space
-  .col
-    @include media-breakpoint-down(md)
-      margin-top: 1em
-      margin-bottom: 2em
-  p + p
-    margin-top: .9em
+    grid-template-columns: 2fr 1fr
+    grid-template-areas: "nav newsletter" "fine-print social-media" "fine-print contact"
+
   h2
     font-size: 1.6em
     margin-bottom: 0.5em
-  @media print
-    padding-top: $space
-    text-align: center
-    margin-top: $space-half
-    padding-top: $space-half
-    padding-bottom: 0
-    font-size: 11px
+  p + p
+    margin-top: .9em
 
-.l__footer__itz
-  img
-    width: 100%
-    height: auto
-  a:hover,
-  a:active
-    img
-      filter: grayscale(100%)
-
-
-.l__footer
-  > div
-    max-width: map-get($container-max-widths, xl)
-    @include make-container()
-    border-top: $greyish 1px solid
-    padding-top: $space
-    display: grid
-    gap: $space
-
-    @include media-breakpoint-down(md)
-      grid-template-areas: "nav" "newsletter" "social-media" "contact" "fine-print"
-      grid-template-rows: repeat(5, auto)
-
-    @include media-breakpoint-up(md)
-      grid-template-columns: 2fr 1fr
-      grid-template-areas: "nav newsletter" "fine-print social-media" "fine-print contact"
 
   aside
     grid-area: sidebar
@@ -55,14 +30,18 @@
 
   nav
     grid-area: nav
+    a
+      text-decoration: none
 
   .l__footer__footnote
     grid-area: fine-print
     color: #6b6b6b
     font-size: 13px
+
     a
       color: $primary
       text-decoration: none
+
       &:hover,
       &:active
         text-decoration: underline

--- a/assets/sass/layout/home.sass
+++ b/assets/sass/layout/home.sass
@@ -1,6 +1,7 @@
 .l__home
   .linked
     position: relative
+    text-decoration: none
     svg
       position: absolute
       top: 3px

--- a/assets/sass/layout/projects.sass
+++ b/assets/sass/layout/projects.sass
@@ -67,6 +67,8 @@ $theight-large: 503px
 .l__projects__list--home
   display: grid
   row-gap: $space
+  a
+    text-decoration: none
   width: 100%
   .c__tile
     height: 100%

--- a/layouts/_default/blog.html
+++ b/layouts/_default/blog.html
@@ -54,7 +54,9 @@
     {{ $nate := .Paginate (where .Site.AllPages "Section" "blog") }}
 
     {{ if eq $nate.HasPrev false}}
-    {{- partial "featured_post.html" . -}}
+      <div class="container">
+          {{- partial "featured_post.html" . -}}
+      </div>
     {{ end }}
 
     <ul class="l__blog__posts container mt-d">

--- a/layouts/_default/profile.html
+++ b/layouts/_default/profile.html
@@ -22,7 +22,7 @@
 {{ define "main" }}
 <div class="container mb-d">
     <h1 class="mb-xs">{{.Params.blurb}}</h1>
-    <img src="/okf/verein/team-2025.jpeg" style="width: 100%"/>
+    <img src="/okf/verein/team-2025.jpeg" style="width: 100%" alt="Teamfoto (eines Teils) der OKF"/>
 
     <h3 class="mt-xs">{{ .Params.intro.title }}</h3>
     {{ .Params.intro.copy | markdownify }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -97,7 +97,9 @@
         <div class="col col-10 mb-s">
           <h2>{{ i18n "home_blog_news" }}</h2>
         </div>
-        {{- partial "featured_post.html" . -}}
+        <div class="col">
+            {{- partial "featured_post.html" . -}}
+        </div>
 
         <ul class="l__blog__posts container mt-s">
           {{ range first 4 ( sort (where (where $.Site.AllPages "Section" "blog") "Kind" "page")) }}

--- a/layouts/partials/featured_post.html
+++ b/layouts/partials/featured_post.html
@@ -1,13 +1,7 @@
-<div class="c__post--featured container">
-  {{ range first 1 (where .Site.AllPages.ByDate.Reverse "Params.featured" "ne" nil) }}
-  <div class="row no-gutters c__post__bg--{{.Params.featured}}">
-    <a href="{{ .Permalink }}" title="{{ .Title }}">
-      <h2 class="h3 col col-sm-10 col-md-8 col-lg-6">{{ .Title }}</h2>
-      <p class="h3 col col-lg-3"><time datetime="{{.Date}}">{{ .Date.Format "02.01.2006" }}</time></p>
-      <div class="c__post__image col col-sm-8 offset-sm-2 col-lg-6 offset-lg-3">
-        {{- partial "blog_image_license" . -}}
-      </div>
-    </a>
-  </div>
-  {{ end }}
-</div>
+{{ range first 1 (where .Site.AllPages.ByDate.Reverse "Params.featured" "ne" nil) }}
+<a class="c__post--featured c__post__bg--{{.Params.featured}}" href="{{ .Permalink }}" title="{{ .Title }}">
+    <h2 class="h3">{{ .Title }}</h2>
+    <time datetime="{{.Date}}">{{ .Date.Format "02.01.2006" }}</time>
+    {{- partial "blog_image_license" . -}}
+</a>
+{{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,4 @@
 <footer class="l__footer">
-  <div class="printer-hidden">
       <nav>
       {{- partial "footer-nav" . -}}
       </nav>
@@ -74,9 +73,4 @@
 
         </div>
     </div>
-  <div class="printer-only">
-    <p>
-      Open Knowledge Foundation Deutschland e. V. | Singerstr. 109, 10179 Berlin | info@okfn.de | www.okfn.de
-    </p>
-  </div>
 </footer>


### PR DESCRIPTION
This change:
- changes the default link style to user underlines and only opts out of the underlines where applicable. This is to match WCAG's SC 1.4.1 which prohibits usage of only color to distinguish information. 
- Adds more merging between the navigation items in the footer to ensure that the touch targets are large enough (finding by Lighthouse)
- Adds an img alt tag to the team page
- Removes printer specific styling

It also cleans up lots of unused CSS
