### PR TITLE
Change newsletter page to offer sign up

### DIFF
--- a/content/newsletter.md
+++ b/content/newsletter.md
@@ -5,7 +5,7 @@ title: Unser Newsletter
 Unser monatlicher Newsletter informiert über Neuigkeiten aus unseren Projekten, der Organisation und von Veranstaltungen, auf denen wir zu treffen sind!
 
 
-Hier kannst du dich einfach anmelden
+Hier kannst du dich einfach anmelden:
 
 <form method="post" action="https://te917244a.emailsys1a.net/172/4129/5126005eed/subscribe/form.html?_g=1655987201" class="c__newsletter">
   <label for="email" class="sr-only">E-Mail</label>

--- a/content/newsletter.md
+++ b/content/newsletter.md
@@ -1,6 +1,17 @@
 ---
-title: Vielen Dank
-meta: Bestätigung Newsletter
+title: Unser Newsletter
 ---
 
-Bitte bestätige deine Anmeldung zu unserem Newsletter über den Link in der Mail, die du erhalten hast.
+Unser monatlicher Newsletter informiert über Neuigkeiten aus unseren Projekten, der Organisation und von Veranstaltungen, auf denen wir zu treffen sind!
+
+
+Hier kannst du dich einfach anmelden
+
+<form method="post" action="https://te917244a.emailsys1a.net/172/4129/5126005eed/subscribe/form.html?_g=1655987201" class="c__newsletter">
+  <label for="email" class="sr-only">E-Mail</label>
+  <input type="text" name="email" class="c__newsletter__input" id="email" placeholder="E-Mail" value="" required>
+  <span class="input-group-btn">
+    <button type="submit" class="c__newsletter__btn">Anmelden</button>
+    <span style="position: absolute; left: -5000px;"></span>
+  </span>
+</form>

--- a/content/newsletter.md
+++ b/content/newsletter.md
@@ -15,3 +15,8 @@ Hier kannst du dich einfach anmelden:
     <span style="position: absolute; left: -5000px;"></span>
   </span>
 </form>
+<br>
+<br>
+<br>
+
+![illustration](/static/files/images/Studie2.jpg)

--- a/content/newsletter.md
+++ b/content/newsletter.md
@@ -15,8 +15,3 @@ Hier kannst du dich einfach anmelden:
     <span style="position: absolute; left: -5000px;"></span>
   </span>
 </form>
-<br>
-<br>
-<br>
-
-![illustration](/static/files/images/Studie2.jpg)


### PR DESCRIPTION
This changes the `/newsletter` page from a (no longer relevant) confirmation page to one where the users can simply sign up for the newsletter itself.