### PR TITLE
Fix invalid front matters

### DIFF
--- a/content/blog/2015/2015-12-31-31c3.markdown
+++ b/content/blog/2015/2015-12-31-31c3.markdown
@@ -13,7 +13,6 @@ tags:
 - CCC
 - Chaos Communication Congress
 title: "Die OKF-Familie auf dem 32C3" 
-type: post
 ---
 
 *Zwischen Hamburg und Berlin, 31.12.2015* – Chaos, Spaß und Kommunikation: Wir waren in Hamburg beim [32. Chaos Communication Congress oder kurz 32C3](http://www.ccc.de). Der [Chaos Communication Congress](https://de.wikipedia.org/wiki/Chaos_Communication_Congress) ist ein mehrtägiges, in Deutschland stattfindendes Treffen der internationalen Hackerszene, das vom Chaos Computer Club (CCC) ausgerichtet und organisiert wird. Der Kongress widmet sich in zahlreichen Vorträgen und Workshops technischen und gesellschaftspolitischen Themen. Über 13.000 Teilnehmer\*innen waren Ende Dezember 2015 in Hamburg mit dabei. 

--- a/content/projekte/big.en.md
+++ b/content/projekte/big.en.md
@@ -4,7 +4,6 @@ title: BIG
 website: https://big-project.eu
 img: projects/big.jpg
 layout: project
-website: http://big-project.eu
 financing:
   -  FP7
 years: 2012 - 2014

--- a/content/projekte/big.md
+++ b/content/projekte/big.md
@@ -4,7 +4,6 @@ title: BIG
 website: https://big-project.eu
 img: projects/big.jpg
 layout: project
-website: http://big-project.eu
 financing:
   -  FP7
 years: 2012 - 2014

--- a/content/projekte/bits-und-baeume.en.md
+++ b/content/projekte/bits-und-baeume.en.md
@@ -21,7 +21,6 @@ financing:
   - Spenden
 contact_alternate_email: 
 years: 2018 - 2022
-website: https://bits-und-baeume.org/de
 contact:
   twitter: bitsundbaeume
 ---

--- a/content/projekte/bits-und-baeume.md
+++ b/content/projekte/bits-und-baeume.md
@@ -21,7 +21,6 @@ financing:
   - Spenden
 contact_alternate_email: claudia.jach@okfn.de
 years: 2018 - 2022
-website: https://bits-und-baeume.org/de
 contact:
   twitter: bitsundbaeume
 ---

--- a/content/projekte/codeforde.en.md
+++ b/content/projekte/codeforde.en.md
@@ -8,29 +8,27 @@ tileclass: dark
 kategorien:
   - Community
   - Civic Tech
-tile: double
-layout: project
 weight: 5
 img: projects/codefor_BigTile.gif
 img_header: projects/codefor_Header.png
 people:
   - name: ca. 300 volunteers all over Germany
     role:
-contact_person: 
+contact_person:
 years: 2014 - today
 partners:
   - Code for All
 website: https://codefor.de
 contact:
-  twitter: 
+  twitter:
   github: https://github.com/codeforgermany
-  mailinglist: 
+  mailinglist:
   g+: https://plus.google.com/communities/101049062262477568057?utm_source=chrome_ntp_icon&utm_medium=chrome_app&utm_campaign=chrome
 cta: Mitmachen
 cta_text: |-
-    You can find out which projects are being developed, when the next meeting will take place and how to participate by clicking on a city on the <a href="https://codefor.de/community">map</a>.
+  You can find out which projects are being developed, when the next meeting will take place and how to participate by clicking on a city on the <a href="https://codefor.de/community">map</a>.
 more_text: |-
-    Further information can be found on the Code for Germany <a href="https://codefor.de/">website</a>.
+  Further information can be found on the Code for Germany <a href="https://codefor.de/">website</a>.
 ---
 
 Code for Germany is a network of volunteers dedicated to a digital future that serves the common good. The network comprises approximately 300 community members in Germany and beyond. They examine the state of digitalization in their cities, municipalities, and regions. They develop helpful software and hardware projects. They analyze current technological developments for their societal benefits. They demonstrate the value of open data and advocate for the sustainable digitalization of public administration.

--- a/content/projekte/codeforde.md
+++ b/content/projekte/codeforde.md
@@ -8,8 +8,6 @@ tileclass: dark
 kategorien:
   - Community
   - Civic Tech
-tile: double
-layout: project
 weight: 5
 img: projects/codefor_BigTile.gif
 img_header: projects/codefor_Header.png

--- a/content/projekte/edulabs.en.md
+++ b/content/projekte/edulabs.en.md
@@ -1,5 +1,4 @@
 ---
-type: education
 categories:
   - education
   - community

--- a/content/projekte/edulabs.md
+++ b/content/projekte/edulabs.md
@@ -1,5 +1,4 @@
 ---
-type: education
 kategorien:
   - Bildung
 categories:

--- a/content/projekte/fragdenstaat.en.md
+++ b/content/projekte/fragdenstaat.en.md
@@ -1,5 +1,4 @@
 ---
-type: politics
 categories:
   - Open Government
   - community

--- a/content/projekte/fragdenstaat.md
+++ b/content/projekte/fragdenstaat.md
@@ -1,5 +1,4 @@
 ---
-type: politics
 kategorien:
   - Offenes Regierungshandeln
   - Community

--- a/content/projekte/httpsjetzt.en.md
+++ b/content/projekte/httpsjetzt.en.md
@@ -14,10 +14,8 @@ people:
   role: Projektleitung 
 contact:
   website: https://https.jetzt
-  website: https://behoerden-online-dienste.de
   twitter: httpsjetzt
   github: https://github.com/robbi5/pulse
-  github: https://github.com/okfde/behoerden-online-dienste.de
 years: 2016 - 2019
 layout: project
 financing:

--- a/content/projekte/httpsjetzt.md
+++ b/content/projekte/httpsjetzt.md
@@ -14,10 +14,8 @@ people:
   role: Projektleitung 
 contact:
   website: https://https.jetzt
-  website: https://behoerden-online-dienste.de
   twitter: httpsjetzt
   github: https://github.com/robbi5/pulse
-  github: https://github.com/okfde/behoerden-online-dienste.de
 years: 2016 - 2019
 layout: project
 financing:

--- a/content/projekte/kleineanfragen.en.md
+++ b/content/projekte/kleineanfragen.en.md
@@ -16,7 +16,6 @@ people:
 years: 2011 - 2020
 financing:
   - ehrenamtliches Projekt
-website: https://kleineanfragen.de
 contact:
   website: https://kleineanfragen.de
   twitter: kleineanfragen

--- a/content/projekte/kleineanfragen.md
+++ b/content/projekte/kleineanfragen.md
@@ -16,7 +16,6 @@ people:
 years: 2015 - 2020
 financing:
   - ehrenamtliches Projekt
-website: https://kleineanfragen.de
 contact:
   website: https://kleineanfragen.de
   twitter: kleineanfragen

--- a/content/projekte/odine.en.md
+++ b/content/projekte/odine.en.md
@@ -2,7 +2,6 @@
 type: archive
 title: ODINE
 subtitle: Open Data Incubator Europe
-website: https://www.d-eiti.de/de/
 img: projects/odine-logo.png
 layout: project
 years: 2015 - 2016

--- a/content/projekte/odine.md
+++ b/content/projekte/odine.md
@@ -2,7 +2,6 @@
 type: archive
 title: ODINE
 subtitle: Open Data Incubator Europe
-website: https://www.d-eiti.de/de/
 img: projects/odine-logo.png
 layout: project
 years: 2015 - 2016

--- a/content/projekte/offenedaten.en.md
+++ b/content/projekte/offenedaten.en.md
@@ -5,7 +5,6 @@ website: https://offenedaten.de
 img: projects/offenedaten.jpg
 layout: project
 years: 2011 - 2012
-website: https://offenedaten.de/
 
 ---
 

--- a/content/projekte/offenedaten.md
+++ b/content/projekte/offenedaten.md
@@ -1,7 +1,6 @@
 ---
 type: archive
 title: Offene Daten
-website: https://offenedaten.de
 img: projects/offenedaten.jpg
 layout: project
 years: 2011 - 2012

--- a/content/projekte/openbudgets.en.md
+++ b/content/projekte/openbudgets.en.md
@@ -6,7 +6,6 @@ website: https://openbudgets.eu
 img: projects/openbudgets.png
 layout: project
 background: backgrounds/openbudgets.png
-years: 2011-heute
 financing:
   - EU Horizon 2020
 years: 2015-2017

--- a/content/projekte/openbudgets.md
+++ b/content/projekte/openbudgets.md
@@ -15,8 +15,6 @@ categories:
   - Civic Tech
 background: backgrounds/openbudgets.png
 img_header: projects/OpenBudgets_Header.png
-img: projects/openbudgets_Projektuebersicht_smallTile.png
-years: 2011-heute
 financing:
   - EU Horizon 2020
 years: 2015-2017

--- a/content/projekte/prototypefund.en.md
+++ b/content/projekte/prototypefund.en.md
@@ -1,13 +1,11 @@
 ---
 title: Prototype Fund
 subtitle: Exploring Ideas - Fostering Openness
-type: research
 categories:
   - Civic Tech
   - Community
   - Public Interest Tech
 tile: double
-website: https://prototypefund.de
 img: projects/PrototypeFund_Projektuebersicht_bigTile.png
 img_square: projects/PrototypeFund_logo_icon_dark.svg
 img_header: projects/PrototypeFund_Header.png

--- a/content/projekte/prototypefund.md
+++ b/content/projekte/prototypefund.md
@@ -1,14 +1,12 @@
 ---
 title: Prototype Fund
 subtitle: Ideen erproben - Offenheit schaffen
-type: research
 kategorien:
   - Civic Tech
   - Community
   - Public Interest Tech
 tile: double
 type: featured
-website: https://prototypefund.de
 img: projects/PrototypeFund_Projektuebersicht_bigTile.png
 img_square: projects/PrototypeFund_logo_icon_dark.svg
 img_header: projects/PrototypeFund_Header.png

--- a/content/projekte/refugeephrasebook.en.md
+++ b/content/projekte/refugeephrasebook.en.md
@@ -10,7 +10,6 @@ people:
     role: Koordination
 financing:
   -  volunteer project
-website: https://refugeephrasebook.de
 contact:
   twitter: info_rpb
   github: https://github.com/refugee-phrasebook/

--- a/content/projekte/refugeephrasebook.md
+++ b/content/projekte/refugeephrasebook.md
@@ -1,7 +1,6 @@
 ---
 type: archive
 title: Refugeephrasebook
-website: https://refugeephrasebook.de
 img: projects/refugeephrasebook.jpg
 years: 2015 - 2016
 layout: project

--- a/content/projekte/transparenzranking.md
+++ b/content/projekte/transparenzranking.md
@@ -9,7 +9,6 @@ kategorien:
 categories:
   - Open Government
   - Informationsfreiheit
-img: projects/dummy_Projektuebersicht_smallTile.png
 img_header: projects/Transparenzranking_Header.png
 img: projects/Transparenzranking_Projektuebersicht_smallTile.png
 layout: project

--- a/content/projekte/turing-bus.en.md
+++ b/content/projekte/turing-bus.en.md
@@ -11,7 +11,6 @@ layout: project
 weight: 1
 img: projects/TuringBus_Projektuebersicht_bigTile.jpg
 img_header: projects/TuringBus_Header.jpg
-website: https://turing-bus.de
 partner:
   - Gesellschaft für Informatik e.V.
 financing:

--- a/content/projekte/turing-bus.md
+++ b/content/projekte/turing-bus.md
@@ -19,7 +19,6 @@ years: 2018 - 2019
 people:
   - name: Bela Seeger
     role: Projektleitung
-website: https://turing-bus.de
 contact:
   mail: bela.seeger@okfn.de
 ---

--- a/content/projekte/volksentscheid.en.md
+++ b/content/projekte/volksentscheid.en.md
@@ -24,7 +24,6 @@ people:
   role: Initiatorin
 - name: Leonard Wolf
   role: Initiator
-website: https://volksentscheid-transparenz.de
 contact:
   github: https://github.com/okfde/volksentscheid-transparenz.de
   twitter: transparenzBER

--- a/content/projekte/volksentscheid.md
+++ b/content/projekte/volksentscheid.md
@@ -22,7 +22,6 @@ people:
   role: Initiatorin
 - name: Leonard Wolf
   role: Initiator
-website: https://volksentscheid-transparenz.de
 contact:
   github: https://github.com/okfde/volksentscheid-transparenz.de
   twitter: transparenzBER


### PR DESCRIPTION
The front matter in the markdown files contains structured meta data the hugo uses to build the website. With the new hugo versions, it has become ore picky with regards to invalid meta data (e.g. keys that get repeated twice).

In this change, I am cleaning up those front matters that caused the build to fail with a more recent version of hugo.